### PR TITLE
fix: escape brackets in awk regex for changelog extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,8 @@ jobs:
 
                 # Extract release notes for this version from CHANGELOG.md
                 # Uses awk to handle both mid-file and end-of-file sections
-                awk -v ver="## [${VERSION}]" '
+                # Note: brackets must be escaped in awk regex
+                awk -v ver="## \\[${VERSION}\\]" '
                     $0 ~ ver { found=1; next }
                     found && /^## \[/ { exit }
                     found { print }


### PR DESCRIPTION
Fixes release notes extraction in the release workflow by escaping square brackets in the awk regex pattern.

## Problem

The square brackets in `## [VERSION]` were being interpreted as regex character classes (matching any single character from the set V, E, R, S, I, O, N) instead of literal bracket characters. This caused the changelog section extraction to fail silently during releases.

## Solution

Escaped the brackets with `\\[` and `\\]` in the awk variable so they are treated as literal characters when used in the regex match.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Testing

- [x] Verified the awk regex logic locally
- [x] No Rust code changes, so existing tests remain valid

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] This change only affects CI workflow scripts