### PR TITLE
fix: drop Intel Mac from release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,11 +89,6 @@ jobs:
                       artifact: git-proxy-mcp-linux-x86_64
                       binary: git-proxy-mcp
 
-                    - os: macos-13
-                      target: x86_64-apple-darwin
-                      artifact: git-proxy-mcp-macos-x86_64
-                      binary: git-proxy-mcp
-
                     - os: macos-latest
                       target: aarch64-apple-darwin
                       artifact: git-proxy-mcp-macos-aarch64


### PR DESCRIPTION
GitHub has retired macOS-13 (Intel) runners, making cross-compilation for `x86_64-apple-darwin` no longer viable in CI. This PR removes the Intel Mac build target from the release workflow.

## Summary

Removes the `x86_64-apple-darwin` target from the build matrix. macOS releases will now only include ARM (aarch64) binaries. Intel Mac users can still build from source using `cargo build --release`.

## Type of Change

- [x] CI/CD changes

## Testing

- [x] CI workflow syntax is valid
- [x] Remaining build targets unaffected