### PR TITLE
feat(config): add request timeout configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Configurable request timeout for git command execution (prevents hung processes)
+    - New `timeouts.request_timeout_secs` configuration option
+    - Default: 300 seconds (5 minutes)
+    - Commands exceeding the timeout are terminated with a clear error message
+
+---
+
 ## Pre-release
 
 This project is in early development. No releases yet.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ path = "src/main.rs"
 # - io-std: stdin(), stdout()
 # - process: async Command for spawning git
 # - macros: #[tokio::test] attribute
-tokio = { version = "1", features = ["rt", "io-util", "io-std", "process", "macros"] }
+# - time: timeout for git process execution
+tokio = { version = "1", features = ["rt", "io-util", "io-std", "process", "macros", "time"] }
 
 # Serialisation
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ Or specify a custom path with `--config /path/to/config.json`.
     },
     "logging": {
         "level": "warn"
+    },
+    "timeouts": {
+        "request_timeout_secs": 300
     }
 }
 ```
@@ -251,6 +254,7 @@ Or specify a custom path with `--config /path/to/config.json`.
 | `security.repo_blocklist` | Block these repository patterns (glob) | `null` (none blocked) |
 | `logging.level` | Log level: trace, debug, info, warn, error | `warn` |
 | `logging.audit_log_path` | Path to audit log file | `null` (disabled) |
+| `timeouts.request_timeout_secs` | Timeout for git command execution in seconds | `300` (5 minutes) |
 
 See [config/example-config.json](config/example-config.json) for a complete example.
 

--- a/TODO.md
+++ b/TODO.md
@@ -102,7 +102,7 @@ Instead, it relies on the user's existing Git configuration (credential helpers,
 
 ## Phase 8: Robustness & Production Readiness <- CURRENT
 
-- [ ] Request timeout configuration (prevent hung git processes)
+- [x] Request timeout configuration (prevent hung git processes)
 - [ ] Graceful shutdown handling (SIGTERM/SIGINT)
 - [ ] Output size limits (prevent protocol buffer overflow)
 - [ ] Configurable rate limiting (currently hardcoded: 20 burst, 5/sec)

--- a/config/example-config.json
+++ b/config/example-config.json
@@ -14,5 +14,8 @@
     "logging": {
         "level": "warn",
         "audit_log_path": null
+    },
+    "timeouts": {
+        "request_timeout_secs": 300
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,7 +24,7 @@
 
 mod settings;
 
-pub use settings::{Config, LoggingConfig, SecurityConfig};
+pub use settings::{Config, LoggingConfig, SecurityConfig, TimeoutConfig};
 
 use std::path::{Path, PathBuf};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,11 +129,12 @@ fn main() -> ExitCode {
     info!(
         force_push = security_config.allow_force_push,
         protected_branches = ?security_config.protected_branches,
+        request_timeout_secs = cfg.timeouts.request_timeout_secs,
         "Configuration loaded"
     );
 
-    // Create git executor (no credentials stored — uses system git config)
-    let executor = GitExecutor::new();
+    // Create git executor with configured timeout
+    let executor = GitExecutor::with_timeout(cfg.timeouts.request_timeout());
 
     // Create MCP server
     let mut server = McpServer::new(executor, security_config, audit_logger);


### PR DESCRIPTION
## Description

Add configurable timeout for git command execution to prevent hung processes from blocking the server indefinitely. This addresses the first item in Phase 8 (Robustness & Production Readiness).

---

## Problem

Without a timeout, a hung git process (e.g., waiting for network, stuck SSH handshake, unresponsive remote) could block the MCP server indefinitely, requiring manual intervention.

## Solution

Wrap git command execution with `tokio::time::timeout()` and provide a configurable timeout duration.

---

## Implementation Details

### New Configuration Option

```json
{
  "timeouts": {
    "request_timeout_secs": 300
  }
}
```

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `timeouts.request_timeout_secs` | `u64` | `300` (5 min) | Timeout for git command execution |

### New Rust Types

**`TimeoutConfig` struct** (`src/config/settings.rs`):
```rust
pub struct TimeoutConfig {
    pub request_timeout_secs: u64,
}

impl TimeoutConfig {
    pub const fn request_timeout(&self) -> Duration { ... }
}
```

**`ExecutorError::Timeout` variant** (`src/git/executor.rs`):
```rust
#[error("command timed out after {timeout_secs} seconds")]
Timeout { timeout_secs: u64 }
```

### Executor Changes

**New constructor:**
```rust
GitExecutor::with_timeout(duration: Duration) -> Self
```

**Timeout wrapper:**
```rust
let output = timeout(self.timeout, cmd.output())
    .await
    .map_err(|_| ExecutorError::Timeout { ... })?
```

---

## Files Changed

| File | Change | Lines |
|------|--------|-------|
| `src/config/settings.rs` | Add `TimeoutConfig` struct + tests | +87 |
| `src/git/executor.rs` | Add timeout wrapping + `Timeout` error | +58/-6 |
| `src/main.rs` | Use `with_timeout()` constructor | +3/-2 |
| `src/config/mod.rs` | Export `TimeoutConfig` | +1/-1 |
| `Cargo.toml` | Add tokio `time` feature | +2/-1 |
| `config/example-config.json` | Add timeouts section | +3 |
| `README.md` | Document new option | +4 |
| `TODO.md` | Mark task complete | +1/-1 |
| `CHANGELOG.md` | Add to Unreleased section | +11 |

**Total:** 9 files, +170/-11 lines

---

## Tests Added

| Test | Location | Description |
|------|----------|-------------|
| `timeout_config_defaults` | settings.rs | Verify default is 300s |
| `parse_timeout_config` | settings.rs | Parse custom timeout value |
| `parse_full_config_with_timeouts` | settings.rs | Full config parsing with timeouts |
| `executor_with_custom_timeout` | executor.rs | Custom timeout constructor |
| `timeout_error_display` | executor.rs | Error message formatting |

---

## User-Facing Changes

**Configuration:**
- New optional `timeouts.request_timeout_secs` setting
- Sensible default (5 minutes) — no action required for most users

**Error messages:**
- Clear timeout error: `"command timed out after 300 seconds"`

**Logging:**
- Timeout value logged at startup

---

## Summary

- **1 commit** on branch `feat/request-timeout`
- **9 files changed** (+170/-11 lines)
- **5 new tests**
- **Latest commit**: `3e6baa3` - feat(config): add request timeout configuration
- **Auto-merge**: Enabled

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation is updated if needed
- [x] CHANGELOG.md is updated for user-facing changes