### PR TITLE
fix(lfs): preserve .git suffix in derive_lfs_url (root cause of LFS resolution failure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `$CARGO_LLVM_COV_TARGET_DIR` (the workspace target directory exposed by
   current cargo-llvm-cov) and switches `--export-prefix` to its non-deprecated
   `--sh` alias.
+- **LFS endpoint URL incorrectly stripped `.git` suffix** — `derive_lfs_url`
+  in `src/git2_ops/lfs.rs` was calling `trim_end_matches(".git")` before
+  appending `/info/lfs`. GitHub's LFS service is mounted at
+  `<repo>.git/info/lfs/objects/batch`; without `.git`, the request reaches
+  GitHub's web frontend instead and gets a 422 + HTML response, causing
+  `lfs_failed += 1` for every LFS pointer. Removed the strip — the URL is
+  now passed through verbatim, matching the canonical `git-lfs` client
+  behaviour. Existing `*_no_git_suffix` tests still pass (those URLs never
+  had a suffix to begin with); the four tests that asserted the stripped
+  form have been updated to expect the correct preserved form.
 
 ### Security
 

--- a/src/git2_ops/lfs.rs
+++ b/src/git2_ops/lfs.rs
@@ -1202,9 +1202,10 @@ mod tests {
     // pointing at it, and exercise the retry/error-mapping paths that are
     // otherwise only reached by talking to a real LFS endpoint.
     //
-    // The `lfs_url` is derived from the repo_url as `{repo_url_without_git}/info/lfs`,
-    // so we pass `repo_url = "{mock_server}/repo.git"` to make the derived
-    // batch endpoint `{mock_server}/repo/info/lfs/objects/batch`.
+    // The `lfs_url` is derived from the repo_url as `{repo_url}/info/lfs`
+    // (the `.git` suffix is preserved verbatim — see `derive_lfs_url` doc),
+    // so we pass `repo_url = "{mock_server}/repo.git"` and the derived batch
+    // endpoint is `{mock_server}/repo.git/info/lfs/objects/batch`.
     // ------------------------------------------------------------------
 
     /// Build a fast-retry config so transient failures don't stall the test.
@@ -1250,11 +1251,11 @@ mod tests {
         let mut server = mockito::Server::new();
         let oid = "abc123def4567890abc123def4567890abc123def4567890abc123def4567890";
         let payload = b"hello LFS world";
-        let download_path = format!("/repo/info/lfs/objects/{oid}");
+        let download_path = format!("/repo.git/info/lfs/objects/{oid}");
         let download_href = format!("{}{}", server.url(), download_path);
 
         let _batch_mock = server
-            .mock("POST", "/repo/info/lfs/objects/batch")
+            .mock("POST", "/repo.git/info/lfs/objects/batch")
             .with_status(200)
             .with_header("content-type", "application/vnd.git-lfs+json")
             .with_body(make_batch_response(
@@ -1284,18 +1285,18 @@ mod tests {
         let mut server = mockito::Server::new();
         let oid = "abc123def4567890abc123def4567890abc123def4567890abc123def4567890";
         let payload = b"recovered after retry";
-        let download_path = format!("/repo/info/lfs/objects/{oid}");
+        let download_path = format!("/repo.git/info/lfs/objects/{oid}");
         let download_href = format!("{}{}", server.url(), download_path);
 
         // First attempt: 503 Service Unavailable (transient)
         let _failing_mock = server
-            .mock("POST", "/repo/info/lfs/objects/batch")
+            .mock("POST", "/repo.git/info/lfs/objects/batch")
             .with_status(503)
             .expect(1)
             .create();
         // Second attempt: success
         let _success_mock = server
-            .mock("POST", "/repo/info/lfs/objects/batch")
+            .mock("POST", "/repo.git/info/lfs/objects/batch")
             .with_status(200)
             .with_header("content-type", "application/vnd.git-lfs+json")
             .with_body(make_batch_response(
@@ -1328,7 +1329,7 @@ mod tests {
 
         // 401 Unauthorized — not retryable.
         let _mock = server
-            .mock("POST", "/repo/info/lfs/objects/batch")
+            .mock("POST", "/repo.git/info/lfs/objects/batch")
             .with_status(401)
             .expect(1) // Must only be called once.
             .create();
@@ -1350,7 +1351,7 @@ mod tests {
 
         // All requests return 502 Bad Gateway (transient).
         let _mock = server
-            .mock("POST", "/repo/info/lfs/objects/batch")
+            .mock("POST", "/repo.git/info/lfs/objects/batch")
             .with_status(502)
             .expect(max_attempts as usize)
             .create();
@@ -1371,7 +1372,7 @@ mod tests {
 
         // No mock should be reached — the size check fails first.
         let _mock = server
-            .mock("POST", "/repo/info/lfs/objects/batch")
+            .mock("POST", "/repo.git/info/lfs/objects/batch")
             .with_status(200)
             .expect(0) // Must NOT be called.
             .create();
@@ -1415,7 +1416,7 @@ mod tests {
         );
 
         let _mock = server
-            .mock("POST", "/repo/info/lfs/objects/batch")
+            .mock("POST", "/repo.git/info/lfs/objects/batch")
             .with_status(200)
             .with_header("content-type", "application/vnd.git-lfs+json")
             .with_body(response_body)
@@ -1437,13 +1438,13 @@ mod tests {
         let mut server = mockito::Server::new();
         let oid = "abc123def4567890abc123def4567890abc123def4567890abc123def4567890";
         let payload = b"authenticated content";
-        let download_path = format!("/repo/info/lfs/objects/{oid}");
+        let download_path = format!("/repo.git/info/lfs/objects/{oid}");
         let download_href = format!("{}{}", server.url(), download_path);
 
         // Expect the Authorization header to be present (Basic base64(user:pass)).
         // base64(test-user:s3cret) = dGVzdC11c2VyOnMzY3JldA==
         let _batch_mock = server
-            .mock("POST", "/repo/info/lfs/objects/batch")
+            .mock("POST", "/repo.git/info/lfs/objects/batch")
             .match_header("authorization", "Basic dGVzdC11c2VyOnMzY3JldA==")
             .with_status(200)
             .with_header("content-type", "application/vnd.git-lfs+json")

--- a/src/git2_ops/lfs.rs
+++ b/src/git2_ops/lfs.rs
@@ -821,7 +821,12 @@ impl LfsClient {
 
 /// Derive LFS server URL from git repository URL.
 ///
-/// For GitHub/GitLab, the LFS URL is typically: `{repo_url}/info/lfs`
+/// The LFS endpoint is `<repo_url>/info/lfs` with the repo URL preserved
+/// verbatim — including any `.git` suffix. GitHub in particular requires
+/// the `.git` to remain (e.g. `https://github.com/o/r.git/info/lfs/...`);
+/// stripping it routes the request to the web frontend, which returns a
+/// 422 + HTML page instead of an LFS batch JSON response. This matches
+/// the canonical `git-lfs` client behaviour.
 fn derive_lfs_url(repo_url: &str) -> Result<String, Git2Error> {
     // Handle SSH URLs: git@github.com:owner/repo.git -> https://github.com/owner/repo.git
     let https_url = if repo_url.starts_with("git@") {
@@ -839,11 +844,8 @@ fn derive_lfs_url(repo_url: &str) -> Result<String, Git2Error> {
         )));
     };
 
-    // Remove .git suffix if present
-    let base = https_url.trim_end_matches(".git");
-
-    // LFS endpoint
-    Ok(format!("{base}/info/lfs"))
+    // LFS endpoint — preserve any `.git` suffix in https_url.
+    Ok(format!("{https_url}/info/lfs"))
 }
 
 #[cfg(test)]
@@ -908,20 +910,25 @@ mod tests {
 
     #[test]
     fn derive_lfs_url_https() {
+        // The `.git` suffix must be preserved — GitHub returns 422 + HTML
+        // if we strip it.
         let url = derive_lfs_url("https://github.com/owner/repo.git").unwrap();
-        assert_eq!(url, "https://github.com/owner/repo/info/lfs");
+        assert_eq!(url, "https://github.com/owner/repo.git/info/lfs");
     }
 
     #[test]
     fn derive_lfs_url_https_no_git_suffix() {
+        // Already lacks `.git` — passed through verbatim. The user is
+        // responsible for providing a URL their LFS server accepts.
         let url = derive_lfs_url("https://github.com/owner/repo").unwrap();
         assert_eq!(url, "https://github.com/owner/repo/info/lfs");
     }
 
     #[test]
     fn derive_lfs_url_ssh() {
+        // SSH `.git` is preserved through the SSH-to-HTTPS rewrite.
         let url = derive_lfs_url("git@github.com:owner/repo.git").unwrap();
-        assert_eq!(url, "https://github.com/owner/repo/info/lfs");
+        assert_eq!(url, "https://github.com/owner/repo.git/info/lfs");
     }
 
     #[test]
@@ -1130,7 +1137,7 @@ mod tests {
     #[test]
     fn derive_lfs_url_http() {
         let url = derive_lfs_url("http://example.com/owner/repo.git").unwrap();
-        assert_eq!(url, "http://example.com/owner/repo/info/lfs");
+        assert_eq!(url, "http://example.com/owner/repo.git/info/lfs");
     }
 
     #[test]
@@ -1142,7 +1149,7 @@ mod tests {
     #[test]
     fn derive_lfs_url_ssh_self_hosted() {
         let url = derive_lfs_url("git@gitlab.example.com:group/project.git").unwrap();
-        assert_eq!(url, "https://gitlab.example.com/group/project/info/lfs");
+        assert_eq!(url, "https://gitlab.example.com/group/project.git/info/lfs");
     }
 
     #[test]


### PR DESCRIPTION
## Description

**Root cause** of the LFS resolution failure that has been failing every push to main since PR #127 merged. PR #132's diagnostic improvements finally exposed it: a one-line bug in `derive_lfs_url`.

## What the diagnostics revealed

After #132 merged, the post-merge `ci_main.yml` run (25208361231) produced this in the server log:

```
DEBUG LFS client created with credentials lfs_url=https://github.com/MatejGomboc/git-proxy-mcp-test-dummy/info/lfs
WARN  LFS batch POST returned non-retryable error status
        status=422 Unprocessable Entity
        url=https://github.com/MatejGomboc/git-proxy-mcp-test-dummy/info/lfs/objects/batch
        response_body=<!DOCTYPE html>...
WARN  failed to fetch LFS content
        path=docs/large.bin
        error=git operation failed: LFS batch API returned status 422 Unprocessable Entity: <!DOCTYPE html>
```

Three things stand out:

1. ✅ **Credentials reached the LFS client.** "LFS client created with credentials" rules out every credential-plumbing hypothesis we had.
2. ❌ **Status 422 + HTML response body.** GitHub's LFS batch API never returns 422 for a real LFS request — it returns 200/401/403/404/422-with-JSON. A 422 + HTML means the request isn't reaching the LFS service at all; it's being handled by GitHub's web frontend.
3. ❌ **Look at the URL — no `.git`.** The expected GitHub LFS endpoint is `<repo>.git/info/lfs/objects/batch`. We were calling it without `.git`.

## The bug

[`src/git2_ops/lfs.rs:843`](src/git2_ops/lfs.rs#L843):

```rust
// Remove .git suffix if present
let base = https_url.trim_end_matches(".git");

// LFS endpoint
Ok(format!("{base}/info/lfs"))
```

`trim_end_matches(".git")` was wrong. GitHub (and Git LFS in general) requires the `.git` to remain. The canonical `git-lfs` client does not strip it; `git lfs env` against a `.git`-suffixed remote shows the LFS URL with `.git` preserved.

## The fix

One line removed plus a corrected doc comment. The URL is now passed through verbatim to `<url>/info/lfs`.

## Test updates

Four existing unit tests baked in the wrong (stripped) behaviour and have been updated to expect the correct (preserved) form:

| Test | Old expectation | New expectation |
|---|---|---|
| `derive_lfs_url_https` | `…/owner/repo/info/lfs` | `…/owner/repo.git/info/lfs` |
| `derive_lfs_url_ssh` | `…/owner/repo/info/lfs` | `…/owner/repo.git/info/lfs` |
| `derive_lfs_url_http` | `…/owner/repo/info/lfs` | `…/owner/repo.git/info/lfs` |
| `derive_lfs_url_ssh_self_hosted` | `…/group/project/info/lfs` | `…/group/project.git/info/lfs` |

The two `_no_git_suffix` tests are **unchanged** — those inputs never had a `.git` to strip, so the URL passes through identically with the new code.

## How this happened (post-mortem)

1. PR #127 introduced both the LFS test fixture (`docs/large.bin`) and the integration tests for it (`test_clone_resolves_lfs_pointer`). The integration test was bound to fail because `derive_lfs_url` was already broken — but PR #127's other change to `ci_main.yml` (the `$CARGO_TARGET_DIR` reference) caused a `FileNotFoundError` *before* the integration tests ran, masking this bug.
2. PR #131 fixed the `$CARGO_TARGET_DIR` issue. Integration tests started running for the first time on main. The LFS test failed with an opaque "status 422" — the existing error message had no body.
3. PR #132 added response-body capture + warn-on-no-credentials. The next run produced the diagnostic above, immediately revealing the `.git` strip bug.
4. This PR fixes the root cause.

The cascade `#127 → #131 → #132 → this PR` is unfortunate but each step was needed to see the next layer. The diagnostics infrastructure from #132 will help if anything similar happens again.

## Related

- Diagnostics: PR #132 (just merged)
- Workflow fix that unblocked the integration tests: PR #131
- Original failing run: [25208361231](https://github.com/MatejGomboc/git-proxy-mcp/actions/runs/25208361231)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — fixes long-broken LFS resolution
- [ ] New feature
- [ ] Breaking change — see note below

**Note on \"breaking change\":** any external user who somehow relied on `derive_lfs_url` returning a URL without `.git` will see different behaviour now. Such reliance would have meant they were also experiencing the 422 failure, so this is a fix for them too. Function is `pub(crate)` (no `pub` modifier) → not a public API.

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately — N/A
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — `cargo test --lib git2_ops::lfs::tests::derive_lfs_url` runs all 9 derive tests, all pass
- [x] I have added tests that prove my fix/feature works — 4 unit tests updated to assert the correct preserved-`.git` form
- [x] New and existing tests pass (`cargo test`) — clippy clean, fmt clean

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --lib --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Documentation is updated if needed — function-level doc comment rewritten to explain *why* `.git` must be preserved (with a forward reference to the GitHub 422+HTML failure mode so future-us doesn't re-introduce the bug)
- [x] CHANGELOG.md is updated for user-facing changes — `[Unreleased]` § Fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)