### PR TITLE
Upgrade git2 0.19 -> 0.20.4 (security fix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ glob = "0.3"
 dirs = "6.0.0"
 
 # git2 library for in-process git operations (Tier 1 credential relay)
-git2 = "0.19"
+git2 = "0.20.4"
 
 # Compression for tar.gz archives
 flate2 = "1.0"


### PR DESCRIPTION
## Summary

- Upgrades `git2` from `0.19` to `0.20.4` to fix Dependabot alert #1
- **Vulnerability:** potential undefined behavior when dereferencing `Buf` struct — null pointer passed to `slice::from_raw_parts` in `Buf::new()`/`default()` (CWE-476, CVSS 2.7 Low)
- No breaking API changes — all 296 tests pass with no code modifications

## Test plan

- [ ] CI passes (cargo check, clippy, tests on all 3 platforms)
- [ ] Dependabot alert #1 auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)