### PR TITLE
docs(changelog): refresh stale test count and coverage in [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Code coverage reporting** — `cargo-llvm-cov` runs on every PR and push to main,
   uploading lcov reports to Codecov. Patch coverage target is 80% for changed lines;
   project coverage cannot drop more than 1% on main. Coverage badge added to README.
-- **501 unit tests** (up from 257 baseline) covering URL validation, error paths,
+- **508 unit tests** (up from 257 baseline) covering URL validation, error paths,
   argument parsing, server request routing, tar archive creation with local bare
   repos, LFS pointer parsing, commit resolution from branch/tag/SHA refs, commit
   counting between two refs, file archive creation from trees, `.gitmodules`
   parsing with realistic content, and progress notification serialisation.
-- Coverage rose from ~58% (baseline) to ~76% lines and ~84% functions, measured
+- Coverage rose from ~58% (baseline) to ~77% lines and ~84% functions, measured
   excluding `main.rs` (CLI entry point) and `transport.rs` (stdio I/O wrapper) —
   both excluded via `codecov.yml` since they cannot be unit-tested without
   invasive refactoring; their behaviour is verified end-to-end by the Python


### PR DESCRIPTION
## Description

Chunk 3 of the documentation accuracy sweep. Two off-by-small-amount numeric claims in `CHANGELOG.md`'s `[Unreleased]` section.

## Findings

| Line | Was | Now | Source of truth |
|---|---|---|---|
| 36 | 501 unit tests | **508** unit tests | `cargo test --lib` reports 508/508 on current main |
| 41 | ~76% lines | **~77%** lines | Most recent main CI run shows 77.35% lines (rounds to 77) |

## Why each was off

**`501 → 508` (test count):** PR #127's CHANGELOG entry was written mid-development, before PR #127 itself added 7 more `mockito`-based LFS unit tests (taking the count from 501 → 508). PR #127's own description correctly noted "508 lib tests (was 501, +7 from mock LFS)" — but the CHANGELOG entry under `[Unreleased]` never got updated to match.

**`~76% → ~77%` (line coverage):** The original "~76%" was the pre-PR-#127 expectation. Once PR #131's LFS unit tests + the diagnostic improvements landed and integration coverage merging was wired up correctly via PR #134/#135, the coverage on current main is **77.35%** (per the post-PR-#135 main CI Codecov upload). 77.35 rounds to 77, not 76.

## What stays unchanged

- **"~84% functions"** — 83.54% rounds to ~84, still accurate
- **"11 properties run with 256 cases each by default"** — verified: `tests/property_tests.rs` contains 11 `proptest!`-wrapped functions
- **"257 baseline"** — that's the count at v1.1.0, out of scope for this fix
- **`[1.1.0]` section in entirety** — historical version sections shouldn't be retroactively edited for refreshed metrics

## Type of Change

- [x] Documentation update
- [x] Bug fix — the numbers were factually inaccurate

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`) — N/A for docs-only PR
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — `cargo test --lib` reports 508; current main coverage per Codecov is 77.35%
- [x] All existing tests pass — no code changed
- [x] No new tests required — docs-only

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`) — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — this IS the documentation update
- [ ] CHANGELOG.md is updated for user-facing changes — **N/A in the usual sense**: this PR *is* the CHANGELOG update; not adding a new entry, just refreshing existing numbers in `[Unreleased]`

## Related

Continues the chunked sweep started in PR #142. Three chunks remain:

- Chunk 4: config.json examples vs `src/config/settings.rs`
- Chunk 5: Tool argument tables/lists vs each tool's args struct
- Chunk 6: JSON request/response examples vs actual tool implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)