### PR TITLE
docs: convert ASCII diagrams to Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,53 +35,39 @@ git-proxy-mcp acts as a local proxy between your AI assistant and Git hosting se
 - **Enables native Git workflow** — Clone, edit, commit, push. AI assistants work with full repo copies, not API calls
 - **Runs locally** — stdio transport means no network exposure between the MCP server and client
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                              User's PC                                      │
-│                                                                             │
-│   ┌────────────────────────────────────────────────────────────────────┐   │
-│   │                    Your Git Configuration                           │   │
-│   │                                                                     │   │
-│   │   ~/.gitconfig ──────────────────────────────────────────────────┐  │   │
-│   │   (credential helpers)                                           │  │   │
-│   │                                                                  │  │   │
-│   │   ~/.ssh/config + ssh-agent ─────────────────────────────────────┤  │   │
-│   │   (SSH keys, already loaded)                                     │  │   │
-│   │                                                                  │  │   │
-│   │   OS Credential Store ───────────────────────────────────────────┤  │   │
-│   │   (macOS Keychain, Windows Credential Manager, libsecret)        │  │   │
-│   └──────────────────────────────────────────────────────────────────┼──┘   │
-│                                                                      │      │
-│                            Git uses these automatically              │      │
-│                                       │                              │      │
-│   ┌───────────────────────────────────▼──────────────────────────────┴──┐   │
-│   │                     git-proxy-mcp                                    │   │
-│   │                                                                      │   │
-│   │   1. Validate command (security guards)                              │   │
-│   │   2. Spawn: git clone/fetch/pull/push/ls-remote                      │   │
-│   │   3. Set GIT_TERMINAL_PROMPT=0 (no interactive prompts)              │   │
-│   │   4. Sanitise output (remove any leaked credentials)                 │   │
-│   │   5. Return result to AI via MCP                                     │   │
-│   │                                                                      │   │
-│   │   NO credentials stored ─────── Git handles auth natively            │   │
-│   │                                                                      │   │
-│   └──────────────────────────────────┬───────────────────────────────────┘   │
-│                                      │ stdio (local process, no network)     │
-│                                      ▼                                       │
-│                               ┌─────────────┐                                │
-│                               │Claude Desktop│                               │
-│                               │ / MCP Client │                               │
-│                               └──────┬──────┘                                │
-│                                      │                                       │
-└──────────────────────────────────────┼───────────────────────────────────────┘
-                                       │
-                                       │ TLS (handled by Anthropic/vendor)
-                                       ▼
-                                ┌─────────────┐
-                                │   AI VM     │
-                                │ (Claude,    │
-                                │  GPT, etc.) │
-                                └─────────────┘
+```mermaid
+flowchart TB
+    subgraph PC["User's PC"]
+        subgraph GitConfig["Your Git Configuration"]
+            gitconfig["~/.gitconfig<br/>(credential helpers)"]
+            sshconfig["~/.ssh/config + ssh-agent<br/>(SSH keys, already loaded)"]
+            oscreds["OS Credential Store<br/>(macOS Keychain, Windows Credential Manager, libsecret)"]
+        end
+
+        subgraph Proxy["git-proxy-mcp"]
+            step1["1. Validate command (security guards)"]
+            step2["2. Spawn: git clone/fetch/pull/push/ls-remote"]
+            step3["3. Set GIT_TERMINAL_PROMPT=0 (no interactive prompts)"]
+            step4["4. Sanitise output (remove any leaked credentials)"]
+            step5["5. Return result to AI via MCP"]
+            nocreds["NO credentials stored — Git handles auth natively"]
+        end
+
+        client["Claude Desktop / MCP Client"]
+    end
+
+    ai["AI VM<br/>(Claude, GPT, etc.)"]
+
+    gitconfig --> Proxy
+    sshconfig --> Proxy
+    oscreds --> Proxy
+    Proxy -->|"stdio (local process, no network)"| client
+    client -->|"TLS (handled by Anthropic/vendor)"| ai
+
+    style PC fill:#f9f9f9,stroke:#333
+    style GitConfig fill:#e6f3ff,stroke:#0066cc
+    style Proxy fill:#e6ffe6,stroke:#006600
+    style nocreds fill:#ffffcc,stroke:#666600
 ```
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -18,29 +18,29 @@
 
 ### Credential-Free Proxy Design
 
-```
-User's PC (existing git setup)
-├── ~/.gitconfig (credential helpers)
-├── ~/.ssh/config (SSH host configs)
-├── ssh-agent (keys loaded)
-└── OS credential store
+```mermaid
+flowchart TB
+    subgraph PC["User's PC (existing git setup)"]
+        gitconfig["~/.gitconfig (credential helpers)"]
+        sshconfig["~/.ssh/config (SSH host configs)"]
+        sshagent["ssh-agent (keys loaded)"]
+        oscreds["OS credential store"]
+    end
 
-          ↓ git uses these automatically
+    subgraph Proxy["git-proxy-mcp"]
+        validate["Validate command (security guards)"]
+        spawn["Spawn: git clone/fetch/pull/push/ls-remote"]
+        prompt["GIT_TERMINAL_PROMPT=0 (no interactive prompts)"]
+        sanitise["Sanitise output (remove any leaked credentials)"]
+        result["Return result to AI via MCP"]
+    end
 
-git-proxy-mcp:
-├── Validate command (security guards)
-├── Spawn: git clone/fetch/pull/push/ls-remote
-├── GIT_TERMINAL_PROMPT=0 (no interactive prompts)
-├── Sanitise output (remove any leaked credentials)
-└── Return result to AI via MCP
+    client["Claude Desktop / MCP Client"]
+    ai["AI VM (Claude, GPT, etc.)"]
 
-          ↓ stdio (local process)
-
-Claude Desktop / MCP Client
-
-          ↓ TLS (handled by vendor)
-
-AI VM (Claude, GPT, etc.)
+    PC -->|"git uses these automatically"| Proxy
+    Proxy -->|"stdio (local process)"| client
+    client -->|"TLS (handled by vendor)"| ai
 ```
 
 **Key Security Properties:**
@@ -84,15 +84,15 @@ Instead, it relies on the user's existing Git configuration (credential helpers,
 
 ---
 
-## Phase 6: Code Quality & Cleanup <- CURRENT
+## Completed: Phase 6 — Code Quality & Cleanup
 
 - [x] Optimise tokio features (currently using "full", only need subset)
-- [ ] Audit codebase for British spelling consistency (see CONTRIBUTING.md)
-- [ ] Convert ASCII diagrams to Mermaid (TODO.md, README.md)
+- [x] Audit codebase for British spelling consistency (see CONTRIBUTING.md)
+- [x] Convert ASCII diagrams to Mermaid (TODO.md, README.md)
 
 ---
 
-## Phase 7: Testing & Documentation
+## Phase 7: Testing & Documentation <- CURRENT
 
 - [ ] Integration tests for full MCP -> git pipeline
 - [ ] Tests for large git output handling
@@ -117,6 +117,9 @@ Instead, it relies on the user's existing Git configuration (credential helpers,
 - [x] Semantic versioning and CHANGELOG maintenance
 - [x] User documentation (installation guide, configuration reference)
 - [x] Example MCP client configurations (Claude Desktop, etc.)
+
+> **Note:** The repository owner decides when to move from pre-release (v0.x) to stable release (v1.0).
+> This decision should be based on real-world usage, security audits, and feature completeness.
 
 ---
 


### PR DESCRIPTION
## Description

Replace ASCII art architecture diagrams with Mermaid flowcharts for better rendering on GitHub, and update roadmap progress.

### Diagram Conversion

**README.md**

Converted the main architecture diagram from 47-line ASCII art to a clean Mermaid flowchart showing:
- User's Git configuration (credential helpers, SSH config, OS credential store)
- git-proxy-mcp processing steps (validate → spawn → prompt disable → sanitise → return)
- Data flow from Git config → MCP server → Claude Desktop → AI VM
- Colour-coded subgraphs for visual clarity

**TODO.md**

Converted the security architecture diagram from ASCII tree format to Mermaid flowchart with same data flow.

### Roadmap Progress

| Phase | Status |
|-------|--------|
| Phase 6: Code Quality & Cleanup | ✅ **Complete** |
| Phase 7: Testing & Documentation | ← **CURRENT** |

Phase 6 completed tasks:
- [x] Optimise tokio features
- [x] Audit codebase for British spelling consistency
- [x] Convert ASCII diagrams to Mermaid

Also added a note about v1.0 release timing being at owner's discretion based on real-world usage.

### Benefits

- **Better rendering** — Mermaid renders natively on GitHub with proper styling
- **Maintainability** — Easier to update than ASCII art
- **Accessibility** — Screenreaders can parse Mermaid better than ASCII

### Summary

- **1 commit** on branch `docs/convert-ascii-to-mermaid`
- **2 files changed** (+63/-74 lines) — net reduction of 11 lines
- **Latest commit**: `11fef3f` - docs: convert ASCII diagrams to Mermaid

## Type of Change

- [x] Documentation update

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Code is formatted (`cargo fmt`)
- [x] Documentation is updated if needed