### PR TITLE
Pin all GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable
@@ -30,7 +30,7 @@ jobs:
 
             - name: Setup Node.js
               id: setup-node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                 node-version: "lts/*"
 
@@ -40,7 +40,7 @@ jobs:
 
             - name: Restore npm cache
               id: npm-cache-restore
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                 path: ~/.npm
                 key: npm-markdownlint-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-mdlint-${{ steps.mdlint-version.outputs.version }}
@@ -56,7 +56,7 @@ jobs:
 
             - name: Save npm cache
               if: steps.npm-cache-restore.outputs.cache-hit != 'true'
-              uses: actions/cache/save@v5
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                 path: ~/.npm
                 key: npm-markdownlint-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-mdlint-${{ steps.mdlint-version.outputs.version }}
@@ -80,7 +80,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable
@@ -101,7 +101,7 @@ jobs:
 
             - name: Restore Rust cache
               id: cache-restore
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                 path: |
                     ~/.cargo/bin/
@@ -140,7 +140,7 @@ jobs:
             - name: Save Rust cache
               if: steps.cache-restore.outputs.cache-hit != 'true'
               continue-on-error: true
-              uses: actions/cache/save@v5
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                 path: |
                     ~/.cargo/bin/
@@ -177,11 +177,11 @@ jobs:
 
             - name: Checkout repository
               if: success()
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Cleanup stale caches
               if: success()
-              uses: actions/github-script@v8
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                 script: |
                     const owner = context.repo.owner;

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable
@@ -27,7 +27,7 @@ jobs:
 
             - name: Setup Node.js
               id: setup-node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                 node-version: "lts/*"
 
@@ -37,7 +37,7 @@ jobs:
 
             # Restore cache from main branch (read-only)
             - name: Restore npm cache
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                 path: ~/.npm
                 key: npm-markdownlint-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-mdlint-${{ steps.mdlint-version.outputs.version }}
@@ -70,7 +70,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable
@@ -91,7 +91,7 @@ jobs:
 
             # Restore cache from main branch (read-only)
             - name: Restore Rust cache
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
               with:
                 path: |
                     ~/.cargo/bin/

--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -21,10 +21,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Run cleanup script
-              uses: actions/github-script@v8
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               env:
                 INPUT_DRY_RUN: ${{ inputs.dry_run || false }}
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Determine version
               id: version
@@ -94,7 +94,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable
@@ -136,7 +136,7 @@ jobs:
 
             - name: Upload artifact (Unix)
               if: runner.os != 'Windows'
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
               with:
                 name: ${{ matrix.artifact }}
                 path: ${{ matrix.artifact }}.tar.gz
@@ -144,7 +144,7 @@ jobs:
 
             - name: Upload artifact (Windows)
               if: runner.os == 'Windows'
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
               with:
                 name: ${{ matrix.artifact }}
                 path: ${{ matrix.artifact }}.zip
@@ -157,10 +157,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             - name: Download all artifacts
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                 path: artifacts
 
@@ -176,7 +176,7 @@ jobs:
                 cat SHA256SUMS.txt
 
             - name: Attest build provenance
-              uses: actions/attest-build-provenance@v4
+              uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
               with:
                 subject-path: |
                     artifacts/*.tar.gz


### PR DESCRIPTION
## Summary

- Pins all GitHub Actions references to full-length commit SHAs across all 4 workflow files (`ci_main.yml`, `ci_pr.yml`, `cleanup_caches.yml`, `release.yml`)
- Fixes CI startup failure caused by repo setting "Require actions to be pinned to a full-length commit SHA"
- Preserves version tags as inline comments (e.g. `# v6`) for readability
- `dtolnay/rust-toolchain@stable` left unpinned as it is explicitly in the repo's allowed patterns list

### Actions pinned

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6 |
| `actions/cache` (restore/save) | `cdf6c1fa76f9f475f3d7449005a359c84ca0f306` | v5 |
| `actions/setup-node` | `53b83947a5a98c8d113130e565377fae1a50d02f` | v6 |
| `actions/github-script` | `ed597411d8f924073f98dfc5c65a23a2325f34cd` | v8 |
| `actions/upload-artifact` | `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` | v7 |
| `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8 |
| `actions/attest-build-provenance` | `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` | v4 |

## Test plan

- [ ] CI workflow runs successfully on this PR (no more "startup failure")
- [ ] Verify all action SHAs resolve to the expected versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)