### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Pre-release
+## [1.0.0] - 2025-01-10
 
-This project is in early development. No releases yet.
+Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-proxy-mcp"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Prepare for first stable release.

## Description

This PR bumps the version from `0.1.0` to `1.0.0` to mark the first stable release of git-proxy-mcp.

### Changes
- Updated `Cargo.toml` version from `0.1.0` to `1.0.0`
- Updated `CHANGELOG.md` to document the initial release with the release date

## Type of Change

- [x] Documentation update
- [x] CI/CD changes

## Security Checklist ⚠️

Since this is a credential-handling project:

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Documentation is updated if needed
- [x] CHANGELOG.md is updated for user-facing changes