### PR TITLE
docs(readme): add missing config options to options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Configuration file location:
 | `logging` | `level` | Log level: trace, debug, info, warn, error |
 | `logging` | `audit_log_path` | Path to audit log file |
 | `timeouts` | `request_timeout_secs` | Git operation timeout (default: 300) |
+| `limits` | `max_output_bytes` | Max combined stdout+stderr per command (default: 10 MiB) |
 | `rate_limits` | `max_burst` | Max burst operations (default: 20) |
 | `rate_limits` | `refill_rate_per_sec` | Sustained rate limit (default: 5.0) |
 | `proxy` | `url` | Proxy URL (HTTP, HTTPS, or SOCKS5) |
@@ -413,9 +414,13 @@ Configuration file location:
 | `sessions` | `max_streaming_sessions` | Max Tier 2 streaming sessions (default: 10) |
 | `sessions` | `max_repo_sessions` | Max repo tracking sessions (default: 100) |
 | `lfs` | `retry_max_attempts` | Max LFS download retries (default: 3) |
+| `lfs` | `retry_initial_backoff_ms` | Initial retry backoff in ms (default: 500) |
+| `lfs` | `retry_max_backoff_ms` | Maximum retry backoff in ms (default: 30000) |
+| `lfs` | `retry_backoff_multiplier` | Exponential backoff multiplier (default: 2.0) |
 | `lfs` | `max_object_size` | Max single LFS object size in bytes |
 | `lfs` | `max_total_size` | Max total LFS size per operation |
 | `submodules` | `max_concurrent` | Parallel submodule fetches (default: 4) |
+| `submodules` | `max_failures` | Max submodule failures before stopping (default: 3) |
 | `submodules` | `include_patterns` | Glob patterns to include |
 | `submodules` | `exclude_patterns` | Glob patterns to exclude |
 


### PR DESCRIPTION
## Description

Chunk 4 of the documentation accuracy sweep. Cross-checked the README "Configuration Options" table against the actual struct definitions in `src/config/settings.rs`.

## Findings

**5 fields exist in code but are missing from the README table:**

| # | Field | Default | Notes |
|---|---|---|---|
| 1 | `limits.max_output_bytes` | 10 MiB | Max combined stdout+stderr per command. Whole `limits` section was missing from the table. |
| 2 | `lfs.retry_initial_backoff_ms` | 500 | Initial retry backoff in ms |
| 3 | `lfs.retry_max_backoff_ms` | 30000 | Max retry backoff in ms |
| 4 | `lfs.retry_backoff_multiplier` | 2.0 | Exponential backoff multiplier |
| 5 | `submodules.max_failures` | 3 | Max submodule failures before stopping |

All five rows added to the table, in the same row format as the existing entries.

## Cross-check, inverse direction (docs → code)

Every existing row in the README table maps to a real struct field — none invented. The struct uses `#[serde(deny_unknown_fields)]` everywhere, so documenting a non-existent field would have failed parsing in any test that loads from JSON. That guard ensures docs-without-code drift is structurally impossible.

## What stays the same

- **Example JSON object** — doesn't need to show every section; users will set what they need. Adding 5 rows to the example would make it noisier without helping.
- **The 10 top-level `Config` sections** — README correctly references all of them: `security`, `logging`, `timeouts`, `limits`, `rate_limits`, `git_identity`, `proxy`, `sessions`, `lfs`, `submodules`
- **SECURITY.md's small `logging` config example** — uses real fields, no change needed
- **Config file path** `~/.git-proxy-mcp/config.json` — matches the path documented in `src/config/mod.rs:18-19`

## Type of Change

- [x] Documentation update
- [x] Bug fix — incomplete table was actively unhelpful for users wanting to tune LFS retries or set output limits

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`) — N/A for docs-only PR
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — all 5 added rows have field names matching the actual `Deserialize` field names in `src/config/settings.rs`
- [x] All existing tests pass — no code changed
- [x] No new tests required — docs-only

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`) — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — this IS the documentation update
- [ ] CHANGELOG.md is updated for user-facing changes — **N/A**: documenting fields that already exist; the underlying behaviour was always there

## Related

Continues the chunked sweep started in PR #142. Two chunks remain:

- Chunk 5: Tool argument tables/lists vs each tool's args struct
- Chunk 6: JSON request/response examples vs actual tool implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)