### PR TITLE
config: cross-reference audit (settings.rs ↔ JSON ↔ README)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Config-drift audit** — comprehensive cross-reference of every config
+  option across `src/config/settings.rs` (canonical), `config/example-config.json`
+  (full reference), and the README configuration table. All 26
+  user-configurable options checked: defaults match exactly across all
+  three sources, no ghost entries, no type/unit mismatches. Two cosmetic
+  alignments applied:
+  1. **`Config` struct field order** rearranged to match the user-facing
+     order in `example-config.json` and the README (`git_identity`
+     first, then `security`, `logging`, ..., `submodules`). Field names
+     drive serde deserialisation, so order is purely cosmetic — but a
+     reader with the README open now sees the source laid out the same
+     way.
+  2. **Six terse field rustdocs brought up to README detail.** The most
+     material gap was `SecurityConfig.protected_branches`: its rustdoc
+     said only "List of protected branch names." with no mention of the
+     empty-list-fallback behaviour (`McpServer::new` substitutes
+     `BranchGuard::with_defaults()` → `main`/`master`/`develop` when the
+     config list is empty). PR #150 documented this in the README,
+     `docs/errors.md`, and `BranchGuard::with_defaults` rustdoc but
+     didn't update the field that triggers the behaviour, so
+     `cargo doc --document-private-items` (which CI publishes) showed
+     less detail on this field than every other user-facing source.
+     Same treatment applied to the five sibling fields (`allow_force_push`,
+     `repo_allowlist`, `repo_blocklist`, `level`, `audit_log_path`),
+     bringing them in line with the already-detailed rustdocs on
+     `TimeoutConfig`, `LimitsConfig`, `RateLimitConfig`, `SessionConfig`,
+     `LfsConfig`, `SubmoduleConfig`, and `ProxyConfig`.
 - **CI/CD audit sweep** — comprehensive pass across every workflow and
   helper script in `.github/`, fixing one real cache bug and a handful
   of hardening/hygiene issues:

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -95,18 +95,41 @@ impl Config {
 #[serde(deny_unknown_fields)]
 pub struct SecurityConfig {
     /// Whether to allow force pushes.
+    ///
+    /// Default: `false`. When `false`, `--force` / `-f` /
+    /// `--force-with-lease` pushes are rejected by `PushGuard::check`.
     #[serde(default)]
     pub allow_force_push: bool,
 
     /// List of protected branch names.
+    ///
+    /// Branches in this list block force-push and deletion attempts.
+    /// Wildcard patterns (e.g. `release/*`) are supported by the matcher.
+    ///
+    /// Default: empty list, which `McpServer::new` treats as "use the
+    /// built-in safe set" — `BranchGuard::with_defaults()` substitutes
+    /// `main`, `master`, `develop`. Setting any non-empty list overrides
+    /// the fallback (so `["main"]` protects only `main`, not also
+    /// `master`/`develop`).
     #[serde(default)]
     pub protected_branches: Vec<String>,
 
     /// Optional allowlist of repository patterns.
+    ///
+    /// If `Some`, only repository URLs matching at least one pattern are
+    /// allowed (allowlist mode). If `None`, allowlist mode is disabled
+    /// and any URL not on the blocklist is allowed.
+    ///
+    /// Default: `None` (allowlist mode disabled).
     #[serde(default)]
     pub repo_allowlist: Option<Vec<String>>,
 
     /// Optional blocklist of repository patterns.
+    ///
+    /// If `Some`, repository URLs matching any pattern are rejected
+    /// (blocklist mode). Takes precedence over the allowlist.
+    ///
+    /// Default: `None` (no blocklist).
     #[serde(default)]
     pub repo_blocklist: Option<Vec<String>>,
 }
@@ -115,11 +138,20 @@ pub struct SecurityConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct LoggingConfig {
-    /// Log level (trace, debug, info, warn, error).
+    /// Log level: one of `trace`, `debug`, `info`, `warn`, `error`.
+    ///
+    /// Default: `"warn"` — only warnings and errors are emitted, keeping
+    /// the JSON-RPC channel quiet for normal operation.
     #[serde(default = "default_log_level")]
     pub level: String,
 
     /// Optional path to audit log file.
+    ///
+    /// When set, every Git operation, security-guard decision, and
+    /// rate-limit event is appended to this file as a JSON line —
+    /// see `src/security/audit.rs` for the schema.
+    ///
+    /// Default: `None` (audit logging disabled).
     #[serde(default)]
     pub audit_log_path: Option<PathBuf>,
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -32,6 +32,14 @@ pub struct Config {
     #[serde(rename = "_note", default)]
     _note: Option<String>,
 
+    // Field order matches the user-facing layout in `config/example-config.json`
+    // and the README configuration table, so a reader who has the JSON file or
+    // the README open sees the struct laid out the same way. Serde keys on
+    // field NAMES (not positions), so reordering doesn't affect deserialisation.
+    /// Git identity settings for AI-assisted commits.
+    #[serde(default)]
+    pub git_identity: GitIdentityConfig,
+
     /// Security settings.
     #[serde(default)]
     pub security: SecurityConfig,
@@ -51,10 +59,6 @@ pub struct Config {
     /// Rate limiting settings.
     #[serde(default)]
     pub rate_limits: RateLimitConfig,
-
-    /// Git identity settings for AI-assisted commits.
-    #[serde(default)]
-    pub git_identity: GitIdentityConfig,
 
     /// Proxy settings for network connections.
     #[serde(default)]


### PR DESCRIPTION
## Summary

Comprehensive cross-reference of every configuration option across the
three sources of truth:

- `src/config/settings.rs` (canonical)
- `config/example-config.json` (full-reference example)
- `README.md` configuration table (user docs)

**All 26 user-configurable options checked.** Defaults match exactly
across all three sources, no ghost entries, no type/unit mismatches —
the previous PR #150 sweep was thorough. Two cosmetic alignments
applied; no functional behaviour change.

## Related Issue

N/A — proactive audit.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (rustdoc)
- [x] Refactoring (no functional changes — struct field reorder)
- [ ] CI/CD changes
- [ ] Security improvement

## Security Checklist

- [x] No credentials, tokens, or secrets in code, comments, or tests
- [x] No new credential flows introduced
- [x] No changes to security guards, audit logging, or threat model

## Testing

- [x] `cargo fmt --all --check` (clean — caught one rustfmt blank-line issue mid-PR; fixed via fixup+autosquash before push)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo test --all-features --workspace` (515 unit + 83 other = 598 tests, all green)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` (clean)
- [x] `markdownlint-cli2 "**/*.md"` (12 files, 0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh` (pin consistent)
- [x] All 39 config-module tests still pass after struct reorder (test JSON is order-independent)

## Code Quality

- [x] Code compiles without warnings
- [x] Clippy passes
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean
- [x] Toolchain pin is consistent
- [x] CHANGELOG.md updated (`[Unreleased]` § Changed)
- [x] STYLE.md and CONTRIBUTING.md conventions followed (British spelling,
      conventional commits, 4-space indentation)

## Audit Findings

**Verified clean (no drift):**

- All 26 options in `settings.rs` are present in `example-config.json`
- All 26 options are documented in README's config table
- All 26 default values match exactly across the three sources
- No ghost options (entries in JSON/README that don't exist in struct)
- No type/unit mismatches (e.g. `max_object_size: u64` is consistently
  documented as bytes everywhere)
- README inline JSON snippet uses valid options only (it's truncated for
  readability and explicitly points to `config/example-config.json` for
  the full reference)

**Drift fixed (2 items, both cosmetic):**

1. **Section ordering inconsistency.** The `Config` struct in
   `settings.rs` listed fields as `security, logging, timeouts, limits,
   rate_limits, git_identity, proxy, sessions, lfs, submodules` — but
   `example-config.json`, the README inline snippet, and the README
   table all order as `git_identity, security, logging, ...`. Reordered
   the struct to match. Field names drive serde deserialisation, so
   order is purely cosmetic, but a reader with the README open now sees
   the source laid out the same way.

2. **`SecurityConfig.protected_branches` rustdoc was outdated.** Said
   only `"List of protected branch names."` with no mention of the
   empty-list-fallback behaviour (`McpServer::new` substitutes
   `BranchGuard::with_defaults()` → `main`/`master`/`develop` when the
   config list is empty). PR #150 documented this in the README,
   `docs/errors.md`, and `BranchGuard::with_defaults` rustdoc but
   didn't update the field that triggers it. `cargo doc
   --document-private-items` (which CI publishes) consequently showed
   less detail on this field than every other user-facing source.
   Brought five sibling fields up to the same level while there:
   `allow_force_push`, `repo_allowlist`, `repo_blocklist`, `level`,
   `audit_log_path` — they were similarly terse next to the
   already-detailed rustdocs on TimeoutConfig, LimitsConfig,
   RateLimitConfig, SessionConfig, LfsConfig, SubmoduleConfig, and
   ProxyConfig.

## Commit Map

| Commit | Category | What |
|--------|----------|------|
| `85c3fc6` | refactor | Reorder `Config` struct fields to match user-facing order (`git_identity` first); add comment explaining serde-keys-on-names rationale. Includes one rustfmt blank-line fix folded via fixup+autosquash. |
| `7cb44c1` | docs | Bring 6 terse `SecurityConfig`/`LoggingConfig` rustdocs up to README detail level (most materially `protected_branches`'s empty-list-fallback semantics). |
| `4ffceaf` | docs | CHANGELOG `[Unreleased]` § Changed entry. |

## Findings That Are NOT in This PR

- **`security.protected_branches: ["main", "master"]` in `example-config.json`**
  doesn't match the literal default (empty list). This is intentional and
  documented — PR #150's CHANGELOG entry explicitly notes "The shipped
  `config/example-config.json` recommends `["main", "master"]`." The
  example shows a recommended override, not the literal default; the
  README config table explains the empty-list-fallback semantics.

- **README inline JSON snippet truncates several sections** (omits
  `repo_allowlist`/`repo_blocklist`, only shows 2 of 6 LFS fields, etc.)
  This is intentional truncation for readability — the README explicitly
  points to `config/example-config.json` for the full reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)