### PR TITLE
chore(lfs): print actual LFS batch error body so CI failures are diagnosable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check (`.github/scripts/check-toolchain-pin.sh`) fails the quick-checks job
   if the action pin and the `rust-toolchain.toml` channel disagree, so future
   toolchain bumps must update both together.
+- **LFS error diagnostics** — three small observability improvements to make
+  LFS resolution failures actionable from CI logs alone:
+  1. `LfsClient::new` now logs a `WARN` if no credentials were provided
+     (private repos will return 401/403 — easier to spot than the eventual
+     batch-API error).
+  2. The non-retryable batch-POST error path now reads the response body
+     (which GitHub/GitLab use for structured error messages such as
+     "Bad credentials" or "Repository not found") and includes it both in
+     a `WARN` log line and the returned error string. The Authorization
+     header is in the request, never the response — so this never echoes
+     the PAT.
+  3. `tests/integration/test_mcp_tools.py` now dumps the **full** server
+     log on test-suite failure instead of `tail -50`, so the LFS batch
+     status code and body (logged at the *start* of each clone, before
+     any progress noise) are visible in the GitHub Actions step output.
 
 ### Fixed
 

--- a/src/git2_ops/lfs.rs
+++ b/src/git2_ops/lfs.rs
@@ -231,7 +231,14 @@ impl LfsClient {
     ) -> Result<Self, Git2Error> {
         let lfs_url = derive_lfs_url(repo_url)?;
 
-        debug!(lfs_url = %lfs_url, "created LFS client");
+        if credentials.is_none() {
+            warn!(
+                lfs_url = %lfs_url,
+                "LFS client created without credentials — batch API requests to private repos will likely return 401/403"
+            );
+        } else {
+            debug!(lfs_url = %lfs_url, "LFS client created with credentials");
+        }
 
         let mut builder = Client::builder().user_agent("git-proxy-mcp/0.1");
 
@@ -392,8 +399,22 @@ impl LfsClient {
                         continue;
                     }
 
+                    // Non-retryable failure: capture the response body so the
+                    // operator can see what the LFS server actually said
+                    // (e.g. "Bad credentials", "Repository not found", rate
+                    // limit details). The body is server-generated text — it
+                    // does not echo our Authorization header.
+                    let body_text = response
+                        .text()
+                        .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
+                    warn!(
+                        status = %status,
+                        url = %url,
+                        response_body = %body_text,
+                        "LFS batch POST returned non-retryable error status"
+                    );
                     return Err(Git2Error::Git2(format!(
-                        "LFS batch API returned status {status}"
+                        "LFS batch API returned status {status}: {body_text}"
                     )));
                 }
                 Err(e) => {

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1903,12 +1903,18 @@ def main():
 
     if exit_code != 0:
         print()
-        print("Server log (last 50 lines):")
+        print("=" * 60)
+        print("Server log (full contents — printed on failure for diagnostics):")
+        print("=" * 60)
         if os.path.exists(SERVER_LOG_PATH):
             with open(SERVER_LOG_PATH, encoding="utf-8") as f:
-                lines = f.readlines()
-                for line in lines[-50:]:
-                    print(line, end="")
+                # Full dump rather than tail -50: the LFS batch status code
+                # and response body are emitted at the start of each clone,
+                # which a tail loses if any progress noise follows. GitHub
+                # Actions truncates step logs at 4 MiB, but the server log
+                # for a single integration run is well under that.
+                print(f.read(), end="")
+        print("=" * 60)
 
     if runner.failed == 0:
         print("All integration tests passed!")


### PR DESCRIPTION
## Description

Path B from the LFS-resolution-failure investigation. PR #131 unblocked main CI, which immediately revealed `test_clone_resolves_lfs_pointer` failing with `lfs_failed > 0`. The current diagnostic surface gives us only the HTTP status code (in the trailing 50 lines of server log, which the *next* test usually overwrites) — we need the response body to know whether it's bad credentials, missing repo, expired PAT, or something else.

This PR adds three small, focused improvements so the next failure is self-explanatory. **Pure observability** — no behaviour change to the success path.

## What this PR does

### 1. `LfsClient::new` warns when no credentials provided ([src/git2_ops/lfs.rs:234](src/git2_ops/lfs.rs#L234))

Today, an LFS client constructed without credentials silently sends batch requests with no Authorization header. Against any private repo the server returns 401/403, and we currently report it as an opaque "status 401" much later in the call chain. Now we log a `WARN` at construction time:

> `LFS client created without credentials — batch API requests to private repos will likely return 401/403`

If credentials *are* present, we keep the existing `DEBUG` line.

### 2. `post_with_retry` captures and logs the response body ([src/git2_ops/lfs.rs:395](src/git2_ops/lfs.rs#L395))

For non-retryable error statuses (4xx and exhausted-5xx) we now read `response.text()` before constructing the `Git2Error`. GitHub returns structured JSON like:

- 401: `{"message": "Bad credentials", "documentation_url": "..."}`
- 403: `{"message": "Repository access blocked"}`
- 404: `{"message": "Repository not found"}`
- 422: `{"message": "Validation failed", "errors": [...]}`

The body goes into both a `WARN` log line (with status, URL, and body fields) and the returned error string. **The Authorization header is in the request, never the response — this never echoes the PAT.**

### 3. Test harness dumps the full server log on failure ([tests/integration/test_mcp_tools.py:1904](tests/integration/test_mcp_tools.py#L1904))

Replaces `tail -50` with a full read. The LFS batch status and body are logged at the *start* of each clone (before any transfer-progress noise), so a tail loses them. GitHub Actions truncates step logs at 4 MiB; a single integration-test server log is well under that.

## What this PR does NOT do

- No retry-on-401/403 (would just loop)
- No `git credential fill` debug output (security concern; the better server-side logging covers what we need)
- No changes to the integration test assertions (they're correct — LFS resolution should work; we just need to know why it doesn't)
- No changes to the two `download_with_retry` paths (those run *after* batch API success — irrelevant for the current failure)

## Why a PR for diagnostics rather than a fix

We have two open hypotheses for the actual failure:
1. `TEST_REPO_PAT` (created ≈2 months ago) has expired and needs rotation — pure secrets-side, no code change
2. `git credential fill` is not returning both username+password from the runner's `~/.git-credentials`, so the LFS client is constructed with `None` credentials

The user is checking hypothesis 1 (PAT rotation) in parallel. Either way, this diagnostic PR makes the next failure tell us exactly what happened, so we don't have to guess again.

## Related

- Builds on PR #131 (which made integration tests actually run on main)
- Follows the LFS test additions from PR #127

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes) — observability/diagnostics only
- [ ] CI/CD changes
- [ ] Security improvement
- [x] Documentation update — CHANGELOG `[Unreleased]` § Changed

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages — verified: only the *response* body is logged, and the Authorization header is in the request
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately — N/A
- [x] Error messages don't leak sensitive information — the body field comes from the LFS server's response and may include the URL/path, but that's already public information in this context

## Testing

- [x] I have tested these changes locally — `cargo check`, `cargo clippy --lib --all-features -- -D warnings`, `cargo fmt --all --check`, and `cargo test --lib git2_ops::lfs` all pass; `py -3 -m py_compile tests/integration/test_mcp_tools.py` succeeds
- [x] All 43 existing LFS unit tests pass — they assert `result.is_err()` rather than the exact error string, so the format change is non-breaking
- [x] `bash .github/scripts/check-toolchain-pin.sh` still passes

## Code Quality

- [x] Code compiles without warnings (`cargo build`) — `cargo check` clean
- [x] Clippy passes (`cargo clippy -- -D warnings`) — clean
- [x] Code is formatted (`cargo fmt`) — clean
- [x] Documentation is updated if needed — CHANGELOG entry added under `[Unreleased]` § Changed
- [x] CHANGELOG.md is updated for user-facing changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)