### PR TITLE
docs(template): replace `secrecy` crate reference with project's actual pattern

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,8 +23,7 @@ Since this is a credential-handling project:
 - [ ] No credentials, tokens, or secrets are included in code, comments, or tests
 - [ ] No credentials appear in log messages or error messages
 - [ ] No credentials are exposed in MCP responses
-- [ ] Credentials are not persisted in process memory beyond a git2 callback's lifetime
-  (this project uses git2 credential callbacks rather than caching secrets — see `src/git2_ops/auth.rs`)
+- [ ] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`)
 - [ ] Error messages don't leak sensitive information
 
 ## Testing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,8 @@ Since this is a credential-handling project:
 - [ ] No credentials, tokens, or secrets are included in code, comments, or tests
 - [ ] No credentials appear in log messages or error messages
 - [ ] No credentials are exposed in MCP responses
-- [ ] If handling sensitive data, `secrecy` crate is used appropriately
+- [ ] Credentials are not persisted in process memory beyond a git2 callback's lifetime
+  (this project uses git2 credential callbacks rather than caching secrets — see `src/git2_ops/auth.rs`)
 - [ ] Error messages don't leak sensitive information
 
 ## Testing


### PR DESCRIPTION
## Description

PR 1 of 3 in a documentation audit series. The PR template's Security Checklist had a checklist item:

```
[ ] If handling sensitive data, `secrecy` crate is used appropriately
```

But the `secrecy` crate is **not** in `Cargo.toml` or `Cargo.lock` and has never been a dependency of this project (verified via `grep -n "secrecy" Cargo.toml Cargo.lock`). Contributors who'd glance at the template would assume there's an established `secrecy`-based pattern in the codebase — there isn't.

## Fix

Replace with a checklist item that describes the project's *actual* secret-handling pattern: credentials live only inside a git2 credential callback's call stack, never cached. Point to `src/git2_ops/auth.rs` as the canonical implementation reference.

## Why two lines

The single-line version exceeded STYLE.md's 170-char max line length (markdownlint-cli2 flagged it as MD013). Wrapped using markdown-list 2-space continuation indent so the second line remains part of the same checklist item visually.

## Related

This PR is part of a small documentation cleanup arc following the audit done in chat. The follow-up PRs in this series will:

- PR 2: refresh stale references in `docs/AI_WORKFLOW.md` (example response version `0.1.0` → `1.1.0`) and `docs/errors.md` (timestamp + missing recent error-message changes)
- PR 3: cross-reference the two `SECURITY.md` files (root vs `docs/`) and add a Requirements section to `README.md` explaining MSRV vs CI pin

## Type of Change

- [x] Documentation update
- [ ] Bug fix — borderline (the line was misleading, not broken)
- [ ] Breaking change

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are not persisted in process memory beyond a git2 callback's lifetime — N/A, this is the very item being added
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — line lengths verified within STYLE.md's 170-char limit
- [x] All existing tests pass — no code changed
- [x] No new tests required — template-only change

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — this IS the documentation update
- [ ] CHANGELOG.md is updated for user-facing changes — **N/A**: PR template change is contributor-facing, not user-facing per CONTRIBUTING.md's CHANGELOG rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)