### PR TITLE
fix: use native runners for macOS release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
                       artifact: git-proxy-mcp-linux-x86_64
                       binary: git-proxy-mcp
 
-                    - os: macos-latest
+                    - os: macos-13
                       target: x86_64-apple-darwin
                       artifact: git-proxy-mcp-macos-x86_64
                       binary: git-proxy-mcp


### PR DESCRIPTION
Use `macos-13` (Intel) runner for `x86_64-apple-darwin` builds instead of `macos-latest`.

## Description

GitHub's `macos-latest` runner now points to `macos-14`, which uses Apple Silicon (ARM). This caused cross-compilation issues when building for x86_64-apple-darwin, particularly with OpenSSL linking.

This PR switches the Intel macOS build to use `macos-13` explicitly, which is the last Intel-based macOS runner. The ARM build (`aarch64-apple-darwin`) continues to use `macos-latest` as intended.

## Type of Change

- [x] CI/CD changes

## Security Checklist ⚠️

Not applicable - this change only affects CI runner selection.

## Testing

- [x] Release workflow matrix configuration verified
- [x] No functional code changes

## Code Quality

- [x] YAML syntax is valid
