### PR TITLE
fix(ci): suppress harmless cache save race condition warnings

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -96,8 +96,11 @@ jobs:
               run: cargo test --verbose
 
             # Save cache only on cache miss (tooling version changed)
+            # continue-on-error suppresses "unable to reserve cache" warnings
+            # when multiple jobs race to save (harmless, one will succeed)
             - name: Save Rust cache
               if: steps.cache-restore.outputs.cache-hit != 'true'
+              continue-on-error: true
               uses: actions/cache/save@v4
               with:
                   path: |


### PR DESCRIPTION
Add `continue-on-error: true` to the cache save step to suppress "unable to reserve cache" warnings. These occur when multiple platform jobs race to save caches simultaneously on cache miss – one succeeds, others gracefully back off. This is expected behaviour, not an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

When the CI pipeline runs on multiple platforms (Windows, Linux, macOS) and encounters a cache miss, all platform jobs attempt to save the cache simultaneously. GitHub Actions only allows one job to successfully reserve the cache key, causing the other jobs to emit "unable to reserve cache" warnings. These warnings are harmless and expected, but they can be confusing in the workflow logs.

This PR adds `continue-on-error: true` to the cache save step along with explanatory comments, ensuring the workflow continues cleanly without displaying misleading warning messages.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Security Checklist ⚠️

Since this is a credential-handling project:

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation is updated if needed

## Additional Notes

This is a cosmetic improvement to reduce noise in CI logs. The underlying cache behaviour remains unchanged – one job will successfully save the cache whilst others gracefully skip the save operation.
