### PR TITLE
fix(ci): run cargo llvm-cov report in same shell as tests

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -226,22 +226,25 @@ jobs:
                 sudo apt-get install -y git-lfs
                 git lfs install
 
-            # Run unit tests AND integration tests in a single shell so
-            # both write `.profraw` files to the same `LLVM_PROFILE_FILE`
-            # location set up by `show-env`. Splitting these into separate
-            # steps (as the previous workflow did) ran them in different
-            # subshells with cargo-llvm-cov's env scoped to whichever step
-            # invoked it — the integration-test profraw files landed
-            # somewhere the final `cargo llvm-cov report` didn't look, so
-            # the merged-coverage feature claimed by PR #127 silently
-            # produced unit-test-only numbers.
+            # Run tests + integration tests + report generation all in
+            # a single shell so they share the env that `show-env --sh`
+            # exports — most importantly `LLVM_PROFILE_FILE` (where
+            # binaries write profraw) and `CARGO_LLVM_COV_TARGET_DIR`
+            # (the workspace target directory). When `cargo llvm-cov
+            # report` runs in a *separate* shell without these env vars,
+            # it defaults to looking for profraw in `target/llvm-cov-target/`
+            # instead of where show-env actually wrote them (`target/`),
+            # and fails with "not found *.profraw files". This was the
+            # observed failure on the post-PR-#134 main run; the previous
+            # diagnostic confirmed profraw files did land in `target/`,
+            # but the standalone report step in a fresh shell looked
+            # elsewhere.
             #
-            # show-env exposes RUSTFLAGS (instrumentation), LLVM_PROFILE_FILE
-            # (where binaries write profraw), and CARGO_LLVM_COV_TARGET_DIR
-            # (the workspace target directory — cargo-llvm-cov stopped
-            # overriding CARGO_TARGET_DIR in 0.1.14, so the build lands in
-            # the regular `target/release/`).
-            - name: Run unit + integration tests under coverage instrumentation
+            # Note on cargo-llvm-cov version history:
+            # - 0.1.14 stopped overriding CARGO_TARGET_DIR — builds now
+            #   land in the regular `target/release/`.
+            # - 0.7.0 renamed `--export-prefix` to `--sh` (deprecated alias).
+            - name: Run tests + generate coverage report under instrumentation
               env:
                 TEST_REPO_URL: ${{ secrets.TEST_REPO_URL }}
               run: |
@@ -270,15 +273,15 @@ jobs:
                 echo "--- total profraw count ---"
                 find target -name '*.profraw' -type f 2>/dev/null | wc -l
 
+                # Generate the merged report from inside this same shell
+                # so `report` inherits the show-env env and looks for
+                # profraw in the directory where the tests just wrote it.
+                cargo llvm-cov report --lcov --output-path lcov.info
+                cargo llvm-cov report --summary-only
+
             - name: Cleanup credentials
               if: always()
               run: rm -f ~/.git-credentials
-
-            - name: Generate merged coverage report (lcov)
-              run: cargo llvm-cov report --lcov --output-path lcov.info
-
-            - name: Generate coverage summary
-              run: cargo llvm-cov report --summary-only
 
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,17 +63,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   endpoint reproducibly returned HTTP 500 for this repo + OIDC
   combination — token-based auth is the working path until Codecov's
   OIDC handling matures.
-- **Coverage merging — unit + integration tests now share an
-  `LLVM_PROFILE_FILE`** — the `coverage` job in `ci_main.yml` previously
-  ran unit tests in one shell step and integration tests in another,
-  with `cargo llvm-cov`'s env vars scoped to whichever step invoked
-  them. The integration-test `.profraw` files landed somewhere the
-  final `cargo llvm-cov report` did not look, so the merged-coverage
-  feature claimed by PR #127 silently produced unit-test-only numbers.
-  Both test phases now run in a single shell with one
-  `source <(cargo llvm-cov show-env --sh)` setup, plus a diagnostic
-  step that prints the post-run profraw count so future regressions
-  are visible in the workflow log.
+- **Coverage merging — tests + report generation share one shell** —
+  the `coverage` job in `ci_main.yml` previously split its work
+  across multiple shell steps: unit tests in one, integration tests
+  in another, and `cargo llvm-cov report` in a third. Each step
+  re-entered a fresh shell where the env vars `cargo llvm-cov
+  show-env --sh` exports (most importantly `LLVM_PROFILE_FILE` and
+  `CARGO_LLVM_COV_TARGET_DIR`) were no longer set — so binaries
+  wrote profraw to one location and `report` looked in another.
+  Net effect: PR #127's "merged unit + integration coverage"
+  feature silently produced unit-test-only numbers (~77% lines)
+  despite the integration tests running fine. Now everything runs
+  in a single shell: `source show-env`, clean stale profraw, run
+  unit tests, build instrumented release binary, run integration
+  tests, list the resulting profraw for diagnostic visibility,
+  generate the lcov + summary reports — all sharing the same env.
+  The next `Upload coverage to Codecov` step (a separate shell)
+  only needs `lcov.info` from disk, which persists across steps.
 - **LFS error diagnostics** — three small observability improvements to make
   LFS resolution failures actionable from CI logs alone:
   1. `LfsClient::new` now logs a `WARN` if no credentials were provided


### PR DESCRIPTION
## Description

Follow-up to PR #134. The post-merge main CI run ([25210973734](https://github.com/MatejGomboc/git-proxy-mcp/actions/runs/25210973734)) failed because the **report generation** suffered the same env-isolation problem PR #134 fixed for the **test execution**.

## What the diagnostic told us

PR #134 added a profraw-count diagnostic at the end of the combined test step. It worked perfectly — and this is what it printed on the failed run:

```
--- profraw files written ---
target/git-proxy-mcp-7436-7667202330552397739_0.profraw
target/git-proxy-mcp-7412-3633489650111708640_0.profraw
target/git-proxy-mcp-7402-3404227693071123704_2.profraw
target/git-proxy-mcp-7379-1285113763205115676_3.profraw
target/git-proxy-mcp-7424-9328522412714280671_0.profraw
target/git-proxy-mcp-7381-2456713637592105607_1.profraw
target/git-proxy-mcp-6851-11893404712607488247_3.profraw
target/git-proxy-mcp-10925-9035762081679612538_1.profraw
--- total profraw count ---
8
```

So profraw files **did** land correctly under `target/`. Then the next step ran `cargo llvm-cov report` and got:

```
error: failed to merge profile data: not found *.profraw files in 
    /home/runner/work/git-proxy-mcp/git-proxy-mcp/target/llvm-cov-target
```

`report` was looking in `target/llvm-cov-target/` — a directory that exists for the all-in-one `cargo llvm-cov` mode but **not** when you use `show-env` standalone (which puts profraw under `target/` directly via `LLVM_PROFILE_FILE`). When `show-env` env is active, `report` knows where to look. Without it, `report` defaults to the all-in-one location.

## The fix

Bring `cargo llvm-cov report --lcov ...` and `cargo llvm-cov report --summary-only` into the **same** `run:` block as the tests, so they inherit `CARGO_LLVM_COV_TARGET_DIR` from the same `source <(cargo llvm-cov show-env --sh)` invocation. The Codecov upload step remains separate because it only needs `lcov.info` on disk — that file persists across step boundaries.

## Why this is the same class of bug as PR #134

PR #134's commit message claimed:

> The integration-test profraw files landed somewhere the final `cargo llvm-cov report` did not look

That was *one* manifestation. PR #134 fixed it for the test side (unit + integration in one shell, both writing to the same place). But it left `report` in a separate shell. So now:

- Unit tests + integration tests → write profraw to `target/` ✓ (PR #134's fix)
- `cargo llvm-cov report` → still looking at `target/llvm-cov-target/` ✗ (this PR's fix)

This PR closes the loop. Diagnostic kept (and now runs BEFORE the report generation in the same shell, so we still see the profraw count even if the report itself blows up).

## Expected outcome after merge

- Coverage upload succeeds.
- Coverage % jumps meaningfully (PR #127's `~76% → ~90%+` estimate becomes verifiable for the first time).
- The Codecov badge transitions from "unknown" to a real percentage.
- The diagnostic profraw count remains visible in the workflow log so future regressions are easy to spot.

## Related

- PR #134 (just merged): merged unit + integration test execution into one shell. Necessary first step but incomplete.
- PR #127 (originally introduced this whole subsystem)
- PR #131 (workflow bug that hid all of this for weeks)
- PR #132 (added the diagnostics that made this debuggable at all)

## Type of Change

- [x] Bug fix (non-breaking) — completes the merge-coverage feature PR #127 set out to deliver
- [x] CI/CD changes
- [ ] Breaking change

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] If handling sensitive data, `secrecy` crate is used appropriately — N/A
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — `bash .github/scripts/check-toolchain-pin.sh` still passes; YAML structure verified
- [x] I have added tests that prove my fix/feature works — the diagnostic profraw count is the regression test; the lcov coverage % on the next main run will be the integration test for the merging fix
- [x] New and existing tests pass — no Rust source changed

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — workflow comment block rewritten to explain the fix
- [x] CHANGELOG.md is updated for user-facing changes — `[Unreleased]` § Changed entry rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)