### PR TITLE
docs: complete example-config + add cargo to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,26 @@
 version: 2
 updates:
+    # GitHub Actions: small dependency surface, easy to review
+    # individually — keep daily.
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
         interval: "daily"
         time: "00:00"
+
+    # Cargo: large transitive dependency surface (~250+ crates).
+    # Weekly cadence + grouping keeps PR noise manageable while
+    # still catching security advisories within ~7 days. Grouping
+    # all updates into one PR per week avoids the rebase-cascade
+    # that a per-crate flow produces.
+    - package-ecosystem: "cargo"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+        day: "monday"
+        time: "00:00"
+      open-pull-requests-limit: 5
+      groups:
+        cargo-dependencies:
+          patterns:
+            - "*"

--- a/config/example-config.json
+++ b/config/example-config.json
@@ -22,6 +22,9 @@
     "timeouts": {
         "request_timeout_secs": 300
     },
+    "limits": {
+        "max_output_bytes": 10485760
+    },
     "rate_limits": {
         "max_burst": 20,
         "refill_rate_per_sec": 5.0


### PR DESCRIPTION
## Description

Final cleanup PR closing the documentation accuracy arc. Two real findings from auditing 7 less-trafficked configuration files.

## Issue 1 — `config/example-config.json` missing `limits` section

The file is referenced from `src/main.rs:84` and `src/config/mod.rs:23` as "a complete example". It covered 9 of 10 config sections. The `limits` section, documented in README's configuration options table since PR #145, was absent.

```json
"limits": {
    "max_output_bytes": 10485760
}
```

`10485760` = `10 * 1024 * 1024` (10 MiB) — matches `default_max_output_bytes()` in `src/config/settings.rs:143`.

## Issue 2 — `.github/dependabot.yml` missing `cargo` ecosystem

Dependabot was only tracking `github-actions`. With ~250+ transitive Rust crates in `Cargo.lock`, this means security advisories on cargo dependencies weren't surfacing as Dependabot PRs at all.

Added cargo ecosystem with:

| Setting | Value | Why |
|---|---|---|
| `interval` | `weekly` (Monday) | Daily would flood PRs given the dependency count |
| `open-pull-requests-limit` | `5` | Cap concurrent PR backlog |
| `groups` (single `cargo-dependencies` covering `*`) | All in one PR | Avoids the per-crate fan-out + rebase-cascade that single-package mode produces |

The `github-actions` block stays daily — small surface, easy to review individually.

## What was verified clean (no changes)

| Item | Status |
|---|---|
| `codecov.yml` | Patch target 80% / project drop 1% match CHANGELOG claims |
| `.editorconfig` | All 5 STYLE.md rules present (4-space indent, 170-char max, UTF-8, final newline, trim trailing except `.md`) |
| `.github/ISSUE_TEMPLATE/bug_report.md` & `feature_request.md` | Accurate, both have proper security-vulnerability redirects to GitHub Security Advisories |
| README badges | Both `[![CI](...)](...)` and `[![codecov](...)](...)` URLs and click targets resolve correctly |
| README `[LICENCE](LICENCE)` link | File is actually named `LICENCE` (British, consistent throughout). File content uses American "LICENSE" because that's the legal text of the GPL document itself — we don't modify legal text. |

## Type of Change

- [x] Documentation update (example config completeness)
- [x] CI/CD changes (Dependabot now tracks cargo deps)
- [x] Security improvement (Dependabot will now surface security advisories on Rust crates)

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`) — N/A for docs/config PR
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally — `python3 -c "import json; json.load(open('config/example-config.json'))"` succeeds; `dependabot.yml` parses as valid YAML
- [x] All existing tests pass — no Rust source code changed
- [x] No new tests required — config/yaml-only

## Code Quality

- [x] Code compiles without warnings — no Rust source changed
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`) — no Rust source changed
- [x] Code is formatted — no Rust source changed
- [x] Documentation is updated if needed — example-config.json now matches the README's options table
- [ ] CHANGELOG.md is updated for user-facing changes — **N/A**: example config completeness fix; the Dependabot change is contributor/security infra, not a user-facing behaviour change

## Related

This **truly closes** the documentation accuracy arc. Final tally:

| Phase | PRs | Files touched |
|---|---|---|
| Original audit cleanup | #137, #138, #139, #140, #141 | PR template, AI_WORKFLOW, errors, SECURITY × 2, README, STYLE, CHANGELOG, source-tree comments + ASCII diagrams + tool-name typos |
| Continued sweep | #142, #143, #144, #145, #146, #147 | source tree, bash commands, CHANGELOG numbers, config table, tool args tables, JSON response shapes |
| **This PR** | **#148** | **example config, dependabot scope** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)