### PR TITLE
docs(claude): add git workflow rule to prevent direct pushes to main

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,9 +13,15 @@ Secure Git proxy MCP server in Rust. Credentials stay on user's PC, never transm
 | PR requirements | `CONTRIBUTING.md` § Pull Requests |
 | Development roadmap | `TODO.md` |
 
-## Critical Security Rule
+## Critical Rules
+
+### Security
 
 Credentials NEVER in logs, errors, MCP responses, or debug output. See `CONTRIBUTING.md` § Security-Conscious Coding.
+
+### Git Workflow
+
+**NEVER push directly to main.** Always create a feature branch and open a pull request. Do not bypass repository branch protection rules under any circumstances.
 
 ## Off Limits
 


### PR DESCRIPTION
Explicitly forbid pushing directly to main and bypassing branch protection rules. All changes must go through pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

This PR updates the `.claude/CLAUDE.md` documentation to add an explicit Git workflow rule that prevents direct pushes to the main branch. The changes include:

- Restructured the "Critical Security Rule" section into a broader "Critical Rules" section
- Added a new "Git Workflow" subsection that explicitly forbids:
  - Pushing directly to main
  - Bypassing repository branch protection rules
- Clarifies that all changes must go through feature branches and pull requests

This documentation update ensures Claude Code and other AI assistants working with this repository follow proper Git branching practices, maintaining code quality and review standards.

## Type of Change

- [x] Documentation update

## Security Checklist ⚠️

Since this is a credential-handling project:

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- N/A - Documentation-only change, no code tests required

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation is updated if needed
- N/A - No CHANGELOG update needed for internal documentation

## Additional Notes

This change improves the project's development workflow documentation and helps maintain branch protection standards when working with AI coding assistants.