### PR TITLE
fix: clippy duration_suboptimal_units and normalise action version comments

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -26,7 +26,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -36,7 +36,7 @@ jobs:
 
             - name: Setup Node.js
               id: setup-node
-              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                 node-version: "lts/*"
 
@@ -86,7 +86,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -174,7 +174,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -252,11 +252,11 @@ jobs:
 
             - name: Checkout repository
               if: success()
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Cleanup stale caches
               if: success()
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                 script: |
                     const cleanupScript = require('./.github/scripts/cleanup-caches.js');

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -23,7 +23,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -33,7 +33,7 @@ jobs:
 
             - name: Setup Node.js
               id: setup-node
-              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                 node-version: "lts/*"
 
@@ -76,7 +76,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -22,10 +22,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Run cleanup script
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
                 INPUT_DRY_RUN: ${{ inputs.dry_run || false }}
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Determine version
               id: version
@@ -95,7 +95,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -138,7 +138,7 @@ jobs:
 
             - name: Upload artifact (Unix)
               if: runner.os != 'Windows'
-              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               with:
                 name: ${{ matrix.artifact }}
                 path: ${{ matrix.artifact }}.tar.gz
@@ -146,7 +146,7 @@ jobs:
 
             - name: Upload artifact (Windows)
               if: runner.os == 'Windows'
-              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+              uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
               with:
                 name: ${{ matrix.artifact }}
                 path: ${{ matrix.artifact }}.zip
@@ -160,10 +160,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Download all artifacts
-              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                 path: artifacts
 
@@ -179,7 +179,7 @@ jobs:
                 cat SHA256SUMS.txt
 
             - name: Attest build provenance
-              uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+              uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
               with:
                 subject-path: |
                     artifacts/*.tar.gz

--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -524,6 +524,7 @@ pub enum AuditLoggerError {
 }
 
 #[cfg(test)]
+#[allow(unknown_lints, clippy::duration_suboptimal_units)] // lint added in Rust 1.95; tests use non-round ms values
 mod tests {
     use super::*;
     use std::io::Read;
@@ -672,7 +673,7 @@ mod tests {
             "abc123def",
             100,
             50000,
-            Duration::from_millis(2000),
+            Duration::from_secs(2),
         );
 
         assert_eq!(event.event_type, AuditEventType::RepoClone);


### PR DESCRIPTION
## Summary

Two fixes bundled together:

### 1. Clippy error (main branch CI failure)

Rust 1.95.0 added a new clippy lint `duration_suboptimal_units` that flags `Duration::from_millis(N)` where `N` is a whole-second multiple. This broke CI on main after the GitHub-hosted runners upgraded their toolchain.

**Fix:**
- `Duration::from_millis(2000)` → `Duration::from_secs(2)` (clean conversion)
- Added `#[allow(unknown_lints, clippy::duration_suboptimal_units)]` to the test module for `1234` and `1500` ms which are intentionally non-round
- `unknown_lints` keeps older stable rustc happy (lint added in 1.95)

### 2. Action version comments normalised to full semver

Dependabot had updated SHAs but left comments as `# v6`, `# v8`, etc. instead of the full semver (`# v6.0.2`, `# v8.0.1`). Mixed with the already-full `# v5.0.5` comments on `actions/cache`, this made the codebase inconsistent.

**Normalised all action version comments:**

| Action | Old comment | New comment |
|--------|-------------|-------------|
| `actions/checkout` | `# v6` | `# v6.0.2` |
| `actions/setup-node` | `# v6` | `# v6.3.0` |
| `actions/github-script` | `# v8` | `# v8.0.0` |
| `actions/upload-artifact` | `# v7` | `# v7.0.0` |
| `actions/download-artifact` | `# v8` | `# v8.0.1` |
| `actions/attest-build-provenance` | `# v4` | `# v4.1.0` |

Versions verified by resolving SHAs against each action's upstream tags via GitHub API.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally
- [x] `cargo test` passes (260 unit tests)
- [x] `cargo fmt --check` clean
- [ ] CI passes on PR (this will verify the fix resolves the main-branch clippy failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)