### PR TITLE
Pin actions to commit SHAs and improve CI/CD workflows

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -10,6 +10,10 @@ on:
 
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 env:
     CARGO_TERM_COLOR: always
     RUSTFLAGS: "-Dwarnings"
@@ -18,6 +22,7 @@ jobs:
     quick-checks:
         name: Quick Checks (fmt, docs, markdown)
         runs-on: ubuntu-latest
+        timeout-minutes: 10
 
         steps:
             - name: Checkout repository
@@ -165,7 +170,8 @@ jobs:
         name: CI Success
         needs: [quick-checks, build]
         runs-on: ubuntu-latest
-        if: always()
+        timeout-minutes: 5
+        if: ${{ !cancelled() }}
 
         steps:
             - name: Check if all jobs succeeded
@@ -186,76 +192,5 @@ jobs:
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
               with:
                 script: |
-                    const owner = context.repo.owner;
-                    const repo = context.repo.repo;
-
-                    // Get current cache keys (just created by this workflow run)
-                    const response = await github.rest.actions.getActionsCacheList({
-                        owner,
-                        repo,
-                        per_page: 100,
-                        sort: 'last_accessed_at',
-                        direction: 'desc',
-                    });
-
-                    const caches = response.data.actions_caches;
-                    if (caches.length === 0) {
-                        core.info('No caches found');
-                        return;
-                    }
-
-                    // Group caches by type and OS
-                    // Rust caches: rust-{OS}-{rustc-hash}-{cargo-lock-hash}
-                    // npm caches: npm-markdownlint-{OS}-node-{version}-mdlint-{version}
-                    const cacheGroups = {};
-                    for (const cache of caches) {
-                        let prefix;
-                        if (cache.key.startsWith('rust-')) {
-                            // Group by rust-{OS} (e.g., rust-Linux, rust-Windows, rust-macOS)
-                            const parts = cache.key.split('-');
-                            prefix = `${parts[0]}-${parts[1]}`;
-                        } else if (cache.key.startsWith('npm-markdownlint-')) {
-                            // Group by npm-markdownlint-{OS} (e.g., npm-markdownlint-Linux)
-                            const parts = cache.key.split('-');
-                            prefix = `${parts[0]}-${parts[1]}-${parts[2]}`;
-                        } else {
-                            // Unknown cache type, use full key as prefix (won't group)
-                            prefix = cache.key;
-                        }
-
-                        if (!cacheGroups[prefix]) {
-                            cacheGroups[prefix] = [];
-                        }
-                        cacheGroups[prefix].push(cache);
-                    }
-
-                    // For each group, keep only the most recently accessed cache
-                    let deletedCount = 0;
-                    let freedBytes = 0;
-
-                    for (const [prefix, groupCaches] of Object.entries(cacheGroups)) {
-                        // Sort by last_accessed_at descending (most recent first)
-                        groupCaches.sort((a, b) =>
-                            new Date(b.last_accessed_at) - new Date(a.last_accessed_at)
-                        );
-
-                        // Delete all but the first (most recent) cache
-                        for (let i = 1; i < groupCaches.length; i++) {
-                            const cache = groupCaches[i];
-                            try {
-                                await github.rest.actions.deleteActionsCacheById({
-                                    owner,
-                                    repo,
-                                    cache_id: cache.id,
-                                });
-                                core.info(`Deleted stale cache: ${cache.key}`);
-                                deletedCount++;
-                                freedBytes += cache.size_in_bytes;
-                            } catch (error) {
-                                core.warning(`Failed to delete cache ${cache.key}: ${error.message}`);
-                            }
-                        }
-                    }
-
-                    const freedMB = (freedBytes / (1024 * 1024)).toFixed(2);
-                    core.info(`Cleanup complete: deleted ${deletedCount} stale cache(s), freed ${freedMB} MB`);
+                    const cleanupScript = require('./.github/scripts/cleanup-caches.js');
+                    await cleanupScript({ github, context, core });

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -5,7 +5,11 @@ permissions:
 
 on:
     pull_request:
-        branches: ["**"]
+        branches: [main]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
 
 env:
     CARGO_TERM_COLOR: always
@@ -15,6 +19,7 @@ jobs:
     quick-checks:
         name: Quick Checks (fmt, docs, markdown)
         runs-on: ubuntu-latest
+        timeout-minutes: 10
 
         steps:
             - name: Checkout repository
@@ -130,7 +135,8 @@ jobs:
         name: CI Success
         needs: [quick-checks, build]
         runs-on: ubuntu-latest
-        if: always()
+        timeout-minutes: 5
+        if: ${{ !cancelled() }}
 
         steps:
             - name: Check if all jobs succeeded

--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -14,6 +14,7 @@ jobs:
     cleanup:
         name: Cleanup Caches
         runs-on: ubuntu-latest
+        timeout-minutes: 5
 
         permissions:
             actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     validate:
         name: Validate Release
         runs-on: ubuntu-latest
+        timeout-minutes: 5
 
         outputs:
             version: ${{ steps.version.outputs.version }}
@@ -155,6 +156,7 @@ jobs:
         name: Create Release
         needs: [validate, build]
         runs-on: ubuntu-latest
+        timeout-minutes: 10
 
         steps:
             - name: Checkout repository
@@ -221,15 +223,17 @@ jobs:
 
                 # Determine if this is a prerelease
                 PRERELEASE_FLAG=""
+                LATEST_FLAG="--latest"
                 if [[ "$VERSION" == *-* ]]; then
                     PRERELEASE_FLAG="--prerelease"
+                    LATEST_FLAG="--latest=false"
                 fi
 
                 # Create the release with gh CLI (more reliable than third-party actions)
                 gh release create "$TAG" \
                     --title "$TAG" \
                     --notes-file release_notes.md \
-                    --latest \
+                    $LATEST_FLAG \
                     $PRERELEASE_FLAG \
                     artifacts/*.tar.gz \
                     artifacts/*.zip \


### PR DESCRIPTION
## Summary

- **Pin `dtolnay/rust-toolchain@stable`** to commit SHA `631a55b1...` with explicit `toolchain: stable` input — fixes startup failure from SHA pinning requirement
- **Add concurrency groups** to `ci_main.yml` and `ci_pr.yml` — cancels superseded runs to save runner minutes
- **Add `timeout-minutes`** to all jobs that were missing it (`quick-checks`, `ci-success`, `cleanup`, `validate`, `release`)
- **Fix `--latest` flag on pre-releases** — pre-release tags (e.g. `v1.0.0-rc1`) no longer get marked as the "latest" release
- **Deduplicate cache cleanup** — `ci_main.yml` now calls the shared `.github/scripts/cleanup-caches.js` instead of inlining a copy
- **Narrow PR trigger** to `branches: [main]` instead of `["**"]`
- **Use `!cancelled()` instead of `always()`** on `ci-success` jobs — skips gracefully on workflow cancellation

## Test plan

- [ ] CI workflow passes on this PR
- [ ] Verify concurrency: push two commits quickly, first run should be cancelled
- [ ] Verify cache cleanup still works after deduplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)