### PR TITLE
style(yaml): enforce multi-line script indentation convention

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -91,13 +91,13 @@ jobs:
               id: rust-version
               shell: bash
               run: |
-                  # Cross-platform: use shasum on macOS, sha256sum elsewhere
-                  if command -v sha256sum &> /dev/null; then
-                      HASH_CMD="sha256sum"
-                  else
-                      HASH_CMD="shasum -a 256"
-                  fi
-                  echo "version=$(rustc --version | $HASH_CMD | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+                # Cross-platform: use shasum on macOS, sha256sum elsewhere
+                if command -v sha256sum &> /dev/null; then
+                    HASH_CMD="sha256sum"
+                else
+                    HASH_CMD="shasum -a 256"
+                fi
+                echo "version=$(rustc --version | $HASH_CMD | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
             - name: Restore Rust cache
               id: cache-restore
@@ -169,12 +169,12 @@ jobs:
             - name: Check if all jobs succeeded
               id: check-results
               run: |
-                  if [[ "${{ needs.quick-checks.result }}" != "success" ]] || \
-                     [[ "${{ needs.build.result }}" != "success" ]]; then
-                      echo "One or more jobs failed"
-                      exit 1
-                  fi
-                  echo "All jobs completed successfully"
+                if [[ "${{ needs.quick-checks.result }}" != "success" ]] || \
+                   [[ "${{ needs.build.result }}" != "success" ]]; then
+                    echo "One or more jobs failed"
+                    exit 1
+                fi
+                echo "All jobs completed successfully"
 
             - name: Checkout repository
               if: success()

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -81,13 +81,13 @@ jobs:
               id: rust-version
               shell: bash
               run: |
-                  # Cross-platform: use shasum on macOS, sha256sum elsewhere
-                  if command -v sha256sum &> /dev/null; then
-                      HASH_CMD="sha256sum"
-                  else
-                      HASH_CMD="shasum -a 256"
-                  fi
-                  echo "version=$(rustc --version | $HASH_CMD | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+                # Cross-platform: use shasum on macOS, sha256sum elsewhere
+                if command -v sha256sum &> /dev/null; then
+                    HASH_CMD="sha256sum"
+                else
+                    HASH_CMD="shasum -a 256"
+                fi
+                echo "version=$(rustc --version | $HASH_CMD | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
             # Restore cache from main branch (read-only)
             - name: Restore Rust cache
@@ -133,9 +133,9 @@ jobs:
         steps:
             - name: Check if all jobs succeeded
               run: |
-                  if [[ "${{ needs.quick-checks.result }}" != "success" ]] || \
-                     [[ "${{ needs.build.result }}" != "success" ]]; then
-                      echo "One or more jobs failed"
-                      exit 1
-                  fi
-                  echo "All jobs completed successfully"
+                if [[ "${{ needs.quick-checks.result }}" != "success" ]] || \
+                   [[ "${{ needs.build.result }}" != "success" ]]; then
+                    echo "One or more jobs failed"
+                    exit 1
+                fi
+                echo "All jobs completed successfully"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,43 +37,43 @@ jobs:
               id: version
               shell: bash
               run: |
-                  if [[ -n "${{ inputs.tag }}" ]]; then
-                      TAG="${{ inputs.tag }}"
-                  else
-                      TAG="${GITHUB_REF#refs/tags/}"
-                  fi
+                if [[ -n "${{ inputs.tag }}" ]]; then
+                    TAG="${{ inputs.tag }}"
+                else
+                    TAG="${GITHUB_REF#refs/tags/}"
+                fi
 
-                  # Validate tag format
-                  if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
-                      echo "Error: Invalid tag format: $TAG"
-                      echo "Expected format: v0.0.0 or v0.0.0-suffix"
-                      exit 1
-                  fi
+                # Validate tag format
+                if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+                    echo "Error: Invalid tag format: $TAG"
+                    echo "Expected format: v0.0.0 or v0.0.0-suffix"
+                    exit 1
+                fi
 
-                  VERSION="${TAG#v}"
-                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-                  echo "Release version: $VERSION (tag: $TAG)"
+                VERSION="${TAG#v}"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+                echo "Release version: $VERSION (tag: $TAG)"
 
             - name: Verify Cargo.toml version matches tag
               shell: bash
               run: |
-                  CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-                  TAG_VERSION="${{ steps.version.outputs.version }}"
+                CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+                TAG_VERSION="${{ steps.version.outputs.version }}"
 
-                  # For pre-release tags like v0.1.0-rc1, compare base version
-                  BASE_TAG_VERSION="${TAG_VERSION%%-*}"
+                # For pre-release tags like v0.1.0-rc1, compare base version
+                BASE_TAG_VERSION="${TAG_VERSION%%-*}"
 
-                  if [[ "$CARGO_VERSION" != "$BASE_TAG_VERSION" ]]; then
-                      echo "Error: Version mismatch!"
-                      echo "  Cargo.toml: $CARGO_VERSION"
-                      echo "  Tag:        $BASE_TAG_VERSION"
-                      echo ""
-                      echo "Update Cargo.toml version before tagging."
-                      exit 1
-                  fi
+                if [[ "$CARGO_VERSION" != "$BASE_TAG_VERSION" ]]; then
+                    echo "Error: Version mismatch!"
+                    echo "  Cargo.toml: $CARGO_VERSION"
+                    echo "  Tag:        $BASE_TAG_VERSION"
+                    echo ""
+                    echo "Update Cargo.toml version before tagging."
+                    exit 1
+                fi
 
-                  echo "Version verified: $CARGO_VERSION"
+                echo "Version verified: $CARGO_VERSION"
 
     build:
         name: Build (${{ matrix.target }})
@@ -130,23 +130,23 @@ jobs:
               if: runner.os != 'Windows'
               shell: bash
               run: |
-                  mkdir -p dist
-                  cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
-                  cp README.md LICENCE CHANGELOG.md dist/
-                  cp config/example-config.json dist/
-                  cd dist
-                  tar -czvf ../${{ matrix.artifact }}.tar.gz *
+                mkdir -p dist
+                cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
+                cp README.md LICENCE CHANGELOG.md dist/
+                cp config/example-config.json dist/
+                cd dist
+                tar -czvf ../${{ matrix.artifact }}.tar.gz *
 
             - name: Prepare artifact (Windows)
               if: runner.os == 'Windows'
               shell: bash
               run: |
-                  mkdir -p dist
-                  cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
-                  cp README.md LICENCE CHANGELOG.md dist/
-                  cp config/example-config.json dist/
-                  cd dist
-                  7z a -tzip ../${{ matrix.artifact }}.zip *
+                mkdir -p dist
+                cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
+                cp README.md LICENCE CHANGELOG.md dist/
+                cp config/example-config.json dist/
+                cd dist
+                7z a -tzip ../${{ matrix.artifact }}.zip *
 
             - name: Upload artifact (Unix)
               if: runner.os != 'Windows'
@@ -184,38 +184,38 @@ jobs:
             - name: Generate checksums
               shell: bash
               run: |
-                  cd artifacts
-                  find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} . \;
-                  sha256sum *.tar.gz *.zip > SHA256SUMS.txt
-                  cat SHA256SUMS.txt
+                cd artifacts
+                find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} . \;
+                sha256sum *.tar.gz *.zip > SHA256SUMS.txt
+                cat SHA256SUMS.txt
 
             - name: Extract release notes from CHANGELOG
               id: release-notes
               shell: bash
               run: |
-                  VERSION="${{ needs.validate.outputs.version }}"
+                VERSION="${{ needs.validate.outputs.version }}"
 
-                  # Try to extract notes for this version from CHANGELOG.md
-                  # Look for ## [version] or ## version header
-                  if grep -q "## \[${VERSION}\]" CHANGELOG.md || grep -q "## ${VERSION}" CHANGELOG.md; then
-                      # Extract content between this version header and the next
-                      sed -n "/## \[${VERSION}\]/,/## \[/p" CHANGELOG.md | sed '$d' > release_notes.md || \
-                      sed -n "/## ${VERSION}/,/## /p" CHANGELOG.md | sed '$d' > release_notes.md
+                # Try to extract notes for this version from CHANGELOG.md
+                # Look for ## [version] or ## version header
+                if grep -q "## \[${VERSION}\]" CHANGELOG.md || grep -q "## ${VERSION}" CHANGELOG.md; then
+                    # Extract content between this version header and the next
+                    sed -n "/## \[${VERSION}\]/,/## \[/p" CHANGELOG.md | sed '$d' > release_notes.md || \
+                    sed -n "/## ${VERSION}/,/## /p" CHANGELOG.md | sed '$d' > release_notes.md
 
-                      if [[ -s release_notes.md ]]; then
-                          echo "Found release notes in CHANGELOG.md"
-                      else
-                          echo "No specific release notes found, using default"
-                          echo "Release ${VERSION}" > release_notes.md
-                      fi
-                  else
-                      echo "No CHANGELOG entry for ${VERSION}, using default"
-                      echo "Release ${VERSION}" > release_notes.md
-                  fi
+                    if [[ -s release_notes.md ]]; then
+                        echo "Found release notes in CHANGELOG.md"
+                    else
+                        echo "No specific release notes found, using default"
+                        echo "Release ${VERSION}" > release_notes.md
+                    fi
+                else
+                    echo "No CHANGELOG entry for ${VERSION}, using default"
+                    echo "Release ${VERSION}" > release_notes.md
+                fi
 
-                  echo ""
-                  echo "--- Release Notes ---"
-                  cat release_notes.md
+                echo ""
+                echo "--- Release Notes ---"
+                cat release_notes.md
 
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v2

--- a/STYLE.md
+++ b/STYLE.md
@@ -104,6 +104,21 @@ jobs:
               run: cargo build
 ```
 
+### Multi-line Scripts (`run: |`)
+
+Use **4 spaces from the `-` column** for shell script content inside `run: |` blocks. This provides clear visual separation between YAML structure and shell commands.
+
+```yaml
+            - name: Example step
+              shell: bash
+              run: |
+                if [[ -n "$VAR" ]]; then
+                    echo "Variable is set"
+                else
+                    echo "Variable is not set"
+                fi
+```
+
 ### Structure
 
 - Blank line between top-level keys (`on`, `env`, `jobs`)


### PR DESCRIPTION
## Description

This PR enforces consistent indentation for multi-line shell scripts in GitHub Actions workflow files. The convention is documented in `STYLE.md` and applied across all workflow files.

### The Convention

Shell script content inside `run: |` blocks uses **4 spaces from the `-` column**:

```yaml
            - name: Example step
              shell: bash
              run: |
                if [[ -n "$VAR" ]]; then
                    echo "Variable is set"
                else
                    echo "Variable is not set"
                fi
```

**Why this matters:**
- Clear visual separation between YAML structure and shell commands
- Consistent style across all workflow files
- Easier to read and maintain
- Avoids confusion between YAML indentation and shell indentation

### Changes Applied

| File | Multi-line Blocks Updated |
|------|---------------------------|
| `ci_main.yml` | 2 blocks (Rust version hash, CI success check) |
| `ci_pr.yml` | 2 blocks (Rust version hash, CI success check) |
| `release.yml` | 6 blocks (version validation, Cargo.toml check, artifact prep ×2, checksums, release notes) |
| `STYLE.md` | Added documentation for the convention |

### Summary

- **1 commit** on branch `style/enforce-multiline-script-indentation`
- **4 files changed** (+110/-95 lines)
- **Latest commit**: `e1fb91f` - style(yaml): enforce multi-line script indentation convention

| File | Change |
|------|--------|
| `.github/workflows/ci_main.yml` | Re-indented 2 `run: \|` blocks |
| `.github/workflows/ci_pr.yml` | Re-indented 2 `run: \|` blocks |
| `.github/workflows/release.yml` | Re-indented 6 `run: \|` blocks |
| `STYLE.md` | Documented the convention |

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Documentation update

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation is updated if needed

## Additional Notes

### Before/After Example

**Before** (inconsistent, 6 spaces from `-`):
```yaml
            - name: Get Rust version
              run: |
                  if command -v sha256sum &> /dev/null; then
                      HASH_CMD="sha256sum"
                  fi
```

**After** (consistent, 4 spaces from `-`):
```yaml
            - name: Get Rust version
              run: |
                if command -v sha256sum &> /dev/null; then
                    HASH_CMD="sha256sum"
                fi
```

This is purely a style change — no functional impact on CI behaviour.