### PR TITLE
feat: display GPL license notice at startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,16 @@ fn main() -> ExitCode {
     let log_level = get_log_level(args.verbose, args.quiet, &cfg.logging.level);
     init_tracing(log_level);
 
+    // Display GPL license notice (required by GPLv3 Section 5d)
+    eprintln!(
+        "git-proxy-mcp {}  Copyright (C) 2025  Matej Gomboc",
+        env!("CARGO_PKG_VERSION")
+    );
+    eprintln!("This program comes with ABSOLUTELY NO WARRANTY.");
+    eprintln!("This is free software, licensed under GPL-3.0-or-later.");
+    eprintln!("Source: {}", env!("CARGO_PKG_REPOSITORY"));
+    eprintln!();
+
     info!(
         version = env!("CARGO_PKG_VERSION"),
         "Starting git-proxy-mcp server"


### PR DESCRIPTION
Adds copyright and licence notice to stderr when the server starts, as required by GPLv3 Section 5d for interactive user interfaces.

## Changes

- Displays programme name and version with copyright notice
- Shows warranty disclaimer and licence type (GPL-3.0-or-later)
- Includes link to source repository
- Outputs to stderr to avoid interfering with MCP protocol communication on stdout

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

Verified locally that the notice displays correctly at startup without affecting MCP functionality.