### PR TITLE
docs: add task management rule to remove completed TODO items

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,6 +23,10 @@ Credentials NEVER in logs, errors, MCP responses, or debug output. See `CONTRIBU
 
 **NEVER push directly to main.** Always create a feature branch and open a pull request. Do not bypass repository branch protection rules under any circumstances.
 
+### Task Management
+
+**Remove completed items from `TODO.md`** after finishing a task. Keep the roadmap current by deleting done items.
+
 ## Off Limits
 
 **`CODE_OF_CONDUCT.md`** — Do not modify. Owned by repository owner.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Adds a new "Task Management" section to the `.claude/CLAUDE.md` documentation file. This establishes a clear guideline for keeping the project roadmap current by removing completed items from `TODO.md` after tasks are finished.

## Type of Change

- [x] Documentation update

## Security Checklist ⚠️

Since this is a credential-handling project:

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- N/A - Documentation only change, no code tests required

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation is updated if needed

## Additional Notes

This is a simple documentation enhancement that improves project workflow by establishing a convention for task management. No code changes are involved.