### PR TITLE
docs: deeper audit cleanup — language tags, stale timestamp, British spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ Use British spelling in all documentation and user-facing text:
 
 We use [Conventional Commits](https://www.conventionalcommits.org/). Format:
 
-```
+```text
 <type>(<scope>): <description>
 
 [optional body]
@@ -215,7 +215,7 @@ We use [Conventional Commits](https://www.conventionalcommits.org/). Format:
 
 ### Examples
 
-```
+```text
 feat(git): Add clone progress streaming
 
 fix(auth): Prevent credential leak in error messages

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Cloud-based AI coding assistants face a fundamental dilemma:
 
 git-proxy-mcp acts as an **authenticated streaming proxy** between Git providers and AI workspaces:
 
-```
+```text
 ┌─────────────────┐      ┌─────────────────┐      ┌─────────────────┐
 │  Git Providers  │      │    YOUR PC      │      │    AI's VM      │
 │                 │      │                 │      │                 │
@@ -84,7 +84,7 @@ git-proxy-mcp acts as an **authenticated streaming proxy** between Git providers
 
 ### Security Model
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │  YOUR PC (credentials stay here, files don't)                   │
 │                                                                 │

--- a/STYLE.md
+++ b/STYLE.md
@@ -284,4 +284,4 @@ See `CONTRIBUTING.md` § British Spelling for the full reference table.
 
 ---
 
-*Last updated: 2026-03-14*
+*Last updated: 2026-04-29*

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -4,7 +4,7 @@ This document explains how an AI assistant uses git-proxy-mcp to work with priva
 
 ## The Complete Workflow
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                        AI's Development Workflow                            │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -254,7 +254,7 @@ git commit -m "Sync from remote: new789..."
 
 **GitHub MCP Server:**
 
-```
+```text
 Call 1:  get_repository_content(path: "/")
 Call 2:  get_file_content(path: "src/main.rs")
 Call 3:  get_file_content(path: "src/lib.rs")
@@ -266,7 +266,7 @@ Total: 100 API calls, several minutes
 
 **git-proxy-mcp:**
 
-```
+```text
 Call 1: repo/clone { url: "..." }
 
 Total: 1 call, seconds
@@ -276,7 +276,7 @@ Total: 1 call, seconds
 
 **GitHub MCP Server:**
 
-```
+```text
 ❌ Not possible — no execution environment
 ```
 
@@ -298,7 +298,7 @@ test validation::tests::test_empty_input ... ok
 
 **GitHub MCP Server:**
 
-```
+```text
 Call 1: create_branch(name: "feature/fix")
 Call 2: update_file(path: "src/main.rs", content: "...", message: "...")
 Call 3: update_file(path: "src/lib.rs", content: "...", message: "...")
@@ -386,7 +386,7 @@ git commit -m "Merge remote changes"
 
 After pushing a feature branch, you might use GitHub MCP server just for PR creation:
 
-```
+```text
 # Use git-proxy-mcp for the code work
 repo/clone → work → repo/push to feature/my-feature
 

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -108,7 +108,7 @@ mkdir -p /home/claude/repo
 tar -xzf repo.tar.gz -C /home/claude/repo
 rm repo.tar.gz
 
-# Initialize git (so we can create commits later)
+# Initialise git (so we can create commits later)
 cd /home/claude/repo
 git init
 git add .

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ This is the fundamental design principle that distinguishes git-proxy-mcp from o
 
 ### Clone Flow (In Detail)
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ CLONE: Stream directly from git objects to tar archive                      │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -83,7 +83,7 @@ repo.checkout_head(...)?;                  // Would write files!
 
 ### Push Flow
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ PUSH: Receive bundle, push to remote                                        │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -128,7 +128,7 @@ repo.checkout_head(...)?;                  // Would write files!
 
 ### Temp Directory Contents
 
-```
+```text
 /tmp/git-proxy-xxxxx/        # Temp dir (auto-deleted)
 ├── objects/                 # Git object database
 │   ├── pack/               # Pack files from fetch
@@ -155,7 +155,7 @@ For large repositories, Tier 1 may buffer too much data in memory. Tier 2 solves
 
 ### Chunked Clone Flow
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ TIER 2: Chunked streaming for large repos                                   │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -225,7 +225,7 @@ All operations logged (without credentials), showing:
 
 ## Component Overview
 
-```
+```text
 src/
 ├── lib.rs                       # Library crate root
 ├── main.rs                      # CLI entry point

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,7 +14,7 @@ The MCP server runs on the user's machine and delegates all authentication to th
 
 **SSH Authentication:**
 
-```
+```text
 git2 needs to authenticate
           │
           ▼
@@ -36,7 +36,7 @@ git2 uses signature for auth
 
 **HTTPS Authentication:**
 
-```
+```text
 git2 needs to authenticate
           │
           ▼

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -12,7 +12,7 @@ Cloud-based AI assistants (Claude.ai, ChatGPT, Gemini) have:
 
 ## The Solution: Credential Relay
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  CREDENTIAL RELAY ARCHITECTURE                                          │
 │                                                                         │
@@ -41,7 +41,7 @@ Repo files:  Stream through MCP → land in AI's VM
 
 ### Tier 1: Single-Response Streaming
 
-```
+```text
 GitHub ──► MCP (buffer in RAM) ──► AI
 ```
 
@@ -57,7 +57,7 @@ GitHub ──► MCP (buffer in RAM) ──► AI
 
 ### Tier 2: Chunked Streaming
 
-```
+```text
 GitHub ──► MCP (small chunks) ──► AI
 ```
 
@@ -100,7 +100,7 @@ GitHub ──► MCP (small chunks) ──► AI
 
 ## Data Flow: Clone Operation
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ CLONE: Authenticated fetch → stream to AI                                   │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -132,7 +132,7 @@ GitHub ──► MCP (small chunks) ──► AI
 
 ## Data Flow: Push Operation
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ PUSH: Receive changes from AI → authenticated push                          │
 ├─────────────────────────────────────────────────────────────────────────────┤


### PR DESCRIPTION
## Description

Follow-up to PRs #137, #138, #139 (the original 3-PR documentation audit cleanup arc). After being asked whether *all* minor and cosmetic issues were fixed, I ran a deeper sweep with stricter pass criteria and found three categories the time-bounded first audit had missed.

## What this PR fixes

### Commit 1 — Bare opening code fences

STYLE.md says `Always specify the language` for fenced code blocks. The deeper sweep turned up **22 bare opening fences** across 6 files. All contain ASCII diagrams or pseudocode — none had a language tag. Tagged each as ```` ```text ````:

| File | Count | What |
|---|---|---|
| `README.md` | 2 | main architecture diagram, security model diagram |
| `CONTRIBUTING.md` | 2 | conventional commit format + examples |
| `docs/AI_WORKFLOW.md` | 6 | workflow overview + 5 comparison pseudocode blocks |
| `docs/ARCHITECTURE.md` | 5 | clone/push flow diagrams + temp dir + chunked clone + component overview |
| `docs/VISION.md` | 5 | credential relay + tier 1/2 + clone/push data flows |
| `docs/SECURITY.md` | 2 | SSH and HTTPS auth flow diagrams |

The 4-backtick `markdown` examples inside STYLE.md itself are unchanged — those are demonstrating fence syntax, not violating it.

### Commit 2 — Stale `STYLE.md` timestamp

Footer said `*Last updated: 2026-03-14*` but `git log -1 --format=%cs STYLE.md` shows the file was last committed `2026-04-29`. Six-week discrepancy. Bumped to match git's record.

### Commit 3 — British "Initialise" in a bash comment

Line 111 of `docs/AI_WORKFLOW.md` had `# Initialize git (so we can create commits later)` — generic verb usage, not a method-name identifier reference. Changed to `Initialise`.

Other "initialize" occurrences in `docs/errors.md` and the heading "Initialize Response" in line 45 reference the JSON-RPC method name `initialize` — those remain American as identifiers per CONTRIBUTING.md's "code identifiers may use American spelling" exception.

## Why this PR (not earlier)

The first audit was 800-word capped — it correctly identified the 5 high-impact issues that PRs #137/#138/#139 fixed, but didn't budget for an exhaustive pass. The deeper sweep used dedicated state-machine analysis to differentiate opening from closing fences, an explicit British-spelling regex sweep, and per-file timestamp cross-checking. Findings were proportional to the deeper budget.

## What this PR doesn't fix

- The `repo_clone_status` tool name doesn't match the `repo/<name>` convention used elsewhere — flagged by the agent but explicitly *not a bug* (CHANGELOG.md describes it as the chosen name; consistent across all docs)
- Pre-existing 183/201-char lines inside README.md code blocks/tables — exempt per `MD013: { code_blocks: false, tables: false }` in `.markdownlint.json`

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] Breaking change

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`) — N/A for docs-only PR
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — re-ran state-machine fence detector to verify only the false positive (closing fence inside 4-backtick `markdown` example in STYLE.md:264) remains; verified all files end with `\n`
- [x] All existing tests pass — no code changed
- [x] No new tests required — docs-only

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — this IS the documentation update
- [ ] CHANGELOG.md is updated for user-facing changes — **N/A**: cosmetic doc fixes (language tags, timestamp, spelling), no behavioural change

## Related

- Previous audit cleanup: PRs #137, #138, #139 (all merged)
- This PR closes the deeper-audit follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)