### PR TITLE
fix: use literal string matching for changelog extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,10 +189,9 @@ jobs:
                 VERSION="${{ needs.validate.outputs.version }}"
 
                 # Extract release notes for this version from CHANGELOG.md
-                # Uses awk to handle both mid-file and end-of-file sections
-                # Note: brackets must be escaped in awk regex
-                awk -v ver="## \\[${VERSION}\\]" '
-                    $0 ~ ver { found=1; next }
+                # Uses awk with index() for literal string matching (avoids regex escaping issues)
+                awk -v ver="## [${VERSION}]" '
+                    index($0, ver) == 1 { found=1; next }
                     found && /^## \[/ { exit }
                     found { print }
                 ' CHANGELOG.md > release_notes.md


### PR DESCRIPTION
Replace regex matching with awk `index()` function to avoid escaping issues across YAML/shell/awk boundaries.

## Description

The previous implementation used regex matching with escaped brackets (`## \\[${VERSION}\\]`), which required careful handling of escape sequences across multiple parsing layers (YAML → shell → awk). This change simplifies the logic by using awk's `index()` function for literal string matching instead.

**Before:** `$0 ~ ver` with regex pattern requiring bracket escaping
**After:** `index($0, ver) == 1` for literal string matching at line start

This approach is more maintainable and eliminates potential issues with escape sequence interpretation in different environments.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/CD changes

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Error messages don't leak sensitive information

## Testing

- [x] CI workflow syntax is valid
- [x] The `index()` function correctly identifies version headers at the start of lines

## Code Quality

- [x] Documentation is updated (inline comment explains the approach)
