### PR TITLE
docs(readme): document missing optional arguments for repo_clone and repo_clone_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ Stream a repository to the AI's workspace (small-to-medium repos).
 }
 ```
 
+**Optional arguments not shown above:**
+
+- `exclude_binary` (bool) — skip binary files
+- `max_file_size` (number, bytes) — skip files exceeding the size limit
+- `resolve_lfs` (bool) — fetch and substitute LFS pointer files with their actual content
+- `include_submodules` (bool) — recursively fetch submodules
+- `submodule_depth` (number) — submodule recursion depth (unlimited by default, mirroring `git clone --recurse-submodules`)
+- `submodule_include` (array of glob patterns) — only fetch submodules matching at least one pattern
+- `submodule_exclude` (array of glob patterns) — skip submodules matching any pattern (takes precedence over include)
+
 **Response:** Base64-encoded tar.gz with commit SHA and file count.
 
 #### `repo_push`
@@ -183,6 +193,17 @@ Start a chunked clone session.
     }
 }
 ```
+
+**Optional arguments not shown above** — same semantics as the corresponding `repo_clone` arguments documented above:
+
+- `sparse` (array of paths/globs)
+- `exclude_binary` (bool)
+- `max_file_size` (number, bytes)
+- `resolve_lfs` (bool)
+- `include_submodules` (bool)
+- `submodule_depth` (number)
+- `submodule_include` (array of glob patterns)
+- `submodule_exclude` (array of glob patterns)
 
 **Response:** Session ID, total chunks, total size.
 


### PR DESCRIPTION
## Description

Chunk 5 of the documentation accuracy sweep. Cross-checked every MCP tool's README example against its `Args` struct in `src/mcp/tools/<tool>.rs`. 8 of 10 tools were 100% clean; the two clone-family tools had documentation gaps.

## Findings

### `repo_clone` example showed 4 of 11 supported arguments

Shown: `url`, `branch`, `depth`, `sparse`
**Missing:** `exclude_binary`, `max_file_size`, `resolve_lfs`, `include_submodules`, `submodule_depth`, `submodule_include`, `submodule_exclude`

### `repo_clone_start` example showed 4 of 12 supported arguments

(Superset of `repo_clone`'s args plus `chunk_size`.)

Shown: `url`, `branch`, `depth`, `chunk_size`
**Missing:** `sparse`, `exclude_binary`, `max_file_size`, `resolve_lfs`, `include_submodules`, `submodule_depth`, `submodule_include`, `submodule_exclude`

## Why these matter

The omissions were not bugs (the fields are all optional), but the README's surrounding prose advertises features like:

- LFS pointer resolution (PR #127's `[Unreleased]` "LFS improvements")
- Submodule filtering with include/exclude glob patterns
- Recursive submodule fetching with per-request depth control

A user reading the JSON example alone wouldn't discover the argument names that activate those features.

## Fix

Added an "Optional arguments not shown above" subsection after each of the two affected JSON examples. For `repo_clone`, each argument is listed with its type and a brief description. For `repo_clone_start` (which has the same set of options), the descriptions reference the `repo_clone` documentation above to avoid duplication.

## Other 8 tools — clean

`repo_push`, `repo_pull`, `repo_diff`, `repo_refs`, `repo_clone_chunk`, `repo_clone_status`, `repo_clone_cancel`, `helper_script` — every argument in their `Args` structs is shown in the README example. No changes needed.

## Inverse direction (no ghost fields)

Verified every argument shown in any README example exists in code. The structs use `#[serde(deny_unknown_fields)]`, so a docs-without-code typo would have failed parsing in tests anyway. None found.

## Type of Change

- [x] Documentation update
- [x] Bug fix — incomplete docs were actively hiding features

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`) — N/A for docs-only PR
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — every newly-listed argument was spot-checked against `pub` field declarations in `src/mcp/tools/repo_clone.rs` and `src/mcp/tools/repo_clone_start.rs` (case-sensitive match)
- [x] All existing tests pass — no code changed
- [x] No new tests required — docs-only

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`) — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — this IS the documentation update
- [ ] CHANGELOG.md is updated for user-facing changes — **N/A**: documenting features that already exist; no behaviour change

## Related

Continues the chunked sweep started in PR #142. One chunk remains:

- Chunk 6: JSON request/response examples vs actual tool implementations (verifies response shape, not just request args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)