### PR TITLE
feat(mcp): add graceful shutdown handling for SIGTERM/SIGINT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ path = "src/main.rs"
 # - process: async Command for spawning git
 # - macros: #[tokio::test] attribute
 # - time: timeout for git process execution
-tokio = { version = "1", features = ["rt", "io-util", "io-std", "process", "macros", "time"] }
+# - signal: graceful shutdown handling (SIGTERM/SIGINT/Ctrl+C)
+tokio = { version = "1", features = ["rt", "io-util", "io-std", "process", "macros", "time", "signal"] }
 
 # Serialisation
 serde = { version = "1", features = ["derive"] }

--- a/TODO.md
+++ b/TODO.md
@@ -103,7 +103,7 @@ Instead, it relies on the user's existing Git configuration (credential helpers,
 ## Phase 8: Robustness & Production Readiness <- CURRENT
 
 - [x] Request timeout configuration (prevent hung git processes)
-- [ ] Graceful shutdown handling (SIGTERM/SIGINT)
+- [x] Graceful shutdown handling (SIGTERM/SIGINT)
 - [ ] Output size limits (prevent protocol buffer overflow)
 - [ ] Configurable rate limiting (currently hardcoded: 20 burst, 5/sec)
 - [ ] Documentation: mention per-repo git config (without `--global`) as alternative

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -33,6 +33,6 @@ pub mod audit;
 pub mod guards;
 pub mod rate_limit;
 
-pub use audit::{AuditEvent, AuditLogger};
+pub use audit::{AuditEvent, AuditLogger, ShutdownReason};
 pub use guards::{BranchGuard, PushGuard, RepoFilter, SecurityGuard};
 pub use rate_limit::RateLimiter;


### PR DESCRIPTION
## Description

Implement cross-platform graceful shutdown handling for the MCP server. This addresses the second item in Phase 8 (Robustness & Production Readiness).

---

## Problem

Without graceful shutdown handling, the server would:
- Not respond to SIGTERM (used by process managers, container orchestrators)
- Not log why it stopped (was it killed? did the client disconnect?)
- Potentially leave audit logs incomplete

## Solution

Use `tokio::select!` to race between signal handling and stdin reading, allowing the server to respond to shutdown signals while processing requests.

---

## Implementation Details

### New Type: `ShutdownReason`

```rust
#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
#[serde(rename_all = "snake_case")]
pub enum ShutdownReason {
    ClientDisconnected,  // stdin closed
    SigInt,              // Ctrl+C / SIGINT
    SigTerm,             // SIGTERM
}
```

### Platform-Specific Signal Handling

| Platform | Signal | Handler |
|----------|--------|---------|
| Unix | SIGINT | `tokio::signal::unix::signal(SignalKind::interrupt())` |
| Unix | SIGTERM | `tokio::signal::unix::signal(SignalKind::terminate())` |
| Windows | Ctrl+C | `tokio::signal::ctrl_c()` |

### Server Loop Architecture

**Before:**
```rust
loop {
    let line = transport.read_line().await?;
    // process...
}
```

**After (Unix):**
```rust
loop {
    tokio::select! {
        _ = sigint.recv() => return Ok(ShutdownReason::SigInt),
        _ = sigterm.recv() => return Ok(ShutdownReason::SigTerm),
        line_result = transport.read_line() => {
            // process or return ShutdownReason::ClientDisconnected
        }
    }
}
```

### Audit Log Enhancement

`server_stopped()` now takes a `ShutdownReason` parameter:

```json
{
  "event_type": "server_stopped",
  "outcome": "success",
  "shutdown_reason": "sig_term"
}
```

---

## Files Changed

| File | Change | Lines |
|------|--------|-------|
| `src/mcp/server.rs` | Add `run_with_shutdown()` with platform-specific impl | +88/-19 |
| `src/security/audit.rs` | Add `ShutdownReason` enum + `shutdown_reason` field | +51/-3 |
| `src/security/mod.rs` | Export `ShutdownReason` | +1/-1 |
| `Cargo.toml` | Add tokio `signal` feature | +2/-1 |
| `TODO.md` | Mark task complete | +1/-1 |

**Total:** 5 files, +143/-25 lines

---

## Tests Added

| Test | Location | Description |
|------|----------|-------------|
| `audit_event_server_stopped_with_reason` | audit.rs | Verify shutdown reason is captured |
| `shutdown_reason_serialisation` | audit.rs | Verify JSON serialisation for all variants |

---

## Platform Support

| Platform | SIGINT | SIGTERM | Ctrl+C |
|----------|--------|---------|--------|
| Linux | ✅ | ✅ | ✅ |
| macOS | ✅ | ✅ | ✅ |
| Windows | ❌ | ❌ | ✅ |

Windows doesn't have Unix signals, so only Ctrl+C is handled (maps to `SigInt` reason).

---

## User-Facing Changes

**Behaviour:**
- Server now responds gracefully to SIGTERM/SIGINT
- Clean shutdown with audit log entry

**Audit logs:**
- New `shutdown_reason` field in `server_stopped` events
- Values: `client_disconnected`, `sig_int`, `sig_term`

**Logging:**
- Info-level log on signal receipt: `"Received SIGTERM, initiating graceful shutdown"`

---

## Summary

- **1 commit** on branch `feat/graceful-shutdown`
- **5 files changed** (+143/-25 lines)
- **2 new tests**
- **Latest commit**: `013a49d` - feat(mcp): add graceful shutdown handling for SIGTERM/SIGINT
- **Auto-merge**: Enabled

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation is updated if needed