### PR TITLE
docs(claude): add custom command and streamline CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,16 +2,15 @@
 
 Secure Git proxy MCP server in Rust. Credentials stay on user's PC, never transmitted to AI.
 
-## Quick Reference
+## Before You Start
 
-| What | Where |
-|------|-------|
-| Build commands | `CONTRIBUTING.md` § Development Setup |
-| Coding standards | `CONTRIBUTING.md` § Coding Standards |
-| Style guide | `STYLE.md` |
-| Commit conventions | `CONTRIBUTING.md` § Commit Messages |
-| PR requirements | `CONTRIBUTING.md` § Pull Requests |
-| Development roadmap | `TODO.md` |
+Read these documents (as a human developer would):
+
+| Document | Contains |
+|----------|----------|
+| `CONTRIBUTING.md` | Build commands, coding standards, commit conventions, PR requirements |
+| `STYLE.md` | Code style guide |
+| `TODO.md` | Development roadmap (current phase marked with `← CURRENT`) |
 
 ## Critical Rules
 
@@ -27,26 +26,19 @@ Secure Git proxy MCP server in Rust. Credentials stay on user's PC, never transm
 
 Credentials NEVER in logs, errors, MCP responses, or debug output. See `CONTRIBUTING.md` § Security-Conscious Coding.
 
-**Before committing**, always clean up stale branches:
+### Before Committing
+
+Clean up stale branches:
 
 ```bash
 git fetch --prune origin
 git branch -vv | grep ': gone]' | awk '{print $1}' | xargs -r git branch -d
 ```
 
-This removes local branches whose remote tracking branch has been deleted.
-
 ### Task Management
 
-**Remove completed items from `TODO.md`** after finishing a task. Keep the roadmap current by deleting done items.
+**Remove completed items from `TODO.md`** after finishing a task. Keep the roadmap current.
 
 ## Off Limits
 
 **`CODE_OF_CONDUCT.md`** — Do not modify. Owned by repository owner.
-
-## Project Structure
-
-```
-src/               # Rust source code
-config/            # Example configuration files
-```

--- a/.claude/commands/do_next_todo.md
+++ b/.claude/commands/do_next_todo.md
@@ -1,0 +1,17 @@
+# Do Next TODO
+
+Familiarise yourself with this project and implement the next task from the roadmap.
+
+## Steps
+
+1. **Read project documentation** — Read `CONTRIBUTING.md`, `STYLE.md`, and `.claude/CLAUDE.md`
+2. **Check `TODO.md`** — Find the current phase (marked with `← CURRENT`) and its incomplete tasks
+3. **Implement the next task** — Work on ONE task at a time
+4. **Run all checks** — See `CONTRIBUTING.md` § Development Setup for commands
+5. **Commit via PR** — Create a feature branch, commit, push, and open a pull request
+
+## CRITICAL
+
+> **You MUST follow ALL rules in `.claude/CLAUDE.md` and `CONTRIBUTING.md` absolutely.**
+>
+> If you accidentally violate any rule, immediately inform the user.


### PR DESCRIPTION
## Description

This PR adds a custom Claude Code command (`/do_next_todo`) and streamlines `CLAUDE.md` to follow the single source of truth principle.

### Key Changes

**New Custom Command: `.claude/commands/do_next_todo.md`**

A reusable command that instructs Claude Code to:
1. Read project documentation (`CONTRIBUTING.md`, `STYLE.md`, `.claude/CLAUDE.md`)
2. Find the current phase in `TODO.md` (marked with `← CURRENT`)
3. Implement ONE task at a time
4. Run all checks
5. Create a PR

Includes a critical reminder to follow all rules and inform the user if any are accidentally violated.

**Streamlined `CLAUDE.md`**

Before: Duplicated information from `CONTRIBUTING.md` and `STYLE.md` in a quick reference table.

After: Simple pointer to existing documentation with a "Before You Start" section that tells the AI to read the docs "as a human developer would".

| Section | Before | After |
|---------|--------|-------|
| Quick Reference | Detailed table with section pointers | Simple document list |
| Project Structure | ASCII tree | Removed (obvious from file listing) |
| Critical Rules | Same | Same |
| Task Management | Same | Slightly condensed |

### Why This Matters

1. **Single source of truth** — Changes to `CONTRIBUTING.md` or `STYLE.md` are automatically reflected
2. **Consistent AI behaviour** — The `/do_next_todo` command provides a repeatable workflow
3. **Less maintenance** — No need to keep `CLAUDE.md` in sync with other docs

### Summary

- **1 commit** on branch `docs/add-custom-command-and-context`
- **2 files changed** (+29/-20 lines)
- **Latest commit**: `58a82f8` - docs(claude): add custom command and streamline CLAUDE.md

| File | Change |
|------|--------|
| `.claude/commands/do_next_todo.md` | New custom command |
| `.claude/CLAUDE.md` | Streamlined to reference existing docs |

## Type of Change

- [x] Documentation update

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Documentation is updated if needed

## Additional Notes

### Custom Command Usage

In Claude Code, users can invoke the command with:

```
/do_next_todo
```

This will trigger Claude Code to read the project docs and work on the next TODO item following project conventions.