### PR TITLE
docs: align clippy command with CI + make HTML coverage step portable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,7 +35,7 @@ Since this is a credential-handling project:
 ## Code Quality
 
 - [ ] Code compiles without warnings (`cargo build`)
-- [ ] Clippy passes (`cargo clippy -- -D warnings`)
+- [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
 - [ ] Code is formatted (`cargo fmt`)
 - [ ] Documentation is updated if needed
 - [ ] CHANGELOG.md is updated for user-facing changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ When submitting:
 - [ ] Code compiles without warnings (`cargo build`)
 - [ ] All tests pass (`cargo test`)
 - [ ] Code is formatted (`cargo fmt`)
-- [ ] Clippy passes (`cargo clippy -- -D warnings`)
+- [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
 - [ ] Documentation is updated if needed
 - [ ] CHANGELOG.md is updated for user-facing changes
 - [ ] Commit messages follow [conventional commits](#commit-messages)
@@ -140,7 +140,7 @@ cargo build
 cargo test
 
 # Run clippy
-cargo clippy -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
 ```
 
 ---
@@ -150,7 +150,7 @@ cargo clippy -- -D warnings
 ### Rust Style
 
 - Follow `rustfmt` formatting (run `cargo fmt` before committing)
-- Follow `clippy` recommendations (run `cargo clippy -- -D warnings`)
+- Follow `clippy` recommendations (run `cargo clippy --all-targets --all-features -- -D warnings`)
 - Write idiomatic Rust code
 - Prefer safe Rust — `unsafe` code is forbidden (see `Cargo.toml` lints)
 
@@ -276,9 +276,12 @@ cargo install cargo-llvm-cov --locked
 # Run coverage with a summary report
 cargo llvm-cov --all-features --workspace --summary-only
 
-# Generate an HTML report (opens in browser)
+# Generate an HTML report — produces target/llvm-cov/html/index.html
+# Open that file in your browser:
+#   macOS:   open target/llvm-cov/html/index.html
+#   Linux:   xdg-open target/llvm-cov/html/index.html
+#   Windows: start target/llvm-cov/html/index.html
 cargo llvm-cov --all-features --workspace --html
-open target/llvm-cov/html/index.html
 
 # Generate lcov for CI (matches what CI uploads to Codecov)
 cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -359,7 +359,7 @@ Always verify locally before pushing:
 
 ```bash
 cargo test
-cargo clippy -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
 cargo fmt --check
 ```
 


### PR DESCRIPTION
## Description

Chunk 2 of the continued documentation accuracy sweep. Two issues found while verifying bash/CLI commands across docs.

## Issue 1 — Clippy command was weaker than CI's

CI runs:
```
cargo clippy --all-targets --all-features -- -D warnings
```

But these doc references showed the simpler form `cargo clippy -- -D warnings`:

| File:line | Context |
|---|---|
| `CONTRIBUTING.md:103` | PR Requirements checklist |
| `CONTRIBUTING.md:143` | Setup section example |
| `CONTRIBUTING.md:153` | Coding Standards prose |
| `.github/PULL_REQUEST_TEMPLATE.md:38` | Code Quality checklist |
| `docs/AI_WORKFLOW.md:362` | Pre-Push Checklist |

The simpler command only lints the default target with default features — it can pass while CI's broader version fails. **I hit this myself yesterday on PR #141:** local `cargo build --lib` + `cargo test --lib` passed, but CI's clippy step caught 10 `doc_markdown` errors I hadn't seen.

`STYLE.md:64` already shows the correct form. This PR aligns the other 5 references.

The `cargo clippy` (no flags) at `docs/AI_WORKFLOW.md:165` is left as-is — it's an illustrative "AI runs cargo clippy after writing code" narrative example, not a normative checklist where matching CI matters.

## Issue 2 — `open target/llvm-cov/html/index.html` was macOS-only

CONTRIBUTING.md's coverage section showed:
```bash
cargo llvm-cov --all-features --workspace --html
open target/llvm-cov/html/index.html
```

`open` is the macOS browser-launching command. Linux uses `xdg-open`; Windows uses `start`. A Linux/Windows contributor copy-pasting this would get an error.

Restructured: the path is now explicit, and the launch step is a comment showing all three platforms — no command auto-fires, the contributor picks the right one for their OS.

## Other bash commands — verified clean

The 100+ other bash lines across docs (git config, ssh-agent, cargo build/test/fmt, rustup install, python3 commands, workflow demos) were spot-checked and look fine.

## Type of Change

- [x] Documentation update
- [x] Bug fix — the clippy mismatch was actively misleading

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`) — N/A for docs-only PR
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — `grep -rE "cargo clippy(\s+--\s+-D\s+warnings)?\$" docs/ CONTRIBUTING.md README.md STYLE.md .github/` no longer matches the weak form
- [x] All existing tests pass — no code changed
- [x] No new tests required — docs-only

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`) — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — this IS the documentation update
- [ ] CHANGELOG.md is updated for user-facing changes — **N/A**: contributor-facing instructions, not user-facing behaviour

## Related

Continues the chunked sweep started in PR #142. Four chunks remain (CHANGELOG factual claims, config.json examples, tool argument tables, JSON request/response examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)