### PR TITLE
fix: helper_script + fetch_bare bugs + comprehensive docs audit

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,13 +102,13 @@ src/
 │   ├── progress.rs     # Progress notifications
 │   └── tools/          # MCP tool handlers
 │       ├── mod.rs              # Module exports
-│       ├── repo_clone.rs       # Tier 1: repo/clone
-│       ├── repo_push.rs        # Tier 1: repo/push
-│       ├── repo_clone_start.rs # Tier 2: repo/clone_start
-│       ├── repo_clone_chunk.rs # Tier 2: repo/clone_chunk + cancel + status
-│       ├── repo_pull.rs        # repo/pull
-│       ├── repo_diff.rs        # repo/diff
-│       ├── repo_refs.rs        # repo/refs
+│       ├── repo_clone.rs       # Tier 1: repo_clone
+│       ├── repo_push.rs        # Tier 1: repo_push
+│       ├── repo_clone_start.rs # Tier 2: repo_clone_start
+│       ├── repo_clone_chunk.rs # Tier 2: repo_clone_chunk + cancel + status
+│       ├── repo_pull.rs        # repo_pull
+│       ├── repo_diff.rs        # repo_diff
+│       ├── repo_refs.rs        # repo_refs
 │       └── helper_script.rs    # helper_script utility
 └── security/           # Security guards
     ├── mod.rs          # Module exports
@@ -119,6 +119,8 @@ tests/
 ├── mcp_integration.rs          # Rust MCP protocol tests
 ├── perf_tests.rs               # Performance benchmarks
 ├── streaming_tests.rs          # Streaming/chunked tests
+├── property_tests.rs           # Property-based tests (URL sanitisation, LFS pointer parsing, .gitmodules)
+├── security_tests.rs           # Security guards, rate limiting, audit event safety
 └── integration/                # End-to-end Python tests (stdlib only)
     ├── test_mcp_tools.py       # Spawn server, exercise all 10 tools
     └── rebuild_fixture.py      # Rebuild private test fixture repo

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,7 +119,7 @@ tests/
 ├── mcp_integration.rs          # Rust MCP protocol tests
 ├── perf_tests.rs               # Performance benchmarks
 ├── streaming_tests.rs          # Streaming/chunked tests
-├── property_tests.rs           # Property-based tests (URL sanitisation, LFS pointer parsing, .gitmodules)
+├── property_tests.rs           # Property-based tests (URL sanitisation, URL validation, LFS pointer detection/parsing)
 ├── security_tests.rs           # Security guards, rate limiting, audit event safety
 └── integration/                # End-to-end Python tests (stdlib only)
     ├── test_mcp_tools.py       # Spawn server, exercise all 10 tools

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,7 +42,7 @@ Paste any error messages here (remember to redact credentials!)
 ## Environment
 
 - **OS:** [e.g., Windows 11, macOS 14.2, Ubuntu 24.04]
-- **git-proxy-mcp version:** [e.g., 0.1.0]
+- **git-proxy-mcp version:** [output of `git-proxy-mcp --version`, e.g., 1.1.0]
 - **Rust version:** [output of `rustc --version`]
 - **MCP client:** [e.g., Claude Desktop, VS Code + Continue.dev, Cursor]
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,9 @@ Since this is a credential-handling project:
 
 - [ ] Code compiles without warnings (`cargo build`)
 - [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
-- [ ] Code is formatted (`cargo fmt`)
+- [ ] Code is formatted (`cargo fmt --all --check`)
+- [ ] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
+- [ ] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
 - [ ] Documentation is updated if needed
 - [ ] CHANGELOG.md is updated for user-facing changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`fetch_bare` hardcoded the fallback branch to `main` despite docs
+  promising "the remote's default branch".** When `repo_clone` /
+  `repo_clone_start` was called without a `branch` argument,
+  `git2_ops::clone::fetch_bare` resolved the missing branch to a literal
+  `"main"` (`options.branch.as_deref().unwrap_or("main")`), so any repo
+  with a non-`main` default (e.g. `master`, `develop`, or a renamed
+  default) would return `RefNotFound("main")` instead of fetching. The
+  `[1.1.0]` CHANGELOG entry that described this as fixed was true at
+  the docs/schema level only — the `tools/list` description and the
+  `RepoCloneArgs.branch` rustdoc had been updated to "remote's default
+  branch", but the code had never been changed to match.
+  Now `fetch_bare` opens a single `connect_auth` to the remote, asks
+  `Remote::default_branch()` when the caller passed no branch, strips
+  the leading `refs/heads/`, and proceeds with the fetch over the same
+  connection. Caller-supplied branches still take precedence and skip
+  the probe. There is no longer a hard-coded `"main"` fallback —
+  malformed remotes (no `HEAD` symref) now surface a proper
+  `FetchFailed("could not determine remote's default branch: …")`
+  error instead of silently pretending the default is `main`.
+  No change to integration tests (they all pass `branch: "main"`
+  explicitly), and the existing in-repo unit test is unaffected since
+  it only checks `FetchOptions2` defaults.
 - **`helper_script` Python helper looked for the wrong `repo_pull` archive
   field name.** The embedded `git_proxy_helper.py` script's `extract` and
   `info` commands expected the `repo_pull` response to carry the archive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source files plus a submodule, a renamed file, and an LFS-tracked
   binary. Replaced with the current layout and a pointer to
   `rebuild_fixture.py` as the canonical source.
+- **`src/security/audit.rs` module-level rustdoc Log Format list was
+  almost half empty.** It enumerated 8 of the 14 fields on `AuditEvent`,
+  omitting `exit_code`, `shutdown_reason`, `url`, `branch`, `commit`,
+  `file_count`, and `archive_size`. Replaced with a complete list and
+  noted which event types each optional field applies to, plus the
+  full set of `event_type` values (the previous list ended with "etc.").
+- **`src/git2_ops/lfs.rs` security claim was too strong.** The module
+  rustdoc said "All LFS server communication is over HTTPS", but
+  `derive_lfs_url` happily accepts `http://` repo URLs and forwards
+  the same scheme to the LFS endpoint (the `derive_lfs_url_http` test
+  pins this behaviour). Reworded to say HTTPS for `https://` and `git@`
+  URLs, HTTP for `http://`, and that `lfs+ssh://` is not supported.
+- **`.github/ISSUE_TEMPLATE/bug_report.md` example version was a
+  pre-1.0 placeholder.** The `git-proxy-mcp version: [e.g., 0.1.0]` hint
+  predated the project's 1.0 release. Replaced with a pointer to
+  `git-proxy-mcp --version` and a current-tier example (1.1.0).
+- **`CONTRIBUTING.md` British-spelling reference table was a partial
+  list.** It had 7 American/British pairs, missing the ones that came
+  up repeatedly during this audit (`sanitize`, `authorize`, `finalize`,
+  `recognize`, `customize`). Added them, plus a clarifying note that
+  the JSON-RPC method names `initialize` and `notifications/initialized`
+  are spec identifiers and stay American — backticked in narrative
+  text.
 - Dependabot CI failures caused by orphaned `dtolnay/rust-toolchain` SHAs. The
   previous `# stable` pin pointed to a commit that fell off the remote when
   the rolling `stable` branch advanced, breaking Dependabot's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,12 +113,154 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`helper_script_uses_correct_repo_pull_archive_field`) that asserts
   the script references `files_archive` and never the obsolete
   `changed_files_archive`.
+- **`src/mcp/tools/mod.rs` rustdoc listed only 8 of the 10 MCP tools.**
+  The `Tier 2 (Chunked Streaming)` section in the module-level doc-comment
+  named `repo_clone_start` and `repo_clone_chunk` but omitted
+  `repo_clone_status` and `repo_clone_cancel`, even though both are
+  re-exported from this module and registered in the `tools/call`
+  dispatch table in `src/mcp/server.rs`. Added both to the rustdoc list
+  with intra-doc links into `repo_clone_chunk` (where their handlers
+  actually live).
+- **`docs/ARCHITECTURE.md` "What Touches Disk" table understated Tier 2
+  disk usage.** The table's `Tar archive | NO | Built in memory` row
+  applied only to Tier 1 — Tier 2 sessions whose tar.gz is at least
+  `DISK_THRESHOLD` (10 MiB, defined in `src/streaming/chunked.rs`) write
+  the archive to a `NamedTempFile` so memory usage stays O(chunk size).
+  Split the row into Tier 1 (always in memory) and Tier 2 (disk-backed
+  when the threshold is exceeded, deleted when the session ends or
+  expires). No code change.
+- **`.claude/CLAUDE.md` source-tree comments still used the slash form
+  for tool names** (`repo/clone`, `repo/push`, `repo/clone_start`, etc.)
+  in the `mcp/tools/` block, even after the wider sweep that switched
+  the rest of the docs to underscores in PR #141. Also added
+  `tests/property_tests.rs` and `tests/security_tests.rs` to the
+  `tests/` tree so it matches reality and the `docs/ARCHITECTURE.md`
+  source-tree diagram.
+- **Documentation accuracy sweep** — vague `**Response:**` summaries in
+  `README.md` for `repo_clone`, `repo_push`, `repo_clone_start`,
+  `repo_clone_chunk`, `repo_clone_status`, `repo_diff`, and `repo_refs`
+  now name the actual response fields (matching the `RepoCloneResult`,
+  `RepoPushResult`, etc. structs). The README configuration example now
+  shows the `timeouts`, `limits`, and `rate_limits` sections — they were
+  documented in the options table below but missing from the example
+  block, which made the example look smaller than the real schema. Added
+  a pointer to `config/example-config.json` for the fully-populated
+  example. `CONTRIBUTING.md` PR Requirements checklist now lists
+  `markdownlint-cli2` and the toolchain-pin pre-flight check (both run
+  in CI). `docs/AI_WORKFLOW.md`'s `Initialize Response` heading is now
+  `` `initialize` response `` — the protocol method name stays as the
+  spec spells it but the surrounding prose is consistent with the
+  British spelling used elsewhere. The `repo_clone`, `repo_push`, and
+  `repo_pull` example responses in `AI_WORKFLOW.md` now show the actual
+  `hint` strings the server returns instead of placeholder text
+  (previously `"Bundle was successfully pushed to the remote."` and
+  `"Apply the diff or extract files_archive into your local clone."`,
+  neither of which the code has ever emitted). The `cargo clippy`
+  example in the same doc now uses the strict
+  `--all-targets --all-features -- -D warnings` form that CI runs, so
+  the AI's local check matches what the project gates on.
+  `CONTRIBUTING.md`'s `Types of Documentation` table now lists
+  `STYLE.md` and every file under `docs/`, and the
+  `Updating Documentation` list now spells out when to touch
+  `docs/`, `STYLE.md`, and `config/example-config.json`.
+- **`docs/SECURITY.md` had multiple fabricated APIs in its illustrative
+  Rust snippets.** The file showed `RepoFilter::allowlist(vec![...])` and
+  `RepoFilter::blocklist(vec![...])` constructors that have never
+  existed (the real API is `RepoFilter::allowlist_mode()` /
+  `blocklist_mode()` plus `.allow(pattern)` / `.block(pattern)` — see
+  `src/security/guards.rs`); `PushGuard::new(allow_force_push: false)`
+  and `RateLimiter::new(max_burst: 20, refill_per_sec: 5.0)` using
+  Rust-doesn't-have-named-arguments syntax (and the latter also got the
+  field name wrong — the parameter is `refill_rate`); a
+  `push_guard.is_force_push(args)` method that doesn't exist (force
+  pushes are detected inside `SecurityGuard::check`); a
+  `sanitize_url(url)` function that doesn't exist (the real one is
+  `sanitize_url_for_logging` and uses byte-safe `find` rather than the
+  shown `Regex::new(...)` — the project has no regex dependency); and
+  `audit_log.info(...)` / `audit_log.debug(...)` calls against an API
+  that's never existed (audit events are constructed via
+  `AuditEvent::repo_clone_success(...)` etc. and submitted via
+  `AuditLogger::log_silent`). All snippets rewritten to compile against
+  the real APIs. The same file's `log::info!` / `log::debug!` examples
+  are now `tracing::info!` / `tracing::debug!` — this project depends on
+  `tracing`, not `log`. Three "Unauthorized" / "unauthorized" instances
+  in narrative text changed to British "Unauthorised" / "unauthorised"
+  (the only remaining `Unauthorized` is the literal HTTP `401
+  Unauthorized` reason phrase in `docs/errors.md`, which is part of the
+  HTTP standard).
+- **`README.md` Prerequisites omitted the runtime Git CLI requirement.**
+  The server shells out to `git credential fill` (in
+  `src/git2_ops/auth.rs`) and `git bundle unbundle` (in
+  `src/git2_ops/push.rs`); a user installing only the prebuilt binary
+  without git on `PATH` would have hit the credential helper failing to
+  return anything and `repo_push` failing to apply the bundle. Added a
+  `#### Git CLI` subsection explaining the requirement.
+- **`.github/PULL_REQUEST_TEMPLATE.md` Code Quality checklist drifted
+  from `CONTRIBUTING.md` § Pull Requests.** Added the same
+  `markdownlint-cli2` and toolchain-pin pre-flight items, and tightened
+  `cargo fmt` to the strict `cargo fmt --all --check` form CI runs.
 - **`helper_script` Python helper's `show_info` enumerated `old_commit`,
   a key no MCP tool has ever returned.** The actual fields are
   `base_commit` + `new_commit` (`repo_pull`) and `base_commit` +
   `head_commit` (`repo_diff`). Replaced `old_commit` with `base_commit`
   and `head_commit`, and added a regression test
   (`helper_script_show_info_uses_real_commit_field_names`).
+- **Inconsistent and imprecise size units across rustdoc and the MCP
+  tool schema.** `src/streaming/chunked.rs` and
+  `src/mcp/tools/repo_clone_start.rs` advertised the chunk and disk
+  thresholds as `1MB` / `4MB` / `10MB`, but the constants are binary
+  (`1024 * 1024`, `4 * 1024 * 1024`, `10 * 1024 * 1024`) — i.e. mebibytes,
+  not megabytes. `src/config/settings.rs` already used `MiB`. Normalised
+  every reference (rustdoc, the `tools/list` schema description for
+  `chunk_size`, the README repo_clone_chunk response summary, and the
+  ARCHITECTURE.md "Tier 2" trade-off table) to use `KiB` / `MiB`. The
+  schema description now also reports the actual clamped range (1 KiB
+  to 4 MiB) instead of just the maximum, and the `chunked.rs` module
+  doc-comment now notes that the 1-hour session timeout is the *default*
+  rather than a hard-coded value (the real timeout comes from
+  `sessions.timeout_secs`).
+- **`README.md` `submodule_depth` description omitted the `0` and `1`
+  values.** The `tools/list` schema explicitly documents `1 = top-level
+  only` and `0 = skip submodules entirely`, but the README only
+  mentioned the unlimited default. Brought the README in line with the
+  schema so callers can pick the right depth without reading the
+  source.
+- **Documentation lines exceeding the 170-character ceiling.**
+  `CONTRIBUTING.md` line 78, and `STYLE.md` lines 207 and 283 had been
+  173 / 192 / 174 columns respectively. Markdownlint was happy because
+  MD013 ignores tables and code blocks, but the project's
+  `.editorconfig` declares `max_line_length = 170` for all files.
+  Wrapped them.
+- **`docs/errors.md` claimed the wrong default for protected branches.**
+  It said `Default protected branches: main, master, develop`, but
+  `SecurityConfig::default()` makes `protected_branches` an empty list
+  — nothing is protected unless the user configures it (the test at
+  `src/config/settings.rs::security_config_defaults` asserts exactly
+  that). Replaced the claim with the actual default and a pointer to
+  `config/example-config.json` for the recommended set.
+- **`src/lib.rs` Tier 2 tools list omitted `repo_clone_status`.** Like
+  the earlier `tools/mod.rs` fix, the crate-level rustdoc named only
+  three of the four Tier 2 tools. Added `repo_clone_status` and a new
+  `Other tools` section listing the four operations that don't fit the
+  Tier 1 / Tier 2 split (`repo_pull`, `repo_diff`, `repo_refs`,
+  `helper_script`) so `cargo doc` no longer hides them.
+- **`README.md` configuration table omitted defaults for half the
+  options.** `git_identity.{name,email}`, `security.{protected_branches,
+  repo_allowlist, repo_blocklist}`, `logging.{level, audit_log_path}`,
+  `proxy.{url, no_proxy}`, `lfs.{max_object_size, max_total_size}`, and
+  `submodules.{include_patterns, exclude_patterns}` had no default
+  documented. Added the actual defaults from `src/config/settings.rs`
+  (mostly `null`/empty/`warn`) so users no longer have to guess what
+  happens when they leave a section out.
+- **`helper_script` rustdoc didn't mention the `info` subcommand or the
+  optional positional arguments.** The Python script supports `extract
+  <result.json> [output_dir]`, `bundle <repo_dir> <since_commit>
+  [head_ref] [output_file]`, and `info <result.json>`, but the
+  module-level rustdoc only listed `extract <result.json> <output_dir>`
+  and `bundle <repo_dir> <since_commit>` and presented the optional
+  arguments as required. Updated the rustdoc and the `usage` string
+  returned by `handle_helper_script` to use `[brackets]` for optionals
+  and to include the `info` subcommand.
 - Dependabot CI failures caused by orphaned `dtolnay/rust-toolchain` SHAs. The
   previous `# stable` pin pointed to a commit that fell off the remote when
   the rolling `stable` branch advanced, breaking Dependabot's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the JSON-RPC method names `initialize` and `notifications/initialized`
   are spec identifiers and stay American — backticked in narrative
   text.
+- **`docs/AI_WORKFLOW.md` "Use Shallow Clone for Large Repos" tip
+  recommended `repo_clone` for monorepos** without mentioning that
+  truly large repos won't fit in a single MCP response and need
+  Tier 2 (`repo_clone_start` + `repo_clone_chunk`). Reframed: shallow +
+  sparse for medium repos, Tier 2 for everything that doesn't fit.
+- **`helper_script.py` top-of-file docstring usage line for `bundle`
+  was missing `[head_ref]`.** The runtime `Usage:` string printed when
+  the user runs `bundle` with too few arguments correctly shows
+  `bundle <repo_dir> <since_commit> [head_ref] [output_file]`, and
+  `create_bundle` accepts both optional arguments, but the module
+  docstring at the top of the script only listed `[output_file]` —
+  inconsistent. Added `[head_ref]` so the module docstring matches the
+  runtime help and the `Examples:` block (which already showed
+  `bundle ./my-repo abc123def HEAD`).
+- **`helper_script.py` `show_info` reported `archive_b64_length` for
+  `repo_clone` results but no equivalent size for `repo_pull`.** The
+  function now also reports `files_archive_b64_length` when a
+  `files_archive` field is present, so `info` output is symmetric
+  between the two result shapes.
 - Dependabot CI failures caused by orphaned `dtolnay/rust-toolchain` SHAs. The
   previous `# stable` pin pointed to a commit that fell off the remote when
   the rolling `stable` branch advanced, breaking Dependabot's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Code coverage reporting** — `cargo-llvm-cov` runs on every PR and push to main,
   uploading lcov reports to Codecov. Patch coverage target is 80% for changed lines;
   project coverage cannot drop more than 1% on main. Coverage badge added to README.
-- **508 unit tests** (up from 257 baseline) covering URL validation, error paths,
+- **510 unit tests** (up from 257 baseline) covering URL validation, error paths,
   argument parsing, server request routing, tar archive creation with local bare
   repos, LFS pointer parsing, commit resolution from branch/tag/SHA refs, commit
   counting between two refs, file archive creation from trees, `.gitmodules`
@@ -98,6 +98,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`helper_script` Python helper looked for the wrong `repo_pull` archive
+  field name.** The embedded `git_proxy_helper.py` script's `extract` and
+  `info` commands expected the `repo_pull` response to carry the archive
+  under a `changed_files_archive` key, but the actual response field has
+  always been named `files_archive` (declared in `RepoPullResult` since
+  v1.1.0 — see `src/mcp/tools/repo_pull.rs`). Net effect: any AI assistant
+  that used the helper script to extract a `repo_pull` result hit
+  `ValueError: No archive found in result` and fell back to manual
+  base64+tar handling. Fixed by renaming both lookups to `files_archive`
+  and updating the resulting `info` key to `has_files_archive`. The
+  `archive` field used for `repo_clone` results was always correct and is
+  unchanged. Added a regression test
+  (`helper_script_uses_correct_repo_pull_archive_field`) that asserts
+  the script references `files_archive` and never the obsolete
+  `changed_files_archive`.
+- **`helper_script` Python helper's `show_info` enumerated `old_commit`,
+  a key no MCP tool has ever returned.** The actual fields are
+  `base_commit` + `new_commit` (`repo_pull`) and `base_commit` +
+  `head_commit` (`repo_diff`). Replaced `old_commit` with `base_commit`
+  and `head_commit`, and added a regression test
+  (`helper_script_show_info_uses_real_commit_field_names`).
 - Dependabot CI failures caused by orphaned `dtolnay/rust-toolchain` SHAs. The
   previous `# stable` pin pointed to a commit that fell off the remote when
   the rolling `stable` branch advanced, breaking Dependabot's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cargo fmt --check`** while CONTRIBUTING.md, STYLE.md, the PR
   template, and the rest of `AI_WORKFLOW.md` all use the strict
   `cargo fmt --all --check` form CI runs. Aligned.
+- **`docs/AI_WORKFLOW.md` Step 1 (Clone) example never configured the
+  Git identity** before its `git commit -m "Initial clone …"` call,
+  even though the section above the example tells AI assistants to
+  apply the `gitIdentity` from the `initialize` response so commits
+  are clearly attributable. The example now includes the two
+  `git config user.name` / `user.email` calls between `git init` and
+  the first `git commit`.
+- **`tests/integration/test_mcp_tools.py` module docstring described
+  the wrong fixture.** The docstring still claimed the fixture had
+  "2 commits, 2 tags, 5 files" — the layout from before PR #112's
+  expanded-fixture commit. The real fixture (built by
+  `tests/integration/rebuild_fixture.py`) has 5 commits, 2 tags, ~45
+  source files plus a submodule, a renamed file, and an LFS-tracked
+  binary. Replaced with the current layout and a pointer to
+  `rebuild_fixture.py` as the canonical source.
 - Dependabot CI failures caused by orphaned `dtolnay/rust-toolchain` SHAs. The
   previous `# stable` pin pointed to a commit that fell off the remote when
   the rolling `stable` branch advanced, breaking Dependabot's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments as required. Updated the rustdoc and the `usage` string
   returned by `handle_helper_script` to use `[brackets]` for optionals
   and to include the `info` subcommand.
+- **British-spelling sweep across `src/`.** The project's rule (see
+  `CONTRIBUTING.md` § British Spelling) explicitly covers comments and
+  user-facing strings, but several rustdoc comments, inline `//` notes,
+  one log message, and one `thiserror`-derived `Display` string still
+  used American spellings ("sanitize", "initialize", "initialization",
+  "finalized"). Files touched: `src/session.rs`, `src/streaming/chunked.rs`,
+  `src/streaming/tar.rs`, `src/git2_ops/{auth,clone,error,push}.rs`,
+  `src/mcp/server.rs`, `src/mcp/tools/{mod,repo_push}.rs`. The user-facing
+  change is the `Git2Error::InitFailed` `Display` string, which now reads
+  `failed to initialise repository` instead of
+  `failed to initialize repository`; the unit test that asserted on the
+  literal string was updated to match. JSON-RPC method names
+  (`initialize`, `notifications/initialized`) and reqwest's
+  `StatusCode::UNAUTHORIZED` enum variant are spec/upstream identifiers
+  and stay American — backticked in narrative text to make that clear.
+- **`docs/SECURITY.md` audit-log snippet had the wrong arity** — the
+  pass-3 rewrite of the audit example called
+  `AuditEvent::repo_clone_success` with three arguments, but the real
+  constructor takes six (`url, branch, commit, file_count, archive_size,
+  duration`). Corrected, plus a note that the URL must be sanitised by
+  the caller (the constructor does not).
+- **`docs/AI_WORKFLOW.md` "Check Before Push" snippet still had
+  `cargo fmt --check`** while CONTRIBUTING.md, STYLE.md, the PR
+  template, and the rest of `AI_WORKFLOW.md` all use the strict
+  `cargo fmt --all --check` form CI runs. Aligned.
 - Dependabot CI failures caused by orphaned `dtolnay/rust-toolchain` SHAs. The
   previous `# stable` pin pointed to a commit that fell off the remote when
   the rolling `stable` branch advanced, breaking Dependabot's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,13 +253,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MD013 ignores tables and code blocks, but the project's
   `.editorconfig` declares `max_line_length = 170` for all files.
   Wrapped them.
-- **`docs/errors.md` claimed the wrong default for protected branches.**
-  It said `Default protected branches: main, master, develop`, but
-  `SecurityConfig::default()` makes `protected_branches` an empty list
-  — nothing is protected unless the user configures it (the test at
-  `src/config/settings.rs::security_config_defaults` asserts exactly
-  that). Replaced the claim with the actual default and a pointer to
-  `config/example-config.json` for the recommended set.
+- **`protected_branches` default was documented imprecisely.** Three
+  pieces of documentation (`docs/errors.md`, `README.md` configuration
+  table, `BranchGuard::with_defaults` rustdoc) each described the
+  default protected-branch set differently — and at least one was wrong
+  outright. The actual logic is two-layered: `SecurityConfig::default()`
+  sets `protected_branches` to an empty list, but `McpServer::new`
+  treats an empty list as "use the built-in safe set" and substitutes
+  `BranchGuard::with_defaults()`, which contains `main`, `master`, and
+  `develop` (not `main`, `master`, `develop`, *and* `release/*` as the
+  rustdoc had been claiming). Fixed all three: `docs/errors.md` and the
+  README table now describe the two-layer behaviour and the resulting
+  effective default; the `with_defaults` rustdoc now lists exactly what
+  the function returns and clarifies that wildcard patterns are
+  *supported* by the matcher but not part of the built-in set.
 - **`src/lib.rs` Tier 2 tools list omitted `repo_clone_status`.** Like
   the earlier `tools/mod.rs` fix, the crate-level rustdoc named only
   three of the four Tier 2 tools. Added `repo_clone_status` and a new
@@ -365,6 +372,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   function now also reports `files_archive_b64_length` when a
   `files_archive` field is present, so `info` output is symmetric
   between the two result shapes.
+- **`tests/property_tests.rs` module docstring, `.claude/CLAUDE.md`,
+  and `docs/ARCHITECTURE.md`'s source-tree comment all claimed
+  property tests covered `.gitmodules` parsing — they don't.** The
+  file actually has 11 properties across URL sanitisation (3), URL
+  validation (4), and LFS pointer detection/parsing (4). `.gitmodules`
+  parsing has unit-test coverage in `src/git2_ops/submodule.rs::tests`,
+  but no proptest. All three docstrings now describe the actual
+  coverage.
 - Dependabot CI failures caused by orphaned `dtolnay/rust-toolchain` SHAs. The
   previous `# stable` pin pointed to a commit that fell off the remote when
   the rolling `stable` branch advanced, breaking Dependabot's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,8 @@ When submitting:
 
 We welcome feature suggestions! Before submitting:
 
-1. Check [existing issues](https://github.com/MatejGomboc/git-proxy-mcp/issues) and [discussions](https://github.com/MatejGomboc/git-proxy-mcp/discussions) for similar ideas
+1. Check [existing issues](https://github.com/MatejGomboc/git-proxy-mcp/issues) and
+   [discussions](https://github.com/MatejGomboc/git-proxy-mcp/discussions) for similar ideas
 2. Consider how the feature fits the project's security-first philosophy
 3. Think about backwards compatibility
 
@@ -99,8 +100,10 @@ When submitting:
 
 - [ ] Code compiles without warnings (`cargo build`)
 - [ ] All tests pass (`cargo test`)
-- [ ] Code is formatted (`cargo fmt`)
+- [ ] Code is formatted (`cargo fmt --all --check`)
 - [ ] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
+- [ ] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"` — also runs in CI)
+- [ ] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
 - [ ] Documentation is updated if needed
 - [ ] CHANGELOG.md is updated for user-facing changes
 - [ ] Commit messages follow [conventional commits](#commit-messages)
@@ -311,15 +314,24 @@ When adding or modifying code that handles credentials:
 |----------|--------|
 | `README.md` | User-facing overview and quick start |
 | `CONTRIBUTING.md` | This file — contributor guidelines |
-| `SECURITY.md` | Security policy and vulnerability reporting |
+| `STYLE.md` | Style conventions for Rust, YAML, JSON, TOML, Python, Markdown |
+| `SECURITY.md` | Security policy and vulnerability reporting (root) |
+| `docs/SECURITY.md` | Technical threat model and security controls |
+| `docs/VISION.md` | Architectural vision and design principles |
+| `docs/ARCHITECTURE.md` | Detailed architecture, source tree, disk usage |
+| `docs/AI_WORKFLOW.md` | How an AI assistant uses git-proxy-mcp end to end |
+| `docs/errors.md` | Error reference (JSON-RPC codes, guard messages, LFS diagnostics) |
 | `CHANGELOG.md` | User-facing change history |
-| Rustdoc comments | API documentation |
+| Rustdoc comments | API documentation (`cargo doc --open`) |
 
 ### Updating Documentation
 
-- Update `README.md` for user-facing changes
-- Update `CHANGELOG.md` for all notable changes
+- Update `README.md` for user-facing changes (config options, MCP tools, response shapes)
+- Update `CHANGELOG.md` `[Unreleased]` section for all notable changes
 - Update rustdoc comments when changing public APIs
+- Update files under `docs/` when changing architecture, security model, error semantics, or the AI workflow
+- Update `STYLE.md` and bump its `*Last updated:* …` timestamp when changing style conventions
+- Update `config/example-config.json` when adding or renaming configuration options
 - Keep examples up to date and working
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,8 +176,17 @@ Use British spelling in all documentation and user-facing text:
 | license (noun) | licence |
 | analyze | analyse |
 | initialize | initialise |
+| sanitize | sanitise |
+| authorize | authorise |
+| finalize | finalise |
+| recognize | recognise |
+| customize | customise |
 
-**Note:** Code identifiers may use American spelling where it matches Rust/library conventions.
+**Note:** Code identifiers may use American spelling where it matches Rust/library
+conventions (e.g. `Cred`, `Regex`, `serde::Serialize`). The JSON-RPC method names
+`initialize` and `notifications/initialized` are spec identifiers and stay American
+even in narrative text — backtick them so it's clear they are method names, not
+prose.
 
 ### Security-Conscious Coding
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ For a fully-populated example showing every section and option, see [`config/exa
 | `git_identity` | `name` | Name for AI-assisted commits, e.g. "Claude AI" (default: null — AI sets its own identity) |
 | `git_identity` | `email` | Email for AI-assisted commits (default: null) |
 | `security` | `allow_force_push` | Allow force pushes (default: false) |
-| `security` | `protected_branches` | Branches that block force push and deletion (default: empty list — nothing protected) |
+| `security` | `protected_branches` | Branches that block force push and deletion. Default: empty list, which the server treats as "use the built-in safe set" (`main`, `master`, `develop`); set to any non-empty list to override the fallback. |
 | `security` | `repo_allowlist` | Only allow these repo patterns (default: null — allowlist mode disabled) |
 | `security` | `repo_blocklist` | Block these repo patterns (default: null — no blocklist) |
 | `logging` | `level` | Log level: trace, debug, info, warn, error (default: `warn`) |

--- a/README.md
+++ b/README.md
@@ -150,11 +150,16 @@ Stream a repository to the AI's workspace (small-to-medium repos).
 - `max_file_size` (number, bytes) — skip files exceeding the size limit
 - `resolve_lfs` (bool) — fetch and substitute LFS pointer files with their actual content
 - `include_submodules` (bool) — recursively fetch submodules
-- `submodule_depth` (number) — submodule recursion depth (unlimited by default, mirroring `git clone --recurse-submodules`)
+- `submodule_depth` (number) — submodule recursion depth. Omit for unlimited (mirroring
+  `git clone --recurse-submodules`). `1` = top-level submodules only; `0` = skip submodules
+  entirely (overriding `include_submodules: true`).
 - `submodule_include` (array of glob patterns) — only fetch submodules matching at least one pattern
 - `submodule_exclude` (array of glob patterns) — skip submodules matching any pattern (takes precedence over include)
 
-**Response:** Base64-encoded tar.gz with commit SHA and file count.
+**Response:** Base64-encoded tar.gz `archive`, `commit` SHA, `branch`, `file_count`, `archive_size`
+(bytes, before base64), and a `hint` string pointing at `helper_script` for extraction.
+Optional counters appear only when non-zero: `skipped_by_filter`, `skipped_binary`,
+`skipped_too_large`, `lfs_resolved`, `lfs_failed`, `submodules_included`, `submodules_failed`.
 
 #### `repo_push`
 
@@ -172,7 +177,8 @@ Push a git bundle from AI's workspace to remote.
 }
 ```
 
-**Response:** Pushed commit SHA and branch name.
+**Response:** `branch`, pushed `commit` SHA, `force` flag (echoed back), sanitised `remote_url`,
+and a `hint` string explaining how to create bundles for follow-up pushes.
 
 ### Tier 2: Chunked Streaming Tools (Large Repos)
 
@@ -205,7 +211,9 @@ Start a chunked clone session.
 - `submodule_include` (array of glob patterns)
 - `submodule_exclude` (array of glob patterns)
 
-**Response:** Session ID, total chunks, total size.
+**Response:** `session_id`, `total_chunks`, `total_size` (bytes, total archive size before base64),
+`chunk_size` (bytes, the negotiated per-chunk size after clamping), `commit`, `branch`, `file_count`,
+and a `hint` string. The same optional skipped/LFS/submodule counters as `repo_clone` appear when non-zero.
 
 #### `repo_clone_chunk`
 
@@ -221,7 +229,9 @@ Get a chunk from a streaming session.
 }
 ```
 
-**Response:** Base64-encoded chunk data, is_last flag, next_missing_chunk (for resume).
+**Response:** Base64-encoded `data`, the `chunk_index` (echoed back), `chunk_size` (this chunk's
+size in bytes before base64), `is_last` flag, and `next_missing_chunk` (omitted when no chunks
+remain — used to resume after an interrupted transfer).
 
 #### `repo_clone_status`
 
@@ -236,7 +246,8 @@ Check progress and resume state of a chunked clone session.
 }
 ```
 
-**Response:** Total/delivered chunks, next missing chunk, progress percentage, completion status.
+**Response:** `session_id` (echoed back), `total_chunks`, `delivered_chunks`, `next_missing_chunk`
+(null when all chunks have been retrieved), `progress_percent` (0.0–100.0), and `is_complete` flag.
 
 #### `repo_clone_cancel`
 
@@ -271,7 +282,8 @@ Sync new changes from remote to AI's workspace.
 ```
 
 **Response:** Unified `diff`, base64 tar.gz of changed/added files (`files_archive`), `changed_files` list with per-file change types,
-`deleted_files` list, `base_commit` and `new_commit` SHAs, change `stats`, and `up_to_date` flag.
+`deleted_files` list, `base_commit` and `new_commit` SHAs, change `stats`, `up_to_date` flag, and a
+`hint` string pointing at `helper_script` for extracting `files_archive`.
 
 #### `repo_diff`
 
@@ -288,7 +300,9 @@ Get diff between two commits.
 }
 ```
 
-**Response:** Diff content with stats.
+**Response:** Unified `diff` text, `stats` (additions/deletions/files-changed counts), and the
+fully-resolved `base_commit` and `head_commit` SHAs (so the AI can cache the comparison without
+re-resolving the original refs).
 
 #### `repo_refs`
 
@@ -303,7 +317,8 @@ List remote branches and tags.
 }
 ```
 
-**Response:** List of refs with commit SHAs.
+**Response:** `branches` and `tags` lists (each entry has the ref name and commit SHA),
+`default_branch` (e.g. `main` or `master`, taken from the remote HEAD), and `total_refs` count.
 
 ### Utilities
 
@@ -325,6 +340,14 @@ Get a Python helper script for processing results (decoding base64, extracting t
 ## Installation
 
 ### Prerequisites
+
+#### Git CLI
+
+The server invokes `git` for two operations: `git credential fill` (to read your stored
+credentials via the OS credential helper — see `src/git2_ops/auth.rs`) and `git bundle unbundle`
+(to apply a `repo_push` payload before the authenticated push — see `src/git2_ops/push.rs`).
+Any reasonably modern git (2.x) on `PATH` works; bundles produced by git ≥ 2.53 (with the
+`# v3 git bundle` header) are also accepted.
 
 #### Rust toolchain
 
@@ -397,6 +420,16 @@ Configuration file location:
         "level": "warn",
         "audit_log_path": "~/.git-proxy-mcp/audit.log"
     },
+    "timeouts": {
+        "request_timeout_secs": 300
+    },
+    "limits": {
+        "max_output_bytes": 10485760
+    },
+    "rate_limits": {
+        "max_burst": 20,
+        "refill_rate_per_sec": 5.0
+    },
     "proxy": {
         "url": "http://proxy.example.com:8080",
         "no_proxy": "*.internal.com,localhost"
@@ -416,24 +449,26 @@ Configuration file location:
 }
 ```
 
+For a fully-populated example showing every section and option, see [`config/example-config.json`](config/example-config.json).
+
 ### Configuration Options
 
 | Section | Option | Description |
 |---------|--------|-------------|
-| `git_identity` | `name` | Name for AI-assisted commits (e.g., "Claude AI") |
-| `git_identity` | `email` | Email for AI-assisted commits |
+| `git_identity` | `name` | Name for AI-assisted commits, e.g. "Claude AI" (default: null — AI sets its own identity) |
+| `git_identity` | `email` | Email for AI-assisted commits (default: null) |
 | `security` | `allow_force_push` | Allow force pushes (default: false) |
-| `security` | `protected_branches` | Branches that block force push |
-| `security` | `repo_allowlist` | Only allow these repo patterns |
-| `security` | `repo_blocklist` | Block these repo patterns |
-| `logging` | `level` | Log level: trace, debug, info, warn, error |
-| `logging` | `audit_log_path` | Path to audit log file |
+| `security` | `protected_branches` | Branches that block force push and deletion (default: empty list — nothing protected) |
+| `security` | `repo_allowlist` | Only allow these repo patterns (default: null — allowlist mode disabled) |
+| `security` | `repo_blocklist` | Block these repo patterns (default: null — no blocklist) |
+| `logging` | `level` | Log level: trace, debug, info, warn, error (default: `warn`) |
+| `logging` | `audit_log_path` | Path to audit log file (default: null — audit logging disabled) |
 | `timeouts` | `request_timeout_secs` | Git operation timeout (default: 300) |
 | `limits` | `max_output_bytes` | Max combined stdout+stderr per command (default: 10 MiB) |
 | `rate_limits` | `max_burst` | Max burst operations (default: 20) |
 | `rate_limits` | `refill_rate_per_sec` | Sustained rate limit (default: 5.0) |
-| `proxy` | `url` | Proxy URL (HTTP, HTTPS, or SOCKS5) |
-| `proxy` | `no_proxy` | Comma-separated hosts to bypass proxy |
+| `proxy` | `url` | Proxy URL — HTTP, HTTPS, or SOCKS5 (default: null — no proxy, falls back to git's `http.proxy`) |
+| `proxy` | `no_proxy` | Comma-separated hosts to bypass proxy (default: null) |
 | `sessions` | `timeout_secs` | Session inactivity timeout (default: 3600) |
 | `sessions` | `max_streaming_sessions` | Max Tier 2 streaming sessions (default: 10) |
 | `sessions` | `max_repo_sessions` | Max repo tracking sessions (default: 100) |
@@ -441,12 +476,12 @@ Configuration file location:
 | `lfs` | `retry_initial_backoff_ms` | Initial retry backoff in ms (default: 500) |
 | `lfs` | `retry_max_backoff_ms` | Maximum retry backoff in ms (default: 30000) |
 | `lfs` | `retry_backoff_multiplier` | Exponential backoff multiplier (default: 2.0) |
-| `lfs` | `max_object_size` | Max single LFS object size in bytes |
-| `lfs` | `max_total_size` | Max total LFS size per operation |
+| `lfs` | `max_object_size` | Max single LFS object size in bytes (default: null — unlimited; oversized objects are kept as pointer files) |
+| `lfs` | `max_total_size` | Max total LFS size per operation (default: null — unlimited) |
 | `submodules` | `max_concurrent` | Parallel submodule fetches (default: 4) |
 | `submodules` | `max_failures` | Max submodule failures before stopping (default: 3) |
-| `submodules` | `include_patterns` | Glob patterns to include |
-| `submodules` | `exclude_patterns` | Glob patterns to exclude |
+| `submodules` | `include_patterns` | Glob patterns to include (default: null — all submodules allowed) |
+| `submodules` | `exclude_patterns` | Glob patterns to exclude (default: null — nothing excluded) |
 
 ---
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -204,7 +204,8 @@ serde = { version = "1.0", features = ["derive"] }
 
 ### Formatter
 
-Use [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) for VS Code. Column width is set to 170 characters (configured in `.vscode/settings.json`).
+Use [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) for VS Code.
+Column width is set to 170 characters (configured in `.vscode/settings.json`).
 
 ---
 
@@ -280,8 +281,9 @@ See `CONTRIBUTING.md` § Commit Messages for conventions and allowed types.
 
 See `CONTRIBUTING.md` § British Spelling for the full reference table.
 
-**Quick rule:** Use British spelling in documentation (colour, behaviour, organisation). Code identifiers may use American spelling where it matches Rust/library conventions.
+**Quick rule:** Use British spelling in documentation (colour, behaviour, organisation).
+Code identifiers may use American spelling where it matches Rust/library conventions.
 
 ---
 
-*Last updated: 2026-04-29*
+*Last updated: 2026-05-01*

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -112,6 +112,12 @@ rm repo.tar.gz
 # Initialise git (so we can create commits later)
 cd /home/claude/repo
 git init
+
+# Configure the identity from the `initialize` response's `gitIdentity`
+# (if present) before any commit, so AI commits are clearly attributable.
+git config user.name "Claude AI"
+git config user.email "ai-assistant@example.com"
+
 git add .
 git commit -m "Initial clone from abc123def456"
 

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -354,6 +354,9 @@ Total: 1 MCP call for all changes
 
 ### 1. Use Shallow Clone for Large Repos
 
+For medium-sized repositories, combine `depth: 1` with `sparse` patterns
+to keep the single MCP response small:
+
 ```json
 {
   "name": "repo_clone",
@@ -364,6 +367,11 @@ Total: 1 MCP call for all changes
   }
 }
 ```
+
+For repositories that genuinely don't fit in a single response, switch
+to Tier 2 (`repo_clone_start` + `repo_clone_chunk`), which streams the
+archive in 1 MiB chunks and supports resume on interruption — see the
+"Tier 2: Chunked Streaming" section in `README.md` for the protocol.
 
 ### 2. Bundle Multiple Commits
 

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -379,7 +379,7 @@ Always verify locally before pushing:
 ```bash
 cargo test
 cargo clippy --all-targets --all-features -- -D warnings
-cargo fmt --check
+cargo fmt --all --check
 ```
 
 ### 4. Handle Merge Conflicts

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -42,7 +42,7 @@ When the MCP server initialises, it may provide a `gitIdentity` in the response.
 This identity should be used for all commits to clearly distinguish AI-assisted
 commits from human commits.
 
-**Initialize Response (with git identity):**
+**`initialize` response (with git identity):**
 
 ```json
 {
@@ -95,7 +95,8 @@ This ensures all commits made by the AI are properly attributed, making it easy 
   "commit": "abc123def456...",
   "branch": "main",
   "file_count": 47,
-  "archive_size": 1048576
+  "archive_size": 1048576,
+  "hint": "Use helper_script tool to get git_proxy_helper.py, then: python git_proxy_helper.py extract <result.json> <output_dir>"
 }
 ```
 
@@ -161,8 +162,8 @@ cargo test
 # Format code
 cargo fmt
 
-# Check with clippy
-cargo clippy
+# Check with clippy (matches the project's CI command)
+cargo clippy --all-targets --all-features -- -D warnings
 
 # Commit
 git add .
@@ -206,7 +207,7 @@ BUNDLE_BASE64=$(base64 -w0 /tmp/changes.bundle)
   "commit": "def789abc...",
   "force": false,
   "remote_url": "https://github.com/user/my-rust-project",
-  "hint": "Bundle was successfully pushed to the remote."
+  "hint": "To create a bundle: use helper_script tool, then: python git_proxy_helper.py bundle <repo_dir> <since_commit>"
 }
 ```
 
@@ -250,7 +251,7 @@ If someone else pushed changes:
     "deletions": 3
   },
   "up_to_date": false,
-  "hint": "Apply the diff or extract files_archive into your local clone."
+  "hint": "Use helper_script tool to get git_proxy_helper.py, then: python git_proxy_helper.py extract <result.json> <output_dir>"
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,7 +124,8 @@ repo.checkout_head(...)?;                  // Would write files!
 | Git objects | Temp only | Bare repo, deleted after |
 | Bundle file | Temp only | For unbundle operation |
 | Credentials | **NO** | System helpers only |
-| Tar archive | **NO** | Built in memory |
+| Tar archive (Tier 1) | **NO** | Built in memory |
+| Tar archive (Tier 2) | Temp only when ≥ 10 MiB | Disk-backed via `NamedTempFile`; deleted when session ends or expires |
 
 ### Temp Directory Contents
 
@@ -193,7 +194,7 @@ For large repositories, Tier 1 may buffer too much data in memory. Tier 2 solves
 
 | Aspect | Tier 1 | Tier 2 |
 |--------|--------|--------|
-| Response size | Entire repo | Configurable (1KB-4MB) |
+| Response size | Entire repo | Configurable (1 KiB – 4 MiB) |
 | Resume on failure | Start over | Resume via `repo_clone_status` |
 | Progress reporting | None | chunk_index / total_chunks / progress % |
 | Memory per response | O(repo) | O(chunk) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -282,7 +282,7 @@ tests/
 ├── mcp_integration.rs           # Rust MCP protocol tests
 ├── perf_tests.rs                # Performance benchmarks
 ├── streaming_tests.rs           # Streaming/chunked tests
-├── property_tests.rs            # Property-based tests (URL sanitisation, LFS pointer parsing, .gitmodules)
+├── property_tests.rs            # Property-based tests (URL sanitisation, URL validation, LFS pointer detection/parsing)
 ├── security_tests.rs            # Security guards, rate limiting, audit event safety
 └── integration/                 # End-to-end Python tests (stdlib only)
     ├── test_mcp_tools.py        # Spawn server, exercise all 10 tools

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -101,16 +101,17 @@ fn clone_and_stream(url: &str) -> Result<Archive> {
 All operations are logged, but credentials are never included:
 
 ```rust
-// ✅ Good: Log operation details
-audit_log.info("repo_clone", json!({
-    "url": sanitize_url(url),  // Removes credentials from URL
-    "branch": branch,
-    "success": true,
-    "duration_ms": elapsed,
-}));
+// ✅ Good: Log operation details. Audit events are constructed via
+// `AuditEvent::repo_clone_success(...)` (or _failed/_blocked) and the
+// URL is sanitised inside the constructor — see `src/security/audit.rs`.
+self.audit_logger.log_silent(&AuditEvent::repo_clone_success(
+    &sanitize_url_for_logging(url),
+    branch,
+    elapsed,
+));
 
 // ❌ Never: Log credential info
-audit_log.debug("Using credential: {:?}", cred);  // NEVER
+tracing::debug!("Using credential: {:?}", cred);  // NEVER
 ```
 
 ## Threat Model
@@ -122,7 +123,7 @@ audit_log.debug("Using credential: {:?}", cred);  // NEVER
 | **Credential theft** | Credentials handled by OS, never stored by us |
 | **Credential logging** | Code audit; no Cred in logs; URL sanitisation |
 | **Code exfiltration** | Temp files only; deleted after streaming |
-| **Unauthorized repo access** | Uses user's own credentials; can only access what they can |
+| **Unauthorised repo access** | Uses user's own credentials; can only access what they can |
 | **Malicious bundles** | Bundle validation before processing |
 | **Path traversal** | Archive extraction validates paths |
 | **Denial of service** | Rate limiting; configurable size limits |
@@ -142,52 +143,55 @@ audit_log.debug("Using credential: {:?}", cred);  // NEVER
 ### 1. Branch Protection
 
 ```rust
-let branch_guard = BranchGuard::new(vec![
-    "main".to_string(),
-    "master".to_string(),
-    "release/*".to_string(),
-]);
+// `BranchGuard::new` accepts any iterator of `Into<String>` patterns.
+let branch_guard = BranchGuard::new(["main", "master", "release/*"]);
 
-// Before push
-if branch_guard.is_protected(branch) && !is_fast_forward {
-    return Err("Cannot force-push to protected branch");
+// Before push: the actual check returns a `SecurityCheckResult` rather
+// than a bool — `Allowed` or `Blocked { reason }` — and `Blocked` is
+// surfaced to the client as a tool error.
+match branch_guard.check("push", &push_args) {
+    SecurityCheckResult::Blocked { reason } => return Err(reason),
+    SecurityCheckResult::Allowed => {}
 }
 ```
 
 ### 2. Force Push Protection
 
 ```rust
-let push_guard = PushGuard::new(allow_force_push: false);
+// `PushGuard::new(false)` blocks all `--force` / `-f` /
+// `--force-with-lease` pushes; `PushGuard::new(true)` allows them.
+let push_guard = PushGuard::new(false);
 
-// Before push
-if push_guard.is_force_push(args) {
-    return Err("Force push is disabled");
+match push_guard.check("push", &push_args) {
+    SecurityCheckResult::Blocked { reason } => return Err(reason),
+    SecurityCheckResult::Allowed => {}
 }
 ```
 
 ### 3. Repository Filtering
 
 ```rust
-// Allowlist mode: only specified repos
-let filter = RepoFilter::allowlist(vec![
-    "github.com/myorg/*",
-]);
+// Allowlist mode: only allow patterns added via `allow(...)`.
+let mut filter = RepoFilter::allowlist_mode();
+filter.allow("github.com/myorg/*");
 
-// Or blocklist mode
-let filter = RepoFilter::blocklist(vec![
-    "github.com/secrets/*",
-]);
+// Or blocklist mode (the default): block patterns added via `block(...)`,
+// allow everything else.
+let mut filter = RepoFilter::blocklist_mode();
+filter.block("github.com/secrets/*");
+
+if !filter.is_allowed(repo_url) {
+    return Err("Repository is not allowed by policy");
+}
 ```
 
 ### 4. Rate Limiting
 
 ```rust
-let limiter = RateLimiter::new(
-    max_burst: 20,
-    refill_per_sec: 5.0,
-);
+// `RateLimiter::new(max_burst, refill_rate)` — no named arguments in
+// Rust, just positional ones.
+let limiter = RateLimiter::new(20, 5.0);
 
-// Before operation
 if !limiter.try_acquire() {
     return Err("Rate limit exceeded");
 }
@@ -195,12 +199,22 @@ if !limiter.try_acquire() {
 
 ### 5. URL Sanitisation
 
+The actual implementation lives at `src/git2_ops/auth.rs::sanitize_url_for_logging`
+and uses byte-safe `find` operations rather than a regex (the project has no
+regex dependency). The behaviour is: if the URL contains both `://` and `@`,
+everything between the scheme and the `@` is replaced with `***`.
+
 ```rust
-/// Remove credentials from URLs before logging
-pub fn sanitize_url(url: &str) -> String {
-    // https://user:token@github.com/... → https://***@github.com/...
-    let re = Regex::new(r"://[^@]+@").unwrap();
-    re.replace(url, "://***@").to_string()
+/// Remove credentials from URLs before logging.
+pub fn sanitize_url_for_logging(url: &str) -> String {
+    if let Some(at_pos) = url.find('@') {
+        if let Some(scheme_end) = url.find("://") {
+            let scheme = &url[..scheme_end + 3];
+            let after_at = &url[at_pos + 1..];
+            return format!("{scheme}***@{after_at}");
+        }
+    }
+    url.to_string()
 }
 ```
 
@@ -216,8 +230,8 @@ Cred::ssh_key_from_agent(username)
 // ✅ Use TempDir for automatic cleanup
 let temp = TempDir::new()?;
 
-// ✅ Sanitise URLs in logs
-log::info!("Cloning {}", sanitize_url(url));
+// ✅ Sanitise URLs in logs (this project uses `tracing`, not `log`)
+tracing::info!("Cloning {}", sanitize_url_for_logging(url));
 
 // ✅ Validate paths in archives
 if path.starts_with("..") {
@@ -235,8 +249,8 @@ Err("Authentication failed. Check your credential configuration.")
 self.token = get_token();  // NEVER
 
 // ❌ Log credentials
-log::debug!("Token: {}", token);  // NEVER
-log::debug!("Cred: {:?}", cred);  // NEVER
+tracing::debug!("Token: {}", token);  // NEVER
+tracing::debug!("Cred: {:?}", cred);  // NEVER
 
 // ❌ Include credentials in errors
 Err(format!("Auth failed with token: {}", token))  // NEVER
@@ -250,11 +264,11 @@ let path = "/tmp/repo";  // Use TempDir instead
 ### If Credentials Are Suspected Leaked
 
 1. **Revoke immediately** — Rotate the affected credential
-2. **Check audit logs** — Look for unauthorized operations
+2. **Check audit logs** — Look for unauthorised operations
 3. **Review code** — Find the leak source
 4. **Report** — If vulnerability, follow SECURITY.md disclosure process
 
-### If Unauthorized Push Detected
+### If Unauthorised Push Detected
 
 1. **Git revert** — Undo the push on the remote
 2. **Check audit logs** — When and from where

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -102,11 +102,16 @@ All operations are logged, but credentials are never included:
 
 ```rust
 // ✅ Good: Log operation details. Audit events are constructed via
-// `AuditEvent::repo_clone_success(...)` (or _failed/_blocked) and the
-// URL is sanitised inside the constructor — see `src/security/audit.rs`.
+// `AuditEvent::repo_clone_success(url, branch, commit, file_count,
+// archive_size, duration)` (and matching `_failed` / `_blocked`
+// constructors) — see `src/security/audit.rs` for the full set.
+// URLs must be sanitised by the *caller* before being passed in.
 self.audit_logger.log_silent(&AuditEvent::repo_clone_success(
-    &sanitize_url_for_logging(url),
+    sanitize_url_for_logging(url),
     branch,
+    commit,
+    file_count,
+    archive_size,
     elapsed,
 ));
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -50,8 +50,13 @@ Default rate limits: 20 operations burst, 5 operations per second sustained.
 | Delete protected branch | `Cannot delete protected branch '{branch}'` |
 | Force push to protected branch | `Cannot force push to protected branch '{branch}'` |
 
-No branches are protected by default — `protected_branches` is an empty list unless configured.
-The shipped `config/example-config.json` recommends `["main", "master"]`.
+Effective default: `main`, `master`, `develop` are protected. The
+`security.protected_branches` field in config defaults to an empty list,
+but the server treats an empty list as "use the built-in safe set" and
+substitutes `BranchGuard::with_defaults()` — see
+`McpServer::new` in `src/mcp/server.rs`. Configuring any non-empty list
+overrides the fallback. The shipped `config/example-config.json`
+recommends `["main", "master"]`.
 
 ### Force Push Blocking
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -50,7 +50,8 @@ Default rate limits: 20 operations burst, 5 operations per second sustained.
 | Delete protected branch | `Cannot delete protected branch '{branch}'` |
 | Force push to protected branch | `Cannot force push to protected branch '{branch}'` |
 
-Default protected branches: `main`, `master`, `develop`.
+No branches are protected by default — `protected_branches` is an empty list unless configured.
+The shipped `config/example-config.json` recommends `["main", "master"]`.
 
 ### Force Push Blocking
 

--- a/src/git2_ops/auth.rs
+++ b/src/git2_ops/auth.rs
@@ -188,7 +188,7 @@ fn credentials_callback(
     ))
 }
 
-/// Sanitize a URL for logging by removing any embedded credentials.
+/// Sanitise a URL for logging by removing any embedded credentials.
 ///
 /// URLs like `https://user:token@github.com/...` become `https://***@github.com/...`
 #[must_use]

--- a/src/git2_ops/clone.rs
+++ b/src/git2_ops/clone.rs
@@ -73,7 +73,7 @@ pub struct FetchOptions2 {
 /// Returns an error if:
 /// - URL validation fails (`InvalidUrl`)
 /// - Temp directory creation fails (`TempDirFailed`)
-/// - Repository initialization fails (`InitFailed`)
+/// - Repository initialisation fails (`InitFailed`)
 /// - Fetch operation fails (`FetchFailed`)
 /// - Branch reference not found (`RefNotFound`)
 ///
@@ -112,7 +112,7 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
     let repo = Repository::init_bare(temp_dir.path())
         .map_err(|e| Git2Error::InitFailed(format!("failed to init bare repo: {}", e.message())))?;
 
-    debug!("initialized bare repository");
+    debug!("initialised bare repository");
 
     // Fetch the specific branch
     let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");

--- a/src/git2_ops/clone.rs
+++ b/src/git2_ops/clone.rs
@@ -17,7 +17,7 @@
 //! - Only git objects (compressed, not plaintext) touch the disk
 //! - Temp directory is automatically cleaned on drop
 
-use git2::{FetchOptions, Oid, Repository};
+use git2::{Direction, FetchOptions, Oid, Repository};
 use tempfile::TempDir;
 use tracing::{debug, info};
 
@@ -92,14 +92,13 @@ pub struct FetchOptions2 {
 /// ```
 pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResult, Git2Error> {
     let options = options.unwrap_or_default();
-    let branch_name = options.branch.as_deref().unwrap_or("main");
 
     // Validate URL before doing anything
     validate_url(url)?;
 
     info!(
         url = %super::auth::sanitize_url_for_logging(url),
-        branch = branch_name,
+        branch = options.branch.as_deref().unwrap_or("(remote default)"),
         "starting bare fetch"
     );
 
@@ -108,56 +107,96 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
 
     debug!(path = %temp_dir.path().display(), "created temp directory");
 
-    // Initialize BARE repository — no working tree!
+    // Initialise BARE repository — no working tree!
     let repo = Repository::init_bare(temp_dir.path())
         .map_err(|e| Git2Error::InitFailed(format!("failed to init bare repo: {}", e.message())))?;
 
     debug!("initialised bare repository");
 
-    // Fetch the specific branch
-    let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");
-
-    // Scope the remote to ensure it's dropped before we return the repo
-    {
+    // Resolve the branch name and fetch in a single connection. Scope the
+    // remote so it's dropped before we return the repo.
+    let branch_name = {
         let mut remote = repo
             .remote_anonymous(url)
             .map_err(|e| Git2Error::InitFailed(format!("failed to create remote: {e}")))?;
 
-        let callbacks = create_callbacks_with_progress(options.progress.as_ref());
-
-        let mut fetch_opts = FetchOptions::new();
-        fetch_opts.remote_callbacks(callbacks);
-
-        let mut proxy_opts = git2::ProxyOptions::new();
+        // Connect once so we can both query the default branch (when the
+        // caller didn't pass one) and reuse the same connection for fetch.
+        let connect_callbacks = create_callbacks_with_progress(options.progress.as_ref());
+        let mut connect_proxy = git2::ProxyOptions::new();
         if let Some(ref proxy_url) = options.proxy_url {
-            proxy_opts.url(proxy_url);
+            connect_proxy.url(proxy_url);
         } else {
-            proxy_opts.auto();
+            connect_proxy.auto();
         }
-        fetch_opts.proxy_options(proxy_opts);
+        remote
+            .connect_auth(
+                Direction::Fetch,
+                Some(connect_callbacks),
+                Some(connect_proxy),
+            )
+            .map_err(|e| Git2Error::FetchFailed(e.message().to_string()))?;
 
-        // Configure shallow clone if depth is specified
+        // Resolve branch: caller-supplied wins; otherwise ask the connected
+        // remote for its default. We never fall back to a hard-coded "main"
+        // because that masks misconfigured remotes.
+        let branch_name = if let Some(b) = options.branch.as_deref() {
+            b.to_string()
+        } else {
+            let default_buf = remote.default_branch().map_err(|e| {
+                Git2Error::FetchFailed(format!(
+                    "could not determine remote's default branch: {}",
+                    e.message()
+                ))
+            })?;
+            let default_str = std::str::from_utf8(&default_buf)
+                .map_err(|e| Git2Error::Git2(format!("invalid default branch encoding: {e}")))?;
+            let resolved = default_str
+                .strip_prefix("refs/heads/")
+                .unwrap_or(default_str)
+                .trim_end_matches(['\0', '\n', '\r'])
+                .to_string();
+            debug!(branch = %resolved, "resolved remote's default branch");
+            resolved
+        };
+
+        // Build fetch options (fresh callbacks since `connect_auth` consumed
+        // ours; git2 reuses the existing TCP connection for the actual fetch).
+        let fetch_callbacks = create_callbacks_with_progress(options.progress.as_ref());
+        let mut fetch_opts = FetchOptions::new();
+        fetch_opts.remote_callbacks(fetch_callbacks);
+
+        let mut fetch_proxy = git2::ProxyOptions::new();
+        if let Some(ref proxy_url) = options.proxy_url {
+            fetch_proxy.url(proxy_url);
+        } else {
+            fetch_proxy.auto();
+        }
+        fetch_opts.proxy_options(fetch_proxy);
+
         if let Some(depth) = options.depth {
-            // git2 depth() takes i32, 0 means full clone
-            // Cap at i32::MAX and convert safely
+            // git2 depth() takes i32, 0 means full clone. Cap at i32::MAX.
             #[allow(clippy::cast_possible_wrap)]
             let depth_i32 = depth.min(i32::MAX as u32) as i32;
             fetch_opts.depth(depth_i32);
             debug!(depth = depth, "shallow clone configured");
         }
 
+        let refspec = format!("refs/heads/{branch_name}:refs/heads/{branch_name}");
         debug!(refspec = %refspec, "fetching");
 
         remote
             .fetch(&[&refspec], Some(&mut fetch_opts), None)
             .map_err(|e| Git2Error::FetchFailed(e.message().to_string()))?;
-    }
+
+        branch_name
+    };
 
     // Get the head commit (remote is now dropped, scope reference too)
     let head_commit = {
         let reference = repo
             .find_reference(&format!("refs/heads/{branch_name}"))
-            .map_err(|_| Git2Error::RefNotFound(branch_name.to_string()))?;
+            .map_err(|_| Git2Error::RefNotFound(branch_name.clone()))?;
 
         reference
             .peel_to_commit()
@@ -167,14 +206,14 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
 
     info!(
         commit = %head_commit,
-        branch = branch_name,
+        branch = %branch_name,
         "fetch complete"
     );
 
     Ok(FetchResult {
         repo,
         head_commit,
-        branch: branch_name.to_string(),
+        branch: branch_name,
         _temp_dir: temp_dir,
     })
 }

--- a/src/git2_ops/clone.rs
+++ b/src/git2_ops/clone.rs
@@ -149,13 +149,7 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
                     e.message()
                 ))
             })?;
-            let default_str = std::str::from_utf8(&default_buf)
-                .map_err(|e| Git2Error::Git2(format!("invalid default branch encoding: {e}")))?;
-            let resolved = default_str
-                .strip_prefix("refs/heads/")
-                .unwrap_or(default_str)
-                .trim_end_matches(['\0', '\n', '\r'])
-                .to_string();
+            let resolved = decode_default_branch(&default_buf)?;
             debug!(branch = %resolved, "resolved remote's default branch");
             resolved
         };
@@ -218,6 +212,19 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
     })
 }
 
+/// Decode the buffer returned by `Remote::default_branch()` into a plain
+/// branch name. libgit2 returns the full ref form (`refs/heads/<branch>`)
+/// and has historically appended trailing NUL/newline noise on some
+/// transports; we strip both.
+fn decode_default_branch(buf: &[u8]) -> Result<String, Git2Error> {
+    let s = std::str::from_utf8(buf)
+        .map_err(|e| Git2Error::Git2(format!("invalid default branch encoding: {e}")))?;
+    Ok(s.strip_prefix("refs/heads/")
+        .unwrap_or(s)
+        .trim_end_matches(['\0', '\n', '\r'])
+        .to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,6 +237,107 @@ mod tests {
         assert!(opts.proxy_url.is_none());
     }
 
-    // Integration tests would go here but require network access
-    // See tests/git2_integration.rs for full integration tests
+    #[test]
+    fn decode_default_branch_strips_refs_heads_prefix() {
+        assert_eq!(
+            decode_default_branch(b"refs/heads/develop").unwrap(),
+            "develop"
+        );
+        assert_eq!(
+            decode_default_branch(b"refs/heads/master").unwrap(),
+            "master"
+        );
+        assert_eq!(
+            decode_default_branch(b"refs/heads/feature/x").unwrap(),
+            "feature/x"
+        );
+    }
+
+    #[test]
+    fn decode_default_branch_trims_trailing_noise() {
+        // libgit2 has historically appended NUL or CRLF on some transports.
+        assert_eq!(
+            decode_default_branch(b"refs/heads/develop\0").unwrap(),
+            "develop"
+        );
+        assert_eq!(
+            decode_default_branch(b"refs/heads/develop\n").unwrap(),
+            "develop"
+        );
+        assert_eq!(
+            decode_default_branch(b"refs/heads/develop\r\n").unwrap(),
+            "develop"
+        );
+        assert_eq!(
+            decode_default_branch(b"refs/heads/develop\0\0").unwrap(),
+            "develop"
+        );
+    }
+
+    #[test]
+    fn decode_default_branch_passes_through_branches_without_prefix() {
+        // Defensive: bare branch name (libgit2 doesn't currently return this
+        // form, but the strip_prefix fallback shouldn't double-mangle it).
+        assert_eq!(decode_default_branch(b"develop").unwrap(), "develop");
+    }
+
+    #[test]
+    fn decode_default_branch_rejects_invalid_utf8() {
+        let bad = &[0xFFu8, 0xFE, 0xFD];
+        let err = decode_default_branch(bad).unwrap_err();
+        assert!(
+            matches!(err, Git2Error::Git2(_)),
+            "expected Git2 error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn fetch_bare_default_branch_resolves_non_main_via_local_remote() {
+        // Validates the libgit2 contract that fetch_bare's no-branch path
+        // relies on: the remote's HEAD symref is what `Remote::default_branch()`
+        // returns. We build a bare repo whose HEAD points to `develop` (not
+        // `main`), connect a fresh anonymous remote to it via file://, and
+        // check the resolved branch name matches the on-disk HEAD target.
+        // This is the closest we can get to end-to-end coverage without
+        // weakening `validate_url`'s file:// rejection.
+        let source = tempfile::TempDir::new().unwrap();
+        let source_repo = Repository::init_bare(source.path()).unwrap();
+
+        // Point HEAD at refs/heads/develop *before* the first commit so that
+        // the commit creates the develop branch (not main/master).
+        source_repo.set_head("refs/heads/develop").unwrap();
+        let signature = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_oid = source_repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = source_repo.find_tree(tree_oid).unwrap();
+        source_repo
+            .commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "init on develop",
+                &tree,
+                &[],
+            )
+            .unwrap();
+
+        // Connect a fresh anonymous remote (mirroring the bare temp repo
+        // created in fetch_bare) and ask for the default branch.
+        let dest = tempfile::TempDir::new().unwrap();
+        let dest_repo = Repository::init_bare(dest.path()).unwrap();
+
+        // file:// URL form, with Windows-friendly path translation.
+        let raw_path = source.path().display().to_string();
+        let url = if cfg!(windows) {
+            format!("file:///{}", raw_path.replace('\\', "/"))
+        } else {
+            format!("file://{raw_path}")
+        };
+
+        let mut remote = dest_repo.remote_anonymous(&url).unwrap();
+        remote.connect(Direction::Fetch).unwrap();
+        let buf = remote.default_branch().unwrap();
+
+        let resolved = decode_default_branch(&buf).unwrap();
+        assert_eq!(resolved, "develop");
+    }
 }

--- a/src/git2_ops/error.rs
+++ b/src/git2_ops/error.rs
@@ -12,8 +12,8 @@ use thiserror::Error;
 /// without leaking credentials.
 #[derive(Error, Debug)]
 pub enum Git2Error {
-    /// Failed to initialize a repository
-    #[error("failed to initialize repository: {0}")]
+    /// Failed to initialise a repository.
+    #[error("failed to initialise repository: {0}")]
     InitFailed(String),
 
     /// Failed to fetch from remote
@@ -44,7 +44,7 @@ pub enum Git2Error {
     #[error("failed to create temporary directory: {0}")]
     TempDirFailed(#[from] io::Error),
 
-    /// Git2 library error (sanitized)
+    /// Git2 library error (sanitised)
     #[error("git operation failed: {0}")]
     Git2(String),
 
@@ -55,7 +55,7 @@ pub enum Git2Error {
 
 impl From<git2::Error> for Git2Error {
     fn from(err: git2::Error) -> Self {
-        // Sanitize the error message to avoid credential leakage
+        // Sanitise the error message to avoid credential leakage
         let message = err.message();
 
         // Check for authentication-related errors
@@ -69,12 +69,12 @@ impl From<git2::Error> for Git2Error {
             return Self::AuthenticationFailed;
         }
 
-        // Generic sanitized error
+        // Generic sanitised error
         Self::Git2(sanitize_error_message(message))
     }
 }
 
-/// Sanitize an error message to remove potential credential information.
+/// Sanitise an error message to remove potential credential information.
 fn sanitize_error_message(message: &str) -> String {
     // Remove anything that looks like a token or password
     // This is a basic implementation — extend as needed
@@ -223,7 +223,7 @@ mod tests {
     fn error_display_messages_match_thiserror() {
         assert_eq!(
             Git2Error::InitFailed("disk full".into()).to_string(),
-            "failed to initialize repository: disk full",
+            "failed to initialise repository: disk full",
         );
         assert_eq!(
             Git2Error::FetchFailed("timeout".into()).to_string(),

--- a/src/git2_ops/lfs.rs
+++ b/src/git2_ops/lfs.rs
@@ -17,7 +17,11 @@
 //!
 //! - LFS authentication uses the same credential helpers as git
 //! - Credentials are never stored or logged
-//! - All LFS server communication is over HTTPS
+//! - LFS server communication uses whatever scheme the repository URL
+//!   declares: `https://` repos and `git@` SSH URLs (which we rewrite
+//!   to `https://` for the LFS endpoint) communicate over HTTPS;
+//!   `http://` repos communicate over HTTP. SSH-only LFS transports
+//!   (the `lfs+ssh://` scheme) are not supported.
 
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};

--- a/src/git2_ops/push.rs
+++ b/src/git2_ops/push.rs
@@ -32,7 +32,7 @@ pub struct PushResult {
     pub branch: String,
     /// The commit ID that was pushed
     pub commit: String,
-    /// Remote URL (sanitized for display)
+    /// Remote URL (sanitised for display)
     pub remote_url: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,16 @@
 //! - Memory usage: O(chunk size)
 //! - Resume interrupted transfers
 //! - Progress reporting
-//! - Tools: `repo_clone_start`, `repo_clone_chunk`, `repo_clone_cancel`
+//! - Tools: `repo_clone_start`, `repo_clone_chunk`, `repo_clone_status`, `repo_clone_cancel`
+//!
+//! ## Other tools
+//!
+//! Independent of the Tier 1 / Tier 2 split:
+//!
+//! - `repo_pull` — Incremental sync since a known commit
+//! - `repo_diff` — Diff between two commits
+//! - `repo_refs` — List remote branches and tags
+//! - `helper_script` — Get a Python helper for parsing tool responses
 //!
 //! # Credential Handling
 //!

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -59,9 +59,9 @@ use crate::streaming::chunked::StreamingSessionManager;
 /// Server state in the MCP lifecycle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServerState {
-    /// Waiting for initialize request.
+    /// Waiting for `initialize` request.
     AwaitingInit,
-    /// Initialize received, waiting for initialized notification.
+    /// `initialize` received, waiting for `notifications/initialized`.
     Initialising,
     /// Ready for normal operation.
     Running,
@@ -122,7 +122,7 @@ pub struct ClientInfo {
     pub version: Option<String>,
 }
 
-/// Parameters for the initialize request.
+/// Parameters for the `initialize` request.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeParams {
@@ -224,7 +224,7 @@ pub struct SecurityConfig {
 
 /// Git identity configuration for AI-assisted commits.
 ///
-/// This identity is communicated to the AI during initialization so they
+/// This identity is communicated to the AI during initialisation so they
 /// can configure their local Git to use it for commits. This allows
 /// clear separation between AI-made commits and human commits.
 #[derive(Debug, Clone, Default, Serialize)]
@@ -517,7 +517,7 @@ impl McpServer {
         // All other notifications (including unknown ones) are ignored per JSON-RPC spec
     }
 
-    /// Handles the initialize request.
+    /// Handles the `initialize` request.
     fn handle_initialize(&mut self, req: &JsonRpcRequest) -> Result<JsonRpcResponse, JsonRpcError> {
         // Must be in AwaitingInit state
         if self.state != ServerState::AwaitingInit {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -800,7 +800,7 @@ impl McpServer {
                         },
                         "chunk_size": {
                             "type": "integer",
-                            "description": "Chunk size in bytes (default: 1MB, max: 4MB)"
+                            "description": "Chunk size in bytes (default: 1 MiB, range: 1 KiB – 4 MiB after clamping)"
                         },
                         "exclude_binary": {
                             "type": "boolean",

--- a/src/mcp/tools/helper_script.rs
+++ b/src/mcp/tools/helper_script.rs
@@ -48,7 +48,7 @@ JSON parsing, base64 decoding, and archive extraction automatically.
 
 Usage:
     python git_proxy_helper.py extract <result_json> [output_dir]
-    python git_proxy_helper.py bundle <repo_dir> <since_commit> [output_file]
+    python git_proxy_helper.py bundle <repo_dir> <since_commit> [head_ref] [output_file]
     python git_proxy_helper.py info <result_json>
 
 Examples:
@@ -229,6 +229,7 @@ def show_info(json_path: str) -> dict:
         info['archive_b64_length'] = len(data['archive'])
     if 'files_archive' in data:
         info['has_files_archive'] = True
+        info['files_archive_b64_length'] = len(data['files_archive'])
     if 'diff' in data:
         info['has_diff'] = True
         info['diff_lines'] = data['diff'].count('\n')

--- a/src/mcp/tools/helper_script.rs
+++ b/src/mcp/tools/helper_script.rs
@@ -3,18 +3,20 @@
 //! This tool returns a Python helper script that AI assistants can save and use
 //! to simplify working with git-proxy-mcp responses. The script handles:
 //!
-//! - Parsing nested MCP JSON responses
+//! - Parsing nested MCP JSON responses (handles the `[{"type":"text","text":"…"}]` wrapper)
 //! - Base64 decoding of archives
 //! - Extracting tar.gz archives to directories
 //! - Creating git bundles for pushing changes
+//! - Inspecting result metadata without extracting
 //!
 //! # Usage by AI
 //!
 //! 1. Call `helper_script` tool once per session
 //! 2. Save the returned script as `git_proxy_helper.py`
 //! 3. Use it for all subsequent operations:
-//!    - `python git_proxy_helper.py extract <result.json> <output_dir>`
-//!    - `python git_proxy_helper.py bundle <repo_dir> <since_commit>`
+//!    - `python git_proxy_helper.py extract <result.json> [output_dir]`
+//!    - `python git_proxy_helper.py bundle <repo_dir> <since_commit> [head_ref] [output_file]`
+//!    - `python git_proxy_helper.py info <result.json>`
 
 use serde::Serialize;
 
@@ -106,8 +108,8 @@ def extract_archive(json_path: str, output_dir: str = ".") -> dict:
     """
     data = parse_mcp_result(json_path)
 
-    # Get the archive field (repo_clone uses 'archive', repo_pull uses 'changed_files_archive')
-    archive_b64 = data.get('archive') or data.get('changed_files_archive')
+    # Get the archive field (repo_clone uses 'archive', repo_pull uses 'files_archive')
+    archive_b64 = data.get('archive') or data.get('files_archive')
 
     if not archive_b64:
         raise ValueError("No archive found in result. Is this a clone/pull result?")
@@ -208,9 +210,12 @@ def show_info(json_path: str) -> dict:
 
     info = {}
 
-    # Common fields
+    # Common fields. `base_commit`/`new_commit` are repo_pull,
+    # `base_commit`/`head_commit` are repo_diff, `commit` is repo_clone /
+    # repo_clone_start / repo_push, and the skipped/lfs/submodule counters
+    # appear on repo_clone and repo_clone_start.
     for key in ['commit', 'branch', 'file_count', 'archive_size',
-                'new_commit', 'old_commit', 'up_to_date',
+                'base_commit', 'new_commit', 'head_commit', 'up_to_date',
                 'skipped_by_filter', 'skipped_binary', 'skipped_too_large',
                 'lfs_resolved', 'lfs_failed',
                 'submodules_included', 'submodules_failed',
@@ -222,8 +227,8 @@ def show_info(json_path: str) -> dict:
     if 'archive' in data:
         info['has_archive'] = True
         info['archive_b64_length'] = len(data['archive'])
-    if 'changed_files_archive' in data:
-        info['has_changed_files_archive'] = True
+    if 'files_archive' in data:
+        info['has_files_archive'] = True
     if 'diff' in data:
         info['has_diff'] = True
         info['diff_lines'] = data['diff'].count('\n')
@@ -325,9 +330,9 @@ pub fn handle_helper_script() -> HelperScriptResult {
         script: HELPER_SCRIPT.to_string(),
         filename: "git_proxy_helper.py".to_string(),
         usage: "Save script and use:\n  \
-            python git_proxy_helper.py extract <result.json> <output_dir>  # Extract clone/pull\n  \
-            python git_proxy_helper.py bundle <repo_dir> <since_commit>    # Create push bundle\n  \
-            python git_proxy_helper.py info <result.json>                  # Show result info"
+            python git_proxy_helper.py extract <result.json> [output_dir]   # Extract clone/pull\n  \
+            python git_proxy_helper.py bundle <repo_dir> <since_commit>     # Create push bundle\n  \
+            python git_proxy_helper.py info <result.json>                   # Show result info"
             .to_string(),
         version: "1.1.0".to_string(),
     }
@@ -361,5 +366,43 @@ mod tests {
         // Verify the script handles the MCP wrapper format
         assert!(result.script.contains("if 'text' in data[0]"));
         assert!(result.script.contains("json.loads(data[0]['text'])"));
+    }
+
+    #[test]
+    fn helper_script_uses_correct_repo_pull_archive_field() {
+        // Regression guard: the script must look up `files_archive`
+        // (the actual `RepoPullResult` field name) and not the historical
+        // typo `changed_files_archive` it used to look for.
+        let result = handle_helper_script();
+        assert!(
+            result.script.contains("data.get('files_archive')"),
+            "script must look up the actual repo_pull archive field name"
+        );
+        assert!(
+            !result.script.contains("changed_files_archive"),
+            "script must not reference the obsolete `changed_files_archive` key"
+        );
+    }
+
+    #[test]
+    fn helper_script_show_info_uses_real_commit_field_names() {
+        // Regression guard: `show_info` used to enumerate `old_commit`,
+        // a key no MCP tool has ever returned. The real commit fields
+        // are `commit` (repo_clone / repo_clone_start / repo_push),
+        // `base_commit` + `new_commit` (repo_pull), and
+        // `base_commit` + `head_commit` (repo_diff).
+        let result = handle_helper_script();
+        assert!(
+            !result.script.contains("'old_commit'"),
+            "script must not reference the non-existent `old_commit` key"
+        );
+        assert!(
+            result.script.contains("'base_commit'"),
+            "script must enumerate `base_commit` (repo_pull / repo_diff)"
+        );
+        assert!(
+            result.script.contains("'head_commit'"),
+            "script must enumerate `head_commit` (repo_diff)"
+        );
     }
 }

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -32,7 +32,7 @@
 //! All tool handlers follow the security principles:
 //! - Credentials never leave the user's PC
 //! - No source files written to disk (bare repos only)
-//! - All responses are sanitized for credential leakage
+//! - All responses are sanitised for credential leakage
 
 pub mod helper_script;
 pub mod repo_clone;

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -15,8 +15,13 @@
 //!
 //! ## Tier 2 (Chunked Streaming)
 //!
+//! Chunk-related handlers (`chunk`, `cancel`, `status`) all live in
+//! [`repo_clone_chunk`] but are exposed as separate MCP tools:
+//!
 //! - [`repo_clone_start`] — Start a chunked clone, returns session info
 //! - [`repo_clone_chunk`] — Get a chunk from a streaming session
+//! - [`repo_clone_status`](repo_clone_chunk::handle_repo_clone_status) — Check progress and resume state of a streaming session
+//! - [`repo_clone_cancel`](repo_clone_chunk::handle_repo_clone_cancel) — Cancel and clean up a streaming session
 //!
 //! ## Utilities
 //!

--- a/src/mcp/tools/repo_clone_start.rs
+++ b/src/mcp/tools/repo_clone_start.rs
@@ -24,7 +24,7 @@
 //!
 //! # Memory Model
 //!
-//! For archives larger than 10MB, data is stored in a temp file instead
+//! For archives larger than 10 MiB, data is stored in a temp file instead
 //! of memory (disk-backed storage). The benefits are:
 //! - O(chunk size) memory instead of O(archive size)
 //! - Progress tracking via chunk retrieval
@@ -61,7 +61,7 @@ pub struct RepoCloneStartArgs {
     #[serde(default)]
     pub sparse: Option<Vec<String>>,
 
-    /// Chunk size in bytes (default: 1MB, max: 4MB)
+    /// Chunk size in bytes (default: 1 MiB, range: 1 KiB – 4 MiB after clamping).
     #[serde(default)]
     pub chunk_size: Option<usize>,
 

--- a/src/mcp/tools/repo_push.rs
+++ b/src/mcp/tools/repo_push.rs
@@ -57,7 +57,7 @@ pub struct RepoPushResult {
     /// Whether force push was used
     pub force: bool,
 
-    /// Remote URL (sanitized)
+    /// Remote URL (sanitised)
     pub remote_url: String,
 
     /// Hint for AI assistants on how to create bundles

--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -5,15 +5,26 @@
 //!
 //! # Log Format
 //!
-//! Each log entry is a JSON object with:
-//! - `timestamp`: ISO 8601 timestamp
-//! - `event_type`: Type of event (`command_executed`, `command_blocked`, etc.)
-//! - `command`: The Git command that was executed
-//! - `args`: Command arguments (sanitised)
-//! - `working_dir`: Working directory (if set)
-//! - `outcome`: Success, failure, or blocked
-//! - `reason`: Reason for blocking (if blocked)
-//! - `duration_ms`: Execution time in milliseconds (if executed)
+//! Each log entry is a JSON object. Only fields that apply to the event are
+//! emitted (everything optional is `skip_serializing_if = "Option::is_none"`):
+//!
+//! - `timestamp` — ISO 8601 timestamp (always present)
+//! - `event_type` — `command_executed`, `command_blocked`, `rate_limit_exceeded`,
+//!   `server_started`, `server_stopped`, `repo_clone`, or `repo_push`
+//! - `outcome` — `success`, `failed`, or `blocked` (always present)
+//! - `command` — the git subcommand (for `command_*` events)
+//! - `args` — command arguments, sanitised (for `command_*` events)
+//! - `working_dir` — working directory (if set)
+//! - `reason` — reason for blocking (for blocked events)
+//! - `duration_ms` — execution time in milliseconds
+//! - `exit_code` — process exit code (for executed git commands)
+//! - `shutdown_reason` — `client_disconnected`, `sig_int`, or `sig_term`
+//!   (for `server_stopped` events)
+//! - `url` — repository URL, sanitised (for Tier 1 / `repo_*` events)
+//! - `branch` — branch name (for Tier 1 / `repo_*` events)
+//! - `commit` — commit SHA (for Tier 1 / `repo_*` events)
+//! - `file_count` — number of files in archive (for `repo_clone` success)
+//! - `archive_size` — archive size in bytes (for `repo_clone` success)
 
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};

--- a/src/security/guards.rs
+++ b/src/security/guards.rs
@@ -78,7 +78,10 @@ impl BranchGuard {
 
     /// Creates a branch guard with common default protections.
     ///
-    /// Protected by default: `main`, `master`, `develop`, `release/*`
+    /// Protected by default: `main`, `master`, `develop`. (Wildcard
+    /// patterns like `release/*` are supported by `is_protected` but are
+    /// not in the built-in default set — add them via the
+    /// `security.protected_branches` config option.)
     #[must_use]
     pub fn with_defaults() -> Self {
         Self::new(["main", "master", "develop"])

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,7 +20,7 @@ use crate::git2_ops::auth::sanitize_url_for_logging;
 /// A session tracking a cloned repository.
 #[derive(Debug, Clone)]
 pub struct RepoSession {
-    /// Repository URL (sanitized for display, original for operations).
+    /// Repository URL (sanitised for display, original for operations).
     url: String,
 
     /// Current branch name.
@@ -56,7 +56,7 @@ impl RepoSession {
         &self.url
     }
 
-    /// Get the repository URL sanitized for logging/display.
+    /// Get the repository URL sanitised for logging/display.
     #[must_use]
     pub fn sanitized_url(&self) -> String {
         sanitize_url_for_logging(&self.url)
@@ -116,7 +116,7 @@ impl SessionManager {
     /// Generate a session ID from URL and branch.
     #[must_use]
     pub fn session_id(url: &str, branch: &str) -> String {
-        // Use sanitized URL for the key to avoid storing credentials
+        // Use sanitised URL for the key to avoid storing credentials
         let sanitized = sanitize_url_for_logging(url);
         format!("{sanitized}@{branch}")
     }

--- a/src/streaming/chunked.rs
+++ b/src/streaming/chunked.rs
@@ -153,7 +153,7 @@ pub struct StreamingSession {
     /// Session ID for retrieval
     pub id: String,
 
-    /// Repository URL (sanitized for display)
+    /// Repository URL (sanitised for display)
     pub url: String,
 
     /// Branch that was cloned
@@ -184,7 +184,7 @@ impl StreamingSession {
     ///
     /// # Errors
     ///
-    /// Returns an error if disk-backed storage fails to initialize
+    /// Returns an error if disk-backed storage fails to initialise
     /// (e.g., temp file creation fails).
     pub fn new(
         id: String,
@@ -367,7 +367,7 @@ impl StreamingSessionManager {
     ///
     /// Returns an error if:
     /// - The maximum number of sessions is reached
-    /// - Disk-backed storage initialization fails (temp file creation)
+    /// - Disk-backed storage initialisation fails (temp file creation)
     #[allow(clippy::significant_drop_tightening)]
     pub fn create_session(
         &self,

--- a/src/streaming/chunked.rs
+++ b/src/streaming/chunked.rs
@@ -38,18 +38,18 @@
 //!
 //! ## Disk-Backed Sessions
 //!
-//! For archives larger than `DISK_THRESHOLD` (default 10MB), the data is
+//! For archives larger than `DISK_THRESHOLD` (10 MiB), the data is
 //! stored in a temporary file instead of memory. This allows handling
 //! repositories larger than available RAM while only keeping the current
 //! chunk in memory.
 //!
-//! Default chunk size: 1MB (adjustable per request)
+//! Default chunk size: 1 MiB (adjustable per request, clamped to 1 KiB – 4 MiB).
 //!
 //! # Resume Support
 //!
 //! Sessions persist until:
 //! - All chunks retrieved (auto-cleanup)
-//! - Session timeout (1 hour)
+//! - Session timeout reached (default 1 hour, configurable via `sessions.timeout_secs`)
 //! - Explicit cleanup call
 //!
 //! AI can resume interrupted transfers by requesting missing chunks.
@@ -63,13 +63,13 @@ use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 use tracing::{debug, info, warn};
 
-/// Default chunk size: 1MB (before base64 encoding)
+/// Default chunk size: 1 MiB (before base64 encoding).
 pub const DEFAULT_CHUNK_SIZE: usize = 1024 * 1024;
 
-/// Maximum chunk size: 4MB
+/// Maximum chunk size: 4 MiB.
 pub const MAX_CHUNK_SIZE: usize = 4 * 1024 * 1024;
 
-/// Threshold for disk-backed sessions: 10MB
+/// Threshold for disk-backed sessions: 10 MiB.
 /// Archives larger than this are stored in temp files instead of memory.
 pub const DISK_THRESHOLD: usize = 10 * 1024 * 1024;
 
@@ -360,7 +360,7 @@ impl StreamingSessionManager {
 
     /// Create a new streaming session.
     ///
-    /// For archives larger than `DISK_THRESHOLD` (10MB), the data is stored
+    /// For archives larger than `DISK_THRESHOLD` (10 MiB), the data is stored
     /// in a temp file instead of memory to reduce memory pressure.
     ///
     /// # Errors

--- a/src/streaming/tar.rs
+++ b/src/streaming/tar.rs
@@ -212,7 +212,7 @@ pub struct TarResult {
 /// - The commit cannot be found
 /// - The tree cannot be retrieved
 /// - The tree walk fails
-/// - The tar archive cannot be finalized
+/// - The tar archive cannot be finalised
 ///
 /// # Memory
 ///
@@ -249,7 +249,7 @@ pub fn create_tar_from_tree(repo: &Repository, commit_id: Oid) -> Result<TarResu
 /// - The commit cannot be found
 /// - The tree cannot be retrieved
 /// - The tree walk fails
-/// - The tar archive cannot be finalized
+/// - The tar archive cannot be finalised
 #[allow(clippy::too_many_lines)] // Tree walk + tar creation is naturally verbose
 pub fn create_tar_from_tree_with_options(
     repo: &Repository,

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -9,10 +9,15 @@ Requires:
     - TEST_REPO_URL environment variable (private test fixture repo)
     - git credentials configured (for private repo access)
 
-Test fixture repo (git-proxy-mcp-test-dummy) has:
-    - 2 commits, 2 tags (v0.1.0, v0.2.0)
-    - 5 files: README.md, src/main.rs, src/lib.rs, docs/DESIGN.md, docs/pixel.png
-    - v0.1.0 -> v0.2.0 diff: 2 files changed (src/lib.rs, docs/DESIGN.md)
+Test fixture repo (git-proxy-mcp-test-dummy) layout - see
+`tests/integration/rebuild_fixture.py` for the canonical source:
+
+    - 5 commits, 2 tags (v0.1.0 = commit 1, v0.2.0 = commit 2)
+    - Commit 3 adds 40+ generated data files
+    - Commit 4 renames `docs/DESIGN.md` -> `docs/ARCHITECTURE.md`
+    - Commit 5 adds an LFS-tracked binary `docs/large.bin`
+      (via `*.bin filter=lfs` in `.gitattributes`)
+    - 45+ source files + 1 submodule total
 """
 
 import base64

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -6,8 +6,8 @@
 //!
 //! - URL sanitisation (must never leak credentials regardless of input shape)
 //! - URL validation (rejects/accepts must be consistent)
-//! - LFS pointer detection (heuristic must not panic on adversarial bytes)
-//! - `.gitmodules` parsing (must not panic on garbage input)
+//! - LFS pointer detection and parsing (must not panic on adversarial bytes,
+//!   must round-trip well-formed inputs)
 
 use git_proxy_mcp::git2_ops::auth::{sanitize_url_for_logging, validate_url};
 use git_proxy_mcp::git2_ops::lfs::{is_lfs_pointer, parse_lfs_pointer};


### PR DESCRIPTION
## Description

Eleven-pass audit of every documentation file, embedded code sample, and rustdoc comment, cross-checked against the actual codebase. Caught **50 distinct issues**, including **2 real functional bugs** that an AI assistant would actually trip over.

The two bugs are isolated in their own commits; everything else is documentation-only. Branch contains 8 commits to keep the per-commit history reviewable.

## Related Issue

N/A — proactive audit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

**Note on `Git2Error::InitFailed` Display string.** The British-spelling sweep changes the user-visible error string from `failed to initialize repository` to `failed to initialise repository`. Error message text is not part of the API contract, but downstream code that string-matches on the literal would need updating. The unit test asserting the literal string was updated; no other test or doc references it.

## Security Checklist ⚠️

Since this is a credential-handling project:

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`)
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
  - `helper_script_uses_correct_repo_pull_archive_field` — pins the script to `files_archive` (never `changed_files_archive`)
  - `helper_script_show_info_uses_real_commit_field_names` — pins the script to `base_commit` / `head_commit` (never `old_commit`)
- [x] New and existing tests pass (`cargo test --all-features --workspace`) — **510 unit tests** + 1 doc-test + 20 mcp_integration + 9 perf + 11 property + 11 security + 31 streaming, all green

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"` — 0 errors)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] Documentation is updated if needed
- [x] CHANGELOG.md is updated for user-facing changes

## Screenshots / Logs

N/A — no UI changes. Runtime behaviour changes are limited to:

1. `repo_clone` / `repo_clone_start` without an explicit `branch` argument now queries the remote's `HEAD` symref via `Remote::default_branch()` and fetches that, instead of always trying `refs/heads/main`. Repos with `master`, `develop`, or any renamed default now work without an explicit `branch` arg.
2. The Python helper script's `extract` / `info` subcommands now actually work on `repo_pull` results (was failing with `ValueError: No archive found in result` because of a wrong field name).
3. `Git2Error::InitFailed`'s `Display` string changed spelling to British (see Type of Change note).

## Additional Notes

### The two functional bugs

1. **`helper_script` (`src/mcp/tools/helper_script.rs`)** — the embedded `git_proxy_helper.py` script's `extract` and `info` commands looked up `data.get('changed_files_archive')`, but the actual `RepoPullResult` field has always been `files_archive`. Any AI that fed a `repo_pull` result through the helper hit `ValueError: No archive found in result` and fell back to manual base64+tar handling. Also fixed `old_commit` (a key no MCP tool ever returned) to `base_commit` / `head_commit` in `show_info`.

2. **`fetch_bare` (`src/git2_ops/clone.rs`)** — fell back to `unwrap_or("main")` when no branch was specified, despite the schema description and rustdoc both promising "remote's default branch" since v1.1.0. Now uses `Remote::default_branch()` over the same connection that the fetch will reuse, so there's no extra round-trip when the AI passes an explicit branch (the common case) and the right thing happens when it doesn't (the broken case).

### Commit map

| Commit | Pass | Highlight |
|--------|------|-----------|
| `8a5636e` | 1 | `fix(helper_script)`: Python field-name bug + 1st regression test |
| `791c292` | 1–5 | First-pass docs sweep (33 distinct issues) |
| `293ae09` | 6 | British-spelling sweep across rustdoc + audit-log signature fix |
| `7fd6bd3` | 7 | AI workflow git-identity step + stale fixture docstring |
| `6152c8d` | 8 | `audit.rs` Log Format + `lfs.rs` scheme claim + small fixes |
| `56398e1` | 9 | AI workflow Tier 2 tip + helper_script docstring/info symmetry |
| `ea3a755` | 10 | `fix(clone)`: remote default branch instead of hard-coded `"main"` |
| `14a0256` | 11 | `protected_branches` default + `property_tests` coverage claims |

### Self-review

Pass 11 caught a regression I'd introduced in pass 5 (`protected_branches` default description), so I'd specifically appreciate a careful reviewer eye on the docs/code-as-text claims rather than treating my own internal review as authoritative.