### PR TITLE
fix(ci): merge integration coverage in single shell + add CODECOV_TOKEN

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -181,14 +181,6 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
 
-        # `id-token: write` lets the codecov-action mint a short-lived OIDC
-        # token instead of relying on a long-lived CODECOV_TOKEN secret.
-        # `contents: read` is re-granted because job-level permissions
-        # entirely override the workflow-level block.
-        permissions:
-            contents: read
-            id-token: write
-
         steps:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -292,9 +284,10 @@ jobs:
               uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
               with:
                 files: lcov.info
-                use_oidc: true
                 fail_ci_if_error: true
                 verbose: true
+              env:
+                CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     ci-success:
         name: CI Success

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -181,6 +181,14 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
 
+        # `id-token: write` lets the codecov-action mint a short-lived OIDC
+        # token instead of relying on a long-lived CODECOV_TOKEN secret.
+        # `contents: read` is re-granted because job-level permissions
+        # entirely override the workflow-level block.
+        permissions:
+            contents: read
+            id-token: write
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -226,28 +234,49 @@ jobs:
                 sudo apt-get install -y git-lfs
                 git lfs install
 
-            # Run unit tests under instrumentation (no report yet) so we can
-            # later merge integration-test coverage into the same dataset.
-            - name: Run unit tests with coverage instrumentation
-              run: cargo llvm-cov --all-features --workspace --no-report
-
-            # Build the instrumented release binary so the Python integration
-            # tests can spawn it and have its execution recorded as coverage.
-            # cargo-llvm-cov's show-env exposes RUSTFLAGS, LLVM_PROFILE_FILE,
-            # and CARGO_LLVM_COV_TARGET_DIR (which equals the workspace target
-            # directory — cargo-llvm-cov stopped overriding CARGO_TARGET_DIR
-            # in 0.1.14, so the build lands in the regular `target/release/`).
-            - name: Build instrumented release binary and run integration tests
+            # Run unit tests AND integration tests in a single shell so
+            # both write `.profraw` files to the same `LLVM_PROFILE_FILE`
+            # location set up by `show-env`. Splitting these into separate
+            # steps (as the previous workflow did) ran them in different
+            # subshells with cargo-llvm-cov's env scoped to whichever step
+            # invoked it — the integration-test profraw files landed
+            # somewhere the final `cargo llvm-cov report` didn't look, so
+            # the merged-coverage feature claimed by PR #127 silently
+            # produced unit-test-only numbers.
+            #
+            # show-env exposes RUSTFLAGS (instrumentation), LLVM_PROFILE_FILE
+            # (where binaries write profraw), and CARGO_LLVM_COV_TARGET_DIR
+            # (the workspace target directory — cargo-llvm-cov stopped
+            # overriding CARGO_TARGET_DIR in 0.1.14, so the build lands in
+            # the regular `target/release/`).
+            - name: Run unit + integration tests under coverage instrumentation
               env:
                 TEST_REPO_URL: ${{ secrets.TEST_REPO_URL }}
               run: |
-                # Export the env vars cargo-llvm-cov needs.
-                eval "$(cargo llvm-cov show-env --sh)"
+                # One env setup for the whole coverage run.
+                source <(cargo llvm-cov show-env --sh)
+                cargo llvm-cov clean --workspace --profraw-only
+
+                # Unit tests (instrumented via show-env's RUSTFLAGS).
+                cargo test --all-features --workspace
+
+                # Release binary (also instrumented).
                 cargo build --release
+
+                # Integration tests against the instrumented release binary.
                 python3 tests/integration/rebuild_fixture.py
-                # Tell the integration tests to spawn the instrumented build.
                 GIT_PROXY_MCP_BINARY="$CARGO_LLVM_COV_TARGET_DIR/release/git-proxy-mcp" \
                     python3 tests/integration/test_mcp_tools.py
+
+                # Diagnostic: confirm both unit-test and integration-test
+                # profraw files landed where `cargo llvm-cov report` will
+                # look. If this prints zero or only unit-test files, the
+                # merge isn't happening and the next coverage number won't
+                # reflect integration paths.
+                echo "--- profraw files written ---"
+                find target -name '*.profraw' -type f 2>/dev/null | head -20
+                echo "--- total profraw count ---"
+                find target -name '*.profraw' -type f 2>/dev/null | wc -l
 
             - name: Cleanup credentials
               if: always()
@@ -263,10 +292,9 @@ jobs:
               uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
               with:
                 files: lcov.info
-                fail_ci_if_error: false
+                use_oidc: true
+                fail_ci_if_error: true
                 verbose: true
-              env:
-                CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     ci-success:
         name: CI Success

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -138,14 +138,6 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
 
-        # `id-token: write` lets the codecov-action mint a short-lived OIDC
-        # token instead of relying on a long-lived CODECOV_TOKEN secret.
-        # `contents: read` is re-granted because job-level permissions
-        # entirely override the workflow-level block.
-        permissions:
-            contents: read
-            id-token: write
-
         steps:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -188,9 +180,10 @@ jobs:
               uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
               with:
                 files: lcov.info
-                use_oidc: true
                 fail_ci_if_error: true
                 verbose: true
+              env:
+                CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     ci-success:
         name: CI Success

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -138,6 +138,14 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
 
+        # `id-token: write` lets the codecov-action mint a short-lived OIDC
+        # token instead of relying on a long-lived CODECOV_TOKEN secret.
+        # `contents: read` is re-granted because job-level permissions
+        # entirely override the workflow-level block.
+        permissions:
+            contents: read
+            id-token: write
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -180,10 +188,9 @@ jobs:
               uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
               with:
                 files: lcov.info
-                fail_ci_if_error: false
+                use_oidc: true
+                fail_ci_if_error: true
                 verbose: true
-              env:
-                CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     ci-success:
         name: CI Success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,16 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check (`.github/scripts/check-toolchain-pin.sh`) fails the quick-checks job
   if the action pin and the `rust-toolchain.toml` channel disagree, so future
   toolchain bumps must update both together.
-- **Codecov uploads use OIDC instead of long-lived secret** — the
-  `Upload coverage to Codecov` step in both `ci_main.yml` and `ci_pr.yml`
-  now sets `use_oidc: true` and the coverage job grants `id-token: write`,
-  letting GitHub Actions mint a short-lived OIDC token that Codecov
-  verifies. Removes the dependency on a `CODECOV_TOKEN` repository
-  secret (which was never set, causing every upload to fall back to
-  tokenless mode and be rejected by Codecov with HTTP 400 — the badge
-  was stuck at "unknown" for that reason). Also flips
-  `fail_ci_if_error: false` → `true` so future upload failures fail
-  the job loudly instead of silently.
+- **Codecov upload — `fail_ci_if_error: true`** — both `ci_main.yml`
+  and `ci_pr.yml` now fail the job loudly when the Codecov upload
+  fails, instead of silently going green. The `CODECOV_TOKEN` repo
+  secret has been added (previously missing — every upload was being
+  rejected with HTTP 400 "Token required - not valid tokenless upload"
+  but `fail_ci_if_error: false` masked this, leaving the badge stuck
+  at "unknown"). OIDC was attempted first but the Codecov ingest
+  endpoint reproducibly returned HTTP 500 for this repo + OIDC
+  combination — token-based auth is the working path until Codecov's
+  OIDC handling matures.
 - **Coverage merging — unit + integration tests now share an
   `LLVM_PROFILE_FILE`** — the `coverage` job in `ci_main.yml` previously
   ran unit tests in one shell step and integration tests in another,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check (`.github/scripts/check-toolchain-pin.sh`) fails the quick-checks job
   if the action pin and the `rust-toolchain.toml` channel disagree, so future
   toolchain bumps must update both together.
+- **Codecov uploads use OIDC instead of long-lived secret** — the
+  `Upload coverage to Codecov` step in both `ci_main.yml` and `ci_pr.yml`
+  now sets `use_oidc: true` and the coverage job grants `id-token: write`,
+  letting GitHub Actions mint a short-lived OIDC token that Codecov
+  verifies. Removes the dependency on a `CODECOV_TOKEN` repository
+  secret (which was never set, causing every upload to fall back to
+  tokenless mode and be rejected by Codecov with HTTP 400 — the badge
+  was stuck at "unknown" for that reason). Also flips
+  `fail_ci_if_error: false` → `true` so future upload failures fail
+  the job loudly instead of silently.
+- **Coverage merging — unit + integration tests now share an
+  `LLVM_PROFILE_FILE`** — the `coverage` job in `ci_main.yml` previously
+  ran unit tests in one shell step and integration tests in another,
+  with `cargo llvm-cov`'s env vars scoped to whichever step invoked
+  them. The integration-test `.profraw` files landed somewhere the
+  final `cargo llvm-cov report` did not look, so the merged-coverage
+  feature claimed by PR #127 silently produced unit-test-only numbers.
+  Both test phases now run in a single shell with one
+  `source <(cargo llvm-cov show-env --sh)` setup, plus a diagnostic
+  step that prints the post-run profraw count so future regressions
+  are visible in the workflow log.
 - **LFS error diagnostics** — three small observability improvements to make
   LFS resolution failures actionable from CI logs alone:
   1. `LfsClient::new` now logs a `WARN` if no credentials were provided


### PR DESCRIPTION
## Description

Two related Codecov-side fixes that together unblock the broken Codecov badge ("unknown") and the long-broken merged-coverage feature from PR #127.

## Background — what we discovered

After PR #133 made the LFS test pass, main CI is fully green and the integration tests run. But two things still aren't working:

1. **Codecov badge stuck at "unknown".** The upload step's actual log (run [25209029471](https://github.com/MatejGomboc/git-proxy-mcp/actions/runs/25209029471)) shows:
   ```
   error - Upload queued for processing failed:
       {"message":"Token required - not valid tokenless upload"}
   ```
   The workflow passed `CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}` but the secret wasn't set in the repo, so the action fell back to tokenless mode, which Codecov's tightened-up policy rejects. `fail_ci_if_error: false` masked this — the job stayed green while Codecov never got the data. **The maintainer has now added the `CODECOV_TOKEN` secret.**

2. **Coverage stuck at 77.35% lines.** PR #127 explicitly anticipated `~76% → ~90%+` from merging integration coverage with unit coverage. The integration tests run, but the coverage number didn't budge.

## Fix 1: Codecov upload — flip `fail_ci_if_error: true` + use the now-existing token

OIDC was attempted in commit `66613a2` but Codecov's ingest endpoint reproducibly returned HTTP 500 for this repo + OIDC combination (verified across two attempts on this PR's CI). The OIDC handshake itself succeeded (action received a Codecov token in exchange for the GitHub OIDC identity), so the failure is on Codecov's side — likely either an unactivated server-side setting we can't see from outside, or a bug in their OIDC flow for repos in this configuration. Codecov's docs are silent on whether OIDC needs server-side enabling at app.codecov.io.

Reverted to token-based auth (commit `54be3e8`) — the `CODECOV_TOKEN` secret has been added to the repo.

Kept `fail_ci_if_error: true` so future upload failures (token expiry, network errors, future Codecov outages) fail loudly instead of silently.

## Fix 2: Coverage merging — single shell session for unit + integration tests

The previous `ci_main.yml` coverage job had three separate `run:` steps:

| Step | Command |
|---|---|
| Run unit tests with coverage instrumentation | `cargo llvm-cov --all-features --workspace --no-report` |
| Build instrumented release binary and run integration tests | `eval "$(cargo llvm-cov show-env --sh)" && cargo build --release && python3 ...` |
| Generate merged coverage report (lcov) | `cargo llvm-cov report --lcov --output-path lcov.info` |

GitHub Actions runs each step in its own subshell. The env vars `show-env` exports in step 2 (RUSTFLAGS, LLVM_PROFILE_FILE, CARGO_LLVM_COV_TARGET_DIR) are visible only to step 2. Step 1's `cargo llvm-cov` invocation manages its own internal env. Depending on cargo-llvm-cov's internal location heuristics, the unit-test profraw files and the integration-test profraw files can end up in different directories — and step 3's `cargo llvm-cov report` only sees one of them.

**Restructure** into a single `run:` step where `source <(cargo llvm-cov show-env --sh)` is sourced once and the env stays active for both unit tests AND integration tests:

```bash
source <(cargo llvm-cov show-env --sh)
cargo llvm-cov clean --workspace --profraw-only

# Unit tests (instrumented via show-env's RUSTFLAGS).
cargo test --all-features --workspace

# Release binary (also instrumented).
cargo build --release

# Integration tests against the instrumented release binary.
python3 tests/integration/rebuild_fixture.py
GIT_PROXY_MCP_BINARY="$CARGO_LLVM_COV_TARGET_DIR/release/git-proxy-mcp" \
    python3 tests/integration/test_mcp_tools.py
```

All `cargo` and binary invocations now share the same `LLVM_PROFILE_FILE`, so all profraw files land in the same directory and are merged by the unchanged final `cargo llvm-cov report` call.

**Diagnostic** added at the end of the combined step:
```bash
echo "--- profraw files written ---"
find target -name '*.profraw' -type f 2>/dev/null | head -20
echo "--- total profraw count ---"
find target -name '*.profraw' -type f 2>/dev/null | wc -l
```

So if the merge breaks again, the next workflow log will show exactly how many profraw files exist and where, instead of us having to guess from a static coverage number.

## What this PR does NOT do

- No changes to `ci_pr.yml`'s coverage step structure beyond the token + fail-loud — that job runs unit tests only via the simpler one-shot `cargo llvm-cov --all-features --workspace --lcov ...` invocation, so the merging issue doesn't apply there.
- No changes to which paths are excluded from coverage. `codecov.yml` still excludes `main.rs` and `transport.rs`.
- No retry-on-Codecov-error logic. If Codecov returns a transient 5xx, the job fails. We can revisit if it becomes flaky in practice.

## Expected outcome after merge

- Codecov badge transitions from "unknown" → an actual percentage on the next push to main.
- Coverage number jumps meaningfully (PR #127's `~76% → ~90%+` estimate becomes verifiable). If it doesn't jump, the diagnostic profraw count will tell us why.
- Future Codecov upload failures fail CI immediately instead of silently swallowing the error.

## Related

- Coverage step originally introduced in PR #127
- LFS endpoint fix that made integration tests actually run: PR #133
- Workflow bug fix that unblocked the integration step: PR #131
- Diagnostics infrastructure: PR #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)