### PR TITLE
docs: refresh stale references in AI_WORKFLOW and errors

### DIFF
--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -48,7 +48,7 @@ commits from human commits.
 {
   "protocolVersion": "2024-11-05",
   "capabilities": { "tools": {} },
-  "serverInfo": { "name": "git-proxy-mcp", "version": "0.1.0" },
+  "serverInfo": { "name": "git-proxy-mcp", "version": "1.1.0" },
   "gitIdentity": {
     "name": "Claude AI",
     "email": "ai-assistant@example.com"

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -151,6 +151,53 @@ Credentials embedded in URLs are replaced with `***` before any logging occurs.
 
 ---
 
+## LFS Resolution Errors
+
+When `repo/clone` or `repo/clone_start` is invoked with `resolve_lfs: true`,
+the server fetches LFS content from `<repo_url>.git/info/lfs/objects/batch`.
+Two log lines help diagnose failures.
+
+### Missing credentials warning
+
+If the `LfsClient` is constructed without credentials, the server emits
+a `WARN` at the start of the clone (before any batch request):
+
+```text
+WARN LFS client created without credentials — batch API requests to private
+     repos will likely return 401/403
+```
+
+For private repos this is almost always the cause of any subsequent
+401/403 from the batch endpoint.
+
+### Batch-API error includes response body
+
+Non-retryable status codes (4xx, plus 5xx after retry exhaustion) log
+the HTTP status, the request URL, and the response body:
+
+```text
+WARN LFS batch POST returned non-retryable error status
+     status=401 Unauthorized
+     url=https://github.com/owner/repo.git/info/lfs/objects/batch
+     response_body={"message":"Bad credentials"}
+```
+
+The body comes from the LFS server's response and is also included in
+the returned `Git2Error`, so it surfaces in the tool-call error too. The
+Authorization header is in the *request*, never the response — the
+logged body cannot leak the PAT.
+
+Common GitHub responses to recognise:
+
+| HTTP code | Typical body | Likely cause |
+|---|---|---|
+| 401 | `{"message":"Bad credentials"}` | Token expired or invalid |
+| 403 | `{"message":"Repository access blocked"}` | PAT lacks `repo` scope (classic) or `Contents: Read and write` (fine-grained) |
+| 404 | `{"message":"Object does not exist"}` | LFS object never uploaded to the remote |
+| 422 | `<!DOCTYPE html>...` | URL missing `.git` — request reached the web frontend, not the LFS service |
+
+---
+
 ## Troubleshooting
 
 ### Authentication Failures
@@ -196,4 +243,4 @@ ssh-add ~/.ssh/id_ed25519
 
 ---
 
-*Last updated: 2026-01-10*
+*Last updated: 2026-05-01*


### PR DESCRIPTION
## Description

PR 2 of 3 in the documentation audit cleanup. Two factually-stale references in `docs/`:

| File | Issue | Fix |
|---|---|---|
| `docs/AI_WORKFLOW.md:51` | Example MCP `serverInfo.version` showed `"0.1.0"`, predating the v1.0.0 → v1.1.0 progression | Bump to `"1.1.0"` to match what the server actually returns (`env!("CARGO_PKG_VERSION")` from `src/mcp/server.rs:109`) |
| `docs/errors.md` | Last-updated timestamp `2026-01-10` predates several recent error-message additions; no documentation for the LFS error logs added in PR #132 | Add new "LFS Resolution Errors" section + bump timestamp to `2026-05-01` |

## docs/AI_WORKFLOW.md change

One-character version bump in the example JSON response. Verified `src/mcp/server.rs:109` populates the field from `env!("CARGO_PKG_VERSION")` which resolves to `Cargo.toml`'s current `version = "1.1.0"`.

## docs/errors.md change

Added a new section between "URL Sanitisation" and "Troubleshooting" that documents the LFS diagnostics introduced in PR #132 (and indirectly PR #133):

- The `LFS client created without credentials` warning at client construction time
- The `LFS batch POST returned non-retryable error status` log with status, URL, and response body
- A small lookup table for the four common HTTP statuses GitHub returns to LFS batch requests:

| HTTP code | Typical body | Likely cause |
|---|---|---|
| 401 | `{"message":"Bad credentials"}` | Token expired or invalid |
| 403 | `{"message":"Repository access blocked"}` | PAT lacks `repo` (classic) or `Contents: R/W` (fine-grained) |
| 404 | `{"message":"Object does not exist"}` | LFS object never uploaded to remote |
| 422 | `<!DOCTYPE html>...` | URL missing `.git` — request reached web frontend, not LFS service |

The 422+HTML row in particular captures the smoking gun for the `derive_lfs_url` bug fixed in PR #133 — preserving the institutional memory in case it ever recurs.

Also clarifies that the `Authorization` header is in the *request*, never the response, so the logged response body cannot leak the PAT.

## Why a single PR (and not split)

Both edits are factually-stale references. Same review lens. Both touch only `docs/` files. Audit suggested grouping them — agreed.

## Related

- PR 1 of 3: PR #137 (replaced `secrecy` crate reference in PR template)
- PR 3 of 3: upcoming — SECURITY scope cross-references + README requirements section
- LFS diagnostics: PR #132
- LFS endpoint URL fix: PR #133

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] Breaking change

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`) — N/A for docs-only PR
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — file contents verified, line-lengths checked against `.markdownlint.json` (MD013 = 170, with tables and code blocks excluded — my new prose fits)
- [x] All existing tests pass — no code changed
- [x] No new tests required — docs-only

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — this IS the documentation update
- [ ] CHANGELOG.md is updated for user-facing changes — **N/A**: refreshing existing docs to match current behaviour, not a behavioural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)