### PR TITLE
fix(mcp): 3 real bugs + observability in server / protocol / audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP server observability for the `initialize` handshake and
+  ignored notifications.** Three previously-silent paths are now
+  traced:
+  1. **Connecting client identity is logged at INFO** —
+     `client_name`, `client_version`, and the requested
+     `client_protocol_version` from `clientInfo` (or a shorter "no
+     clientInfo" line when the field is absent, which the spec
+     allows). The handler had been parsing these fields into
+     `_params` only to discard them.
+  2. **Mismatched protocol version is logged at WARN** with both
+     `requested` and `supported` versions. Previously the handler
+     silently substituted our supported version with no trace,
+     making client-version drift impossible to diagnose from server
+     logs. Behaviour unchanged — we still accept and respond with
+     our version per spec, just with visibility now.
+  3. **Ignored notifications are traced at DEBUG** with method name
+     and current server state. Useful when the client thinks it sent
+     something we should have acted on (typically a state-machine
+     misalignment, e.g. sending a notification before `initialize`).
+  Two new tests cover the previously-uncovered initialize paths
+  (`handle_initialize_accepts_mismatched_protocol_version` and
+  `handle_initialize_accepts_missing_client_info`).
 - **`get_credentials_for_url` now traces each subprocess failure mode
   at debug level.** Previously, every error path
   (`spawn` fail, stdin write fail, wait fail, non-zero exit, non-UTF-8
@@ -200,6 +222,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Audit log misidentified blocked `repo_refs` / `repo_diff` /
+  `repo_pull` operations as `repo_clone`.** `call_repo_refs_tool`,
+  `call_repo_diff_tool`, and `call_repo_pull_tool` were all calling
+  `AuditEvent::repo_clone_blocked(...)` for their rate-limit and
+  filter-block events — so an operator searching the audit log for
+  blocked refs / diff / pull operations would find nothing (they all
+  showed as `event_type: "repo_clone"`). Added three new
+  `AuditEventType` variants (`RepoRefs`, `RepoDiff`, `RepoPull`)
+  and matching `repo_*_blocked` constructors, then updated the three
+  tool functions to use them. Three new audit-module tests cover
+  each constructor; one regression test pins that all three serialise
+  with their proper `event_type` field.
+- **Tier 2 `repo_clone_start` audit log always recorded
+  `file_count: 0`.** `call_repo_clone_start_tool` passed `0` to
+  `AuditEvent::repo_clone_success` with a comment claiming the count
+  was "not known until all chunks retrieved". That hasn't been true
+  since `RepoCloneStartResult` gained the `file_count` field — the
+  archive (and hence the file count) is fully built before the first
+  chunk goes out the door. Now passes `result.file_count`. Tier 1
+  (`repo_clone`) was logging the real count all along, so the bug
+  only affected Tier 2 audit entries.
+- **JSON-RPC `parse_message` discarded request `id` on
+  `InvalidRequest` errors when the rest of the request was malformed.**
+  Per JSON-RPC 2.0 spec, when the `id` field is well-typed but other
+  fields (jsonrpc version, method) are malformed, the error response
+  SHOULD echo the `id` so the client can correlate the failure to its
+  outstanding request. Three uncovered cases were dropping the ID:
+  missing `jsonrpc` field, wrong `jsonrpc` version, and `jsonrpc`
+  field of wrong type. Added a small `extract_request_id` helper that
+  pre-walks the JSON object and returns `Some(RequestId)` only for
+  spec-valid shapes (integer or string); `null`, arrays, objects, and
+  non-integer numbers correctly map to `None`. Eight new tests cover
+  ID-preservation across each discard case plus ID-drop for each
+  invalid shape.
 - **`sanitize_url_for_logging` mangled URLs with `@` outside the
   authority component.** The function found the FIRST `@` anywhere in
   the URL and treated everything between `://` and that `@` as

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -363,11 +363,32 @@ impl IncomingMessage {
     }
 }
 
+/// Extracts a `RequestId` from a raw JSON object's `id` field, if present
+/// and well-typed.
+///
+/// Per JSON-RPC 2.0 / MCP, the `id` field must be a string or integer;
+/// `null`, arrays, objects, and floats are not valid request IDs and
+/// `None` is returned for them. This is used by `parse_message` to
+/// preserve the ID across `Invalid Request` errors when the rest of
+/// the request is malformed but the ID is still legible.
+fn extract_request_id(obj: &serde_json::Map<String, Value>) -> Option<RequestId> {
+    match obj.get("id")? {
+        Value::Number(n) => n.as_i64().map(RequestId::Number),
+        Value::String(s) => Some(RequestId::String(s.clone())),
+        // `null`, arrays, objects, and non-integer numbers are not
+        // valid IDs — drop them rather than guess.
+        _ => None,
+    }
+}
+
 /// Parses a JSON string into an incoming message.
 ///
 /// # Errors
 ///
 /// Returns a `JsonRpcError` if the JSON is malformed or not a valid message.
+/// When the `id` field is present and well-typed in the input, it is
+/// preserved on the returned error so the client can correlate the
+/// failure to its outstanding request.
 pub fn parse_message(json: &str) -> Result<IncomingMessage, JsonRpcError> {
     // First, try to parse as generic JSON to check structure
     let value: Value = serde_json::from_str(json).map_err(|_| JsonRpcError::parse_error())?;
@@ -375,21 +396,25 @@ pub fn parse_message(json: &str) -> Result<IncomingMessage, JsonRpcError> {
     // Check if it's an object
     let obj = value.as_object().ok_or_else(JsonRpcError::parse_error)?;
 
+    // Pre-extract the ID so we can echo it back on `Invalid Request`
+    // errors even when other fields (jsonrpc, method) are malformed.
+    let extracted_id = extract_request_id(obj);
+
     // Check for jsonrpc field
     let jsonrpc = obj
         .get("jsonrpc")
         .and_then(Value::as_str)
-        .ok_or_else(|| JsonRpcError::invalid_request(None))?;
+        .ok_or_else(|| JsonRpcError::invalid_request(extracted_id.clone()))?;
 
     if jsonrpc != "2.0" {
-        return Err(JsonRpcError::invalid_request(None));
+        return Err(JsonRpcError::invalid_request(extracted_id));
     }
 
     // Check if this is a request (has id) or notification (no id)
     if obj.contains_key("id") {
         // This is a request
-        let request: JsonRpcRequest =
-            serde_json::from_value(value).map_err(|_| JsonRpcError::invalid_request(None))?;
+        let request: JsonRpcRequest = serde_json::from_value(value)
+            .map_err(|_| JsonRpcError::invalid_request(extracted_id.clone()))?;
 
         if request.validate().is_some() {
             return Err(JsonRpcError::invalid_request(Some(request.id)));
@@ -726,6 +751,95 @@ mod tests {
         let err = JsonRpcErrorData::from_code(ErrorCode::ParseError);
         let json = serde_json::to_string(&err).unwrap();
         assert!(!json.contains("\"data\""));
+    }
+
+    #[test]
+    fn parse_message_preserves_id_on_missing_jsonrpc_field() {
+        // Regression: the error must echo the request `id` so the client
+        // can correlate the failure to its outstanding request. Previously
+        // we returned `id: None` here, which broke client-side promise
+        // resolution under strict JSON-RPC clients.
+        let json = r#"{"id": 42, "method": "test"}"#;
+        let err = parse_message(json).unwrap_err();
+        assert_eq!(err.error.code, ErrorCode::InvalidRequest.code());
+        assert_eq!(err.id, Some(RequestId::Number(42)));
+    }
+
+    #[test]
+    fn parse_message_preserves_id_on_wrong_jsonrpc_version() {
+        let json = r#"{"jsonrpc": "1.0", "id": "abc-123", "method": "test"}"#;
+        let err = parse_message(json).unwrap_err();
+        assert_eq!(err.error.code, ErrorCode::InvalidRequest.code());
+        assert_eq!(err.id, Some(RequestId::String("abc-123".to_string())));
+    }
+
+    #[test]
+    fn parse_message_preserves_id_on_jsonrpc_not_string() {
+        let json = r#"{"jsonrpc": 2.0, "id": 7, "method": "test"}"#;
+        let err = parse_message(json).unwrap_err();
+        assert_eq!(err.error.code, ErrorCode::InvalidRequest.code());
+        assert_eq!(err.id, Some(RequestId::Number(7)));
+    }
+
+    #[test]
+    fn parse_message_drops_id_when_id_is_null() {
+        // `null` is not a valid request ID (per JSON-RPC spec) — drop it
+        // rather than return `RequestId::Number(0)` or similar.
+        let json = r#"{"jsonrpc": "2.0", "id": null, "method": "x"}"#;
+        let err = parse_message(json).unwrap_err();
+        assert_eq!(err.error.code, ErrorCode::InvalidRequest.code());
+        assert!(err.id.is_none());
+    }
+
+    #[test]
+    fn parse_message_drops_id_when_id_is_array() {
+        // Arrays are not valid request IDs.
+        let json = r#"{"jsonrpc": "1.0", "id": [1, 2, 3], "method": "test"}"#;
+        let err = parse_message(json).unwrap_err();
+        assert_eq!(err.error.code, ErrorCode::InvalidRequest.code());
+        assert!(err.id.is_none());
+    }
+
+    #[test]
+    fn parse_message_drops_id_when_id_is_object() {
+        let json = r#"{"jsonrpc": "1.0", "id": {"x": 1}, "method": "test"}"#;
+        let err = parse_message(json).unwrap_err();
+        assert_eq!(err.error.code, ErrorCode::InvalidRequest.code());
+        assert!(err.id.is_none());
+    }
+
+    #[test]
+    fn parse_message_drops_id_when_id_is_float() {
+        // JSON-RPC IDs must be integers — non-integer numbers don't fit
+        // the `RequestId::Number(i64)` variant.
+        let json = r#"{"jsonrpc": "1.0", "id": 3.14, "method": "test"}"#;
+        let err = parse_message(json).unwrap_err();
+        assert_eq!(err.error.code, ErrorCode::InvalidRequest.code());
+        assert!(err.id.is_none());
+    }
+
+    #[test]
+    fn extract_request_id_handles_all_supported_shapes() {
+        let mut obj = serde_json::Map::new();
+
+        // Number
+        obj.insert("id".to_string(), serde_json::json!(123));
+        assert_eq!(extract_request_id(&obj), Some(RequestId::Number(123)));
+
+        // String
+        obj.insert("id".to_string(), serde_json::json!("hello"));
+        assert_eq!(
+            extract_request_id(&obj),
+            Some(RequestId::String("hello".to_string()))
+        );
+
+        // Null → None
+        obj.insert("id".to_string(), Value::Null);
+        assert_eq!(extract_request_id(&obj), None);
+
+        // Missing → None
+        obj.remove("id");
+        assert_eq!(extract_request_id(&obj), None);
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1330,11 +1330,10 @@ impl McpServer {
 
         // Check rate limiter
         if !self.rate_limiter.try_acquire() {
-            self.audit_logger
-                .log_silent(&AuditEvent::repo_clone_blocked(
-                    &sanitized_url,
-                    "rate limit exceeded",
-                ));
+            self.audit_logger.log_silent(&AuditEvent::repo_refs_blocked(
+                &sanitized_url,
+                "rate limit exceeded",
+            ));
             return ToolCallResult::error(
                 "Rate limit exceeded. Please wait before sending more requests.",
             );
@@ -1347,7 +1346,7 @@ impl McpServer {
             .reason()
         {
             self.audit_logger
-                .log_silent(&AuditEvent::repo_clone_blocked(&sanitized_url, reason));
+                .log_silent(&AuditEvent::repo_refs_blocked(&sanitized_url, reason));
             return ToolCallResult::error(reason.to_string());
         }
 
@@ -1400,11 +1399,10 @@ impl McpServer {
 
         // Check rate limiter
         if !self.rate_limiter.try_acquire() {
-            self.audit_logger
-                .log_silent(&AuditEvent::repo_clone_blocked(
-                    &sanitized_url,
-                    "rate limit exceeded",
-                ));
+            self.audit_logger.log_silent(&AuditEvent::repo_diff_blocked(
+                &sanitized_url,
+                "rate limit exceeded",
+            ));
             return ToolCallResult::error(
                 "Rate limit exceeded. Please wait before sending more requests.",
             );
@@ -1417,7 +1415,7 @@ impl McpServer {
             .reason()
         {
             self.audit_logger
-                .log_silent(&AuditEvent::repo_clone_blocked(&sanitized_url, reason));
+                .log_silent(&AuditEvent::repo_diff_blocked(&sanitized_url, reason));
             return ToolCallResult::error(reason.to_string());
         }
 
@@ -1470,11 +1468,10 @@ impl McpServer {
 
         // Check rate limiter
         if !self.rate_limiter.try_acquire() {
-            self.audit_logger
-                .log_silent(&AuditEvent::repo_clone_blocked(
-                    &sanitized_url,
-                    "rate limit exceeded",
-                ));
+            self.audit_logger.log_silent(&AuditEvent::repo_pull_blocked(
+                &sanitized_url,
+                "rate limit exceeded",
+            ));
             return ToolCallResult::error(
                 "Rate limit exceeded. Please wait before sending more requests.",
             );
@@ -1487,7 +1484,7 @@ impl McpServer {
             .reason()
         {
             self.audit_logger
-                .log_silent(&AuditEvent::repo_clone_blocked(&sanitized_url, reason));
+                .log_silent(&AuditEvent::repo_pull_blocked(&sanitized_url, reason));
             return ToolCallResult::error(reason.to_string());
         }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1211,7 +1211,12 @@ impl McpServer {
                         &sanitized_url,
                         &result.branch,
                         &result.commit,
-                        0, // file_count not known until all chunks retrieved
+                        // `RepoCloneStartResult` carries `file_count` as soon
+                        // as the archive is built (which is before any chunks
+                        // are retrieved) — log it here rather than the
+                        // hard-coded 0 the previous comment claimed was
+                        // unavoidable.
+                        result.file_count,
                         result.total_size,
                         duration,
                     ));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -252,6 +252,39 @@ impl GitIdentity {
     }
 }
 
+/// Maximum length (in bytes) for a client-controlled string before we
+/// truncate it for logging. Anything beyond this is replaced with `…`.
+/// 200 bytes is enough to be useful for debugging and small enough
+/// that a hostile or buggy client can't flood the log file with a
+/// huge `clientInfo.name`.
+const MAX_CLIENT_STRING_LOG_LEN: usize = 200;
+
+/// Sanitises a client-controlled string for safe logging.
+///
+/// Two protections, both targeting buggy or hostile clients (the local
+/// stdio peer):
+///
+/// - Control characters (newlines, ANSI escape sequences, NULs, etc.)
+///   are escaped via `char::escape_debug`, so a value like
+///   `"foo\x1b[31mEVIL\x1b[0m"` renders as the literal characters
+///   rather than disrupting the operator's terminal log reader.
+/// - Length is capped at `MAX_CLIENT_STRING_LOG_LEN` bytes to prevent
+///   a 1-MiB name from flooding the log file. Truncation appends `…`
+///   so the operator can see the value was cut.
+fn sanitize_for_log(s: &str) -> String {
+    let mut escaped: String = s.chars().flat_map(char::escape_debug).collect();
+    if escaped.len() > MAX_CLIENT_STRING_LOG_LEN {
+        // Truncate at a char boundary so we don't slice mid-codepoint.
+        let mut cut = MAX_CLIENT_STRING_LOG_LEN;
+        while !escaped.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        escaped.truncate(cut);
+        escaped.push('…');
+    }
+    escaped
+}
+
 /// The MCP server.
 pub struct McpServer {
     /// Current server state.
@@ -554,6 +587,12 @@ impl McpServer {
                 JsonRpcError::invalid_params(req.id.clone(), "Missing initialize params")
             })?;
 
+        // Sanitise the client-controlled values we're about to log:
+        // escape control chars / ANSI escapes (so a buggy or hostile
+        // client can't disrupt log readers) and cap the length (so a
+        // 1-MiB name can't flood the log file).
+        let safe_proto = sanitize_for_log(&params.protocol_version);
+
         // Log the connecting client's identity for diagnostic visibility.
         // The MCP spec says client_info is optional, so handle the absent
         // case gracefully. Single-line macro form so cargo-llvm-cov
@@ -561,10 +600,12 @@ impl McpServer {
         // doesn't enable INFO-level logging (`tracing` doesn't evaluate
         // macro args when the level is below threshold).
         if let Some(client_info) = params.client_info.as_ref() {
-            let client_version = client_info.version.as_deref().unwrap_or("(unspecified)");
-            tracing::info!(client_name = %client_info.name, client_version = client_version, client_protocol_version = %params.protocol_version, "client connected");
+            let safe_name = sanitize_for_log(&client_info.name);
+            let safe_version =
+                sanitize_for_log(client_info.version.as_deref().unwrap_or("(unspecified)"));
+            tracing::info!(client_name = %safe_name, client_version = %safe_version, client_protocol_version = %safe_proto, "client connected");
         } else {
-            tracing::info!(client_protocol_version = %params.protocol_version, "client connected (no clientInfo)");
+            tracing::info!(client_protocol_version = %safe_proto, "client connected (no clientInfo)");
         }
 
         // Protocol version: per the MCP spec, we MUST respond with a
@@ -576,7 +617,7 @@ impl McpServer {
         // disconnect (if it strictly requires its requested version).
         if params.protocol_version != MCP_PROTOCOL_VERSION {
             tracing::warn!(
-                requested = %params.protocol_version,
+                requested = %safe_proto,
                 supported = MCP_PROTOCOL_VERSION,
                 "client requested unsupported MCP protocol version; \
                  responding with our supported version"
@@ -1740,6 +1781,62 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_for_log_passes_clean_strings_unchanged() {
+        assert_eq!(sanitize_for_log("Claude AI"), "Claude AI");
+        assert_eq!(sanitize_for_log(""), "");
+        assert_eq!(sanitize_for_log("v1.2.3-rc.1"), "v1.2.3-rc.1");
+    }
+
+    #[test]
+    fn sanitize_for_log_escapes_control_characters() {
+        // ANSI escape sequence — raw ESC must not pass through, or it
+        // could repaint the operator's terminal (and fake "harmless"
+        // log lines around an injected message).
+        let evil = "foo\x1b[31mEVIL\x1b[0m";
+        let sanitised = sanitize_for_log(evil);
+        assert!(!sanitised.contains('\x1b'), "raw ESC must be escaped");
+        // `char::escape_debug` renders `\x1b` as `\u{1b}`.
+        assert!(sanitised.contains("\\u{1b}"));
+
+        // Newline — must be escaped so it doesn't fake a log-line break.
+        assert_eq!(sanitize_for_log("a\nb"), "a\\nb");
+
+        // Tab and CR.
+        assert_eq!(sanitize_for_log("a\tb\rc"), "a\\tb\\rc");
+
+        // NUL — `escape_debug` uses the short form `\0` for NUL.
+        assert_eq!(sanitize_for_log("a\0b"), "a\\0b");
+    }
+
+    #[test]
+    fn sanitize_for_log_caps_length_to_prevent_log_flood() {
+        // 1 KiB of `a` — must be truncated.
+        let huge = "a".repeat(1024);
+        let sanitised = sanitize_for_log(&huge);
+        assert!(sanitised.len() <= MAX_CLIENT_STRING_LOG_LEN + "…".len());
+        assert!(
+            sanitised.ends_with('…'),
+            "truncation marker must be appended"
+        );
+    }
+
+    #[test]
+    fn sanitize_for_log_truncates_at_char_boundary() {
+        // String with multibyte chars right around the truncation point.
+        // `é` is 2 bytes in UTF-8. If MAX_CLIENT_STRING_LOG_LEN landed
+        // mid-codepoint we'd panic on `escaped.truncate(cut)` — this
+        // test pins the boundary-search loop.
+        let s = "é".repeat(150); // 300 bytes
+        let sanitised = sanitize_for_log(&s);
+        assert!(sanitised.ends_with('…'));
+        // Verify we didn't break a codepoint — the prefix before the
+        // truncation marker must be valid UTF-8 (it is by construction
+        // since `escaped` is a String, but assert it's well-formed anyway).
+        let prefix = &sanitised[..sanitised.len() - "…".len()];
+        assert!(prefix.is_char_boundary(prefix.len()));
+    }
+
+    #[test]
     fn handle_initialize_accepts_mismatched_protocol_version() {
         // The spec says we MUST respond with a version we support. A
         // client requesting an unsupported version still gets a
@@ -1962,6 +2059,27 @@ mod tests {
     }
 
     #[test]
+    fn handle_notification_initialized_in_running_state_is_ignored() {
+        // Sending `notifications/initialized` again after the server is
+        // already in `Running` (e.g. a duplicate or out-of-order notif
+        // from a buggy client) must be a no-op state-wise. The method
+        // matches but the state guard fails, so the new debug! trace
+        // for "ignoring notification" fires and state stays `Running`.
+        // Pins the combinatorial case (right method, wrong state).
+        let mut server = create_test_server();
+        initialise_server(&mut server);
+        assert_eq!(server.state(), ServerState::Running);
+
+        let notif = JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: "notifications/initialized".to_string(),
+            params: None,
+        };
+        server.handle_notification(&notif);
+        assert_eq!(server.state(), ServerState::Running);
+    }
+
+    #[test]
     fn handle_notification_unknown_method_ignored() {
         let mut server = create_test_server();
         initialise_server(&mut server);
@@ -2159,8 +2277,24 @@ mod tests {
             SubmoduleConfig::default(),
         );
         initialise_server(&mut server);
-        // First call: not blocked by rate limit, but `repo_refs` itself
-        // will fail (no real network). The point is to consume the token.
+        // First call: consumes the bucket's only token.
+        //
+        // The dispatch order in every `call_repo_*_tool` is: parse args
+        // → sanitise URL → `try_acquire()` → repo-filter check →
+        // execute. The token is consumed in `try_acquire()` BEFORE
+        // any actual network operation, so even when the underlying
+        // `handle_repo_refs` fails, the bucket has already been
+        // drained.
+        //
+        // We use `.invalid` (RFC 6761 reserved TLD — guaranteed never
+        // to resolve in DNS) so the failed network attempt completes
+        // in milliseconds rather than waiting for a TCP timeout. CI
+        // runners and developer machines all fail-fast here. (Same
+        // pattern as the auth.rs e2e test from PR #153.)
+        //
+        // We deliberately don't assert on the first call's outcome —
+        // it returns an error, but the test only cares that the token
+        // got consumed.
         let _ = server.call_repo_refs_tool(&json!({
             "url": "https://nonexistent-rate-limit-test.invalid/repo.git",
         }));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -513,8 +513,16 @@ impl McpServer {
     fn handle_notification(&mut self, notif: &JsonRpcNotification) {
         if notif.method == "notifications/initialized" && self.state == ServerState::Initialising {
             self.state = ServerState::Running;
+            return;
         }
-        // All other notifications (including unknown ones) are ignored per JSON-RPC spec
+        // All other notifications (including unknown ones) are ignored per
+        // JSON-RPC spec, but trace them at debug level so an operator
+        // diagnosing protocol mismatches can see which methods were sent.
+        tracing::debug!(
+            method = %notif.method,
+            state = ?self.state,
+            "ignoring notification (unknown method or wrong state)"
+        );
     }
 
     /// Handles the `initialize` request.
@@ -531,7 +539,7 @@ impl McpServer {
         }
 
         // Parse initialise params
-        let _params: InitializeParams = req
+        let params: InitializeParams = req
             .params
             .as_ref()
             .map(|p| serde_json::from_value(p.clone()))
@@ -546,9 +554,34 @@ impl McpServer {
                 JsonRpcError::invalid_params(req.id.clone(), "Missing initialize params")
             })?;
 
-        // Check protocol version
-        // We currently only support one version, so we always return our version
-        // The client will disconnect if it doesn't support our version
+        // Log the connecting client's identity for diagnostic visibility.
+        // The MCP spec says client_info is optional, so handle the absent
+        // case gracefully. Single-line macro form so cargo-llvm-cov
+        // counts the call site as covered even when the test runner
+        // doesn't enable INFO-level logging (`tracing` doesn't evaluate
+        // macro args when the level is below threshold).
+        if let Some(client_info) = params.client_info.as_ref() {
+            let client_version = client_info.version.as_deref().unwrap_or("(unspecified)");
+            tracing::info!(client_name = %client_info.name, client_version = client_version, client_protocol_version = %params.protocol_version, "client connected");
+        } else {
+            tracing::info!(client_protocol_version = %params.protocol_version, "client connected (no clientInfo)");
+        }
+
+        // Protocol version: per the MCP spec, we MUST respond with a
+        // version we support. We currently only support one
+        // (`MCP_PROTOCOL_VERSION`), so we always return that. If the
+        // client requested a different version, log a warning so the
+        // operator can see the mismatch — the client may still proceed
+        // (the spec says it can reconcile by checking the response) or
+        // disconnect (if it strictly requires its requested version).
+        if params.protocol_version != MCP_PROTOCOL_VERSION {
+            tracing::warn!(
+                requested = %params.protocol_version,
+                supported = MCP_PROTOCOL_VERSION,
+                "client requested unsupported MCP protocol version; \
+                 responding with our supported version"
+            );
+        }
         let negotiated_version = MCP_PROTOCOL_VERSION.to_string();
 
         self.protocol_version = Some(negotiated_version.clone());
@@ -1707,6 +1740,48 @@ mod tests {
     }
 
     #[test]
+    fn handle_initialize_accepts_mismatched_protocol_version() {
+        // The spec says we MUST respond with a version we support. A
+        // client requesting an unsupported version still gets a
+        // successful response (with our version), accompanied by a
+        // warning log so the operator can see the mismatch. The state
+        // still advances to Initialising.
+        let mut server = create_test_server();
+        let req = make_request(
+            1,
+            "initialize",
+            Some(json!({
+                "protocolVersion": "2099-01-01",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1"},
+            })),
+        );
+        let resp = server.handle_initialize(&req).unwrap();
+        // We always respond with our version, regardless of what the
+        // client requested.
+        assert_eq!(resp.result["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert_eq!(server.state(), ServerState::Initialising);
+    }
+
+    #[test]
+    fn handle_initialize_accepts_missing_client_info() {
+        // `clientInfo` is optional per the spec — initialize must succeed
+        // and log via the "no clientInfo" path.
+        let mut server = create_test_server();
+        let req = make_request(
+            1,
+            "initialize",
+            Some(json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+            })),
+        );
+        let resp = server.handle_initialize(&req).unwrap();
+        assert_eq!(resp.result["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert_eq!(server.state(), ServerState::Initialising);
+    }
+
+    #[test]
     fn handle_initialize_includes_git_identity_when_set() {
         let security_config = SecurityConfig::default();
         let git_identity = GitIdentity {
@@ -2012,6 +2087,103 @@ mod tests {
         let result = McpServer::call_helper_script_tool();
         assert!(!result.is_error);
         assert_eq!(result.content.len(), 1);
+    }
+
+    #[test]
+    fn call_repo_diff_tool_with_blocked_url_returns_error() {
+        let security_config = SecurityConfig {
+            repo_blocklist: Some(vec!["github.com/blocked/*".to_string()]),
+            ..Default::default()
+        };
+        let mut server = McpServer::new(
+            security_config,
+            GitIdentity::default(),
+            AuditLogger::disabled(),
+            ProxyConfig::default(),
+            &SessionConfig::default(),
+            LfsConfig::default(),
+            SubmoduleConfig::default(),
+        );
+        initialise_server(&mut server);
+        let result = server.call_repo_diff_tool(&json!({
+            "url": "https://github.com/blocked/repo.git",
+            "base_commit": "abc",
+            "head_commit": "def",
+        }));
+        assert!(result.is_error);
+    }
+
+    #[test]
+    fn call_repo_pull_tool_with_blocked_url_returns_error() {
+        let security_config = SecurityConfig {
+            repo_blocklist: Some(vec!["github.com/blocked/*".to_string()]),
+            ..Default::default()
+        };
+        let mut server = McpServer::new(
+            security_config,
+            GitIdentity::default(),
+            AuditLogger::disabled(),
+            ProxyConfig::default(),
+            &SessionConfig::default(),
+            LfsConfig::default(),
+            SubmoduleConfig::default(),
+        );
+        initialise_server(&mut server);
+        let result = server.call_repo_pull_tool(&json!({
+            "url": "https://github.com/blocked/repo.git",
+            "branch": "main",
+            "since_commit": "abc123",
+        }));
+        assert!(result.is_error);
+    }
+
+    #[test]
+    fn rate_limit_exhaustion_blocks_subsequent_calls() {
+        // Configure a tiny rate limit (max_burst=1, refill=0) so the
+        // first call exhausts the bucket and subsequent calls are
+        // rejected with the rate-limit error message. This exercises
+        // the rate-limit branch in tool dispatch (refs/diff/pull all
+        // share the same shape).
+        let security_config = SecurityConfig {
+            rate_limit_max_burst: 1,
+            rate_limit_refill_rate: 0.0,
+            ..Default::default()
+        };
+        let mut server = McpServer::new(
+            security_config,
+            GitIdentity::default(),
+            AuditLogger::disabled(),
+            ProxyConfig::default(),
+            &SessionConfig::default(),
+            LfsConfig::default(),
+            SubmoduleConfig::default(),
+        );
+        initialise_server(&mut server);
+        // First call: not blocked by rate limit, but `repo_refs` itself
+        // will fail (no real network). The point is to consume the token.
+        let _ = server.call_repo_refs_tool(&json!({
+            "url": "https://nonexistent-rate-limit-test.invalid/repo.git",
+        }));
+        // Second call: bucket empty, must be blocked.
+        let result = server.call_repo_diff_tool(&json!({
+            "url": "https://nonexistent-rate-limit-test.invalid/repo.git",
+            "base_commit": "a",
+            "head_commit": "b",
+        }));
+        assert!(result.is_error);
+        // `ToolContent::Text` is the only variant — irrefutable pattern.
+        let ToolContent::Text { text } = &result.content[0];
+        assert!(
+            text.contains("Rate limit"),
+            "expected rate-limit error, got: {text}"
+        );
+        // Third call (pull): same bucket, still blocked.
+        let result = server.call_repo_pull_tool(&json!({
+            "url": "https://nonexistent-rate-limit-test.invalid/repo.git",
+            "branch": "main",
+            "since_commit": "abc",
+        }));
+        assert!(result.is_error);
     }
 
     #[test]

--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -24,8 +24,11 @@
 //! - `url` — repository URL, sanitised (for `repo_*` events)
 //! - `branch` — branch name (for `repo_clone` / `repo_push` events)
 //! - `commit` — commit SHA (for `repo_clone` / `repo_push` events)
-//! - `file_count` — number of files in archive (for `repo_clone` success)
-//! - `archive_size` — archive size in bytes (for `repo_clone` success)
+//! - `file_count` — number of files in archive. Populated for both
+//!   Tier 1 `repo_clone` and Tier 2 `repo_clone_start` success events
+//!   (both share `event_type: "repo_clone"`, since `repo_clone_start`
+//!   uses the same `repo_clone_success` constructor).
+//! - `archive_size` — archive size in bytes. Same scope as `file_count`.
 
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};

--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -10,7 +10,8 @@
 //!
 //! - `timestamp` — ISO 8601 timestamp (always present)
 //! - `event_type` — `command_executed`, `command_blocked`, `rate_limit_exceeded`,
-//!   `server_started`, `server_stopped`, `repo_clone`, or `repo_push`
+//!   `server_started`, `server_stopped`, `repo_clone`, `repo_push`, `repo_refs`,
+//!   `repo_diff`, or `repo_pull`
 //! - `outcome` — `success`, `failed`, or `blocked` (always present)
 //! - `command` — the git subcommand (for `command_*` events)
 //! - `args` — command arguments, sanitised (for `command_*` events)
@@ -20,9 +21,9 @@
 //! - `exit_code` — process exit code (for executed git commands)
 //! - `shutdown_reason` — `client_disconnected`, `sig_int`, or `sig_term`
 //!   (for `server_stopped` events)
-//! - `url` — repository URL, sanitised (for Tier 1 / `repo_*` events)
-//! - `branch` — branch name (for Tier 1 / `repo_*` events)
-//! - `commit` — commit SHA (for Tier 1 / `repo_*` events)
+//! - `url` — repository URL, sanitised (for `repo_*` events)
+//! - `branch` — branch name (for `repo_clone` / `repo_push` events)
+//! - `commit` — commit SHA (for `repo_clone` / `repo_push` events)
 //! - `file_count` — number of files in archive (for `repo_clone` success)
 //! - `archive_size` — archive size in bytes (for `repo_clone` success)
 
@@ -72,6 +73,15 @@ pub enum AuditEventType {
 
     /// Tier 1 `repo_push` operation.
     RepoPush,
+
+    /// `repo_refs` operation (list remote branches/tags).
+    RepoRefs,
+
+    /// `repo_diff` operation (diff between two commits).
+    RepoDiff,
+
+    /// `repo_pull` operation (incremental sync since a known commit).
+    RepoPull,
 }
 
 /// Reason for server shutdown.
@@ -325,6 +335,33 @@ impl AuditEvent {
     #[must_use]
     pub fn repo_push_blocked(url: impl Into<String>, reason: impl Into<String>) -> Self {
         let mut event = Self::new(AuditEventType::RepoPush, AuditOutcome::Blocked);
+        event.url = Some(url.into());
+        event.reason = Some(reason.into());
+        event
+    }
+
+    /// Creates an event for a blocked `repo_refs` operation.
+    #[must_use]
+    pub fn repo_refs_blocked(url: impl Into<String>, reason: impl Into<String>) -> Self {
+        let mut event = Self::new(AuditEventType::RepoRefs, AuditOutcome::Blocked);
+        event.url = Some(url.into());
+        event.reason = Some(reason.into());
+        event
+    }
+
+    /// Creates an event for a blocked `repo_diff` operation.
+    #[must_use]
+    pub fn repo_diff_blocked(url: impl Into<String>, reason: impl Into<String>) -> Self {
+        let mut event = Self::new(AuditEventType::RepoDiff, AuditOutcome::Blocked);
+        event.url = Some(url.into());
+        event.reason = Some(reason.into());
+        event
+    }
+
+    /// Creates an event for a blocked `repo_pull` operation.
+    #[must_use]
+    pub fn repo_pull_blocked(url: impl Into<String>, reason: impl Into<String>) -> Self {
+        let mut event = Self::new(AuditEventType::RepoPull, AuditOutcome::Blocked);
         event.url = Some(url.into());
         event.reason = Some(reason.into());
         event
@@ -774,6 +811,68 @@ mod tests {
             event.reason,
             Some("force push to protected branch".to_string())
         );
+    }
+
+    #[test]
+    fn audit_event_repo_refs_blocked() {
+        let event = AuditEvent::repo_refs_blocked(
+            "https://github.com/owner/repo.git",
+            "rate limit exceeded",
+        );
+
+        assert_eq!(event.event_type, AuditEventType::RepoRefs);
+        assert_eq!(event.outcome, AuditOutcome::Blocked);
+        assert_eq!(
+            event.url,
+            Some("https://github.com/owner/repo.git".to_string())
+        );
+        assert_eq!(event.reason, Some("rate limit exceeded".to_string()));
+    }
+
+    #[test]
+    fn audit_event_repo_diff_blocked() {
+        let event = AuditEvent::repo_diff_blocked(
+            "https://github.com/owner/repo.git",
+            "repository not in allowlist",
+        );
+
+        assert_eq!(event.event_type, AuditEventType::RepoDiff);
+        assert_eq!(event.outcome, AuditOutcome::Blocked);
+        assert_eq!(
+            event.reason,
+            Some("repository not in allowlist".to_string())
+        );
+    }
+
+    #[test]
+    fn audit_event_repo_pull_blocked() {
+        let event = AuditEvent::repo_pull_blocked(
+            "https://github.com/owner/repo.git",
+            "rate limit exceeded",
+        );
+
+        assert_eq!(event.event_type, AuditEventType::RepoPull);
+        assert_eq!(event.outcome, AuditOutcome::Blocked);
+        assert_eq!(event.reason, Some("rate limit exceeded".to_string()));
+    }
+
+    #[test]
+    fn audit_event_repo_refs_diff_pull_serialise_with_correct_event_type() {
+        // Regression: previously, blocked refs/diff/pull operations were
+        // logged with event_type=`repo_clone`, making audit-log filtering
+        // by operation type impossible.
+        let refs = AuditEvent::repo_refs_blocked("u", "r");
+        let diff = AuditEvent::repo_diff_blocked("u", "r");
+        let pull = AuditEvent::repo_pull_blocked("u", "r");
+        assert!(serde_json::to_string(&refs)
+            .unwrap()
+            .contains("\"event_type\":\"repo_refs\""));
+        assert!(serde_json::to_string(&diff)
+            .unwrap()
+            .contains("\"event_type\":\"repo_diff\""));
+        assert!(serde_json::to_string(&pull)
+            .unwrap()
+            .contains("\"event_type\":\"repo_pull\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Deep review of `src/mcp/server.rs` (2112 lines) and `src/mcp/protocol.rs`
(738 lines) — the JSON-RPC entry point that parses every untrusted client
message and routes every tool call. Found **3 real bugs**, plus 3
observability improvements. Five commits, each focused on a single
category.

This was the highest-leverage remaining un-audited area per the
progressive-audit cadence — and the audit found real bugs, not just
cosmetics.

## Related Issue

N/A — proactive audit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (rustdoc)
- [x] Refactoring (no functional changes — fmt cleanups folded via fixup)
- [ ] CI/CD changes
- [x] Security improvement (audit-log accuracy + protocol-spec compliance)

## Security Checklist

- [x] No credentials, tokens, or secrets in code, comments, or tests
- [x] No new credential flows introduced
- [x] Audit-event accuracy improved — three operation types
      (`repo_refs` / `repo_diff` / `repo_pull`) now correctly identified
      in the audit log instead of being conflated with `repo_clone`

## The Three Real Bugs

**1. Audit log misidentified blocked refs/diff/pull as repo_clone.**
`call_repo_refs_tool`, `call_repo_diff_tool`, and `call_repo_pull_tool`
were all calling `AuditEvent::repo_clone_blocked(...)` for their rate-limit
and filter-block events — so an operator searching the audit log for
blocked refs / diff / pull operations would find nothing (they all showed
as `event_type: "repo_clone"`). Fixed by adding three new `AuditEventType`
variants (`RepoRefs`, `RepoDiff`, `RepoPull`) and matching `repo_*_blocked`
constructors. **Audit-log accuracy regression** — operator-visible
post-incident analysis impact.

**2. Tier 2 `repo_clone_start` audit log always recorded `file_count: 0`.**
The handler passed a hard-coded `0` with a comment claiming the count
was "not known until all chunks retrieved". That hasn't been true since
`RepoCloneStartResult` gained the `file_count` field — the archive (and
hence the file count) is fully built before the first chunk goes out the
door. Tier 1 (`repo_clone`) was logging the real count all along, so the
bug only affected Tier 2 audit entries. **Audit-log accuracy regression**.

**3. JSON-RPC `parse_message` discarded request `id` on InvalidRequest
errors.** Per JSON-RPC 2.0 spec, when the `id` field is well-typed but
other fields are malformed, the error response SHOULD echo the `id`. We
were dropping it in three cases: missing `jsonrpc`, wrong `jsonrpc`
version, wrong `jsonrpc` field type. Strict JSON-RPC clients tracking
outstanding requests by ID couldn't correlate the failure. Fixed via a
small `extract_request_id` helper that pre-walks the JSON object and
returns `Some(RequestId)` only for spec-valid shapes (integer or string).
**Spec-deviation regression**.

## Observability Improvements

The MCP `initialize` handler had been parsing `client_info` and
`protocol_version` from the request only to throw them away. Three
silent paths now traced:

- **INFO**: connecting client identity (`client_name`, `client_version`,
  `client_protocol_version`) — useful for diagnosing version-mismatch
  issues and attributing audit-log activity to a specific client.
- **WARN**: protocol-version mismatch — the spec lets us substitute our
  supported version (and we still do), but the silent substitution made
  it impossible to diagnose client-version drift from server logs.
- **DEBUG**: ignored notifications — useful when a client thinks it sent
  something we should have acted on (typically a state-machine
  misalignment).

## Testing

- [x] Tested locally: `cargo fmt --all --check`, `cargo clippy
      --all-targets --all-features -- -D warnings`, `cargo test
      --all-features --workspace` (548 unit + 83 other = 631 tests),
      `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps
      --document-private-items`, `markdownlint-cli2 "**/*.md"` (12
      files, 0 errors)
- [x] All existing tests pass; **17 new tests added**:
    - 8 `parse_message` ID-preservation tests (3 preservation cases + 4
      drop cases for invalid shapes + helper-direct test)
    - 4 audit-event tests (3 new constructors + 1 regression test
      pinning correct `event_type` serialisation)
    - 2 initialize handshake tests (mismatched protocol version,
      missing clientInfo)
    - 2 blocked-URL tests (`call_repo_diff_tool`, `call_repo_pull_tool`)
    - 1 rate-limit-exhaustion test (max_burst=1, refill=0)

## Code Quality

- [x] Code compiles without warnings
- [x] Clippy passes (`-D warnings`) — caught one `irrefutable_let_patterns`
      mid-PR, fixed before push
- [x] Code is formatted (`cargo fmt --all --check`) — caught two fmt
      drifts mid-PR; both folded into the right commits via fixup +
      autosquash before push, history stays clean
- [x] Markdown is lint-clean
- [x] Toolchain pin is consistent
- [x] CHANGELOG.md updated (`[Unreleased]` § Fixed × 3 + § Changed × 1)
- [x] STYLE.md and CONTRIBUTING.md conventions followed (British
      spelling, conventional commits, 4-space indentation, 170-char
      line limit)

## Commit Map

| Commit | Category | What |
|--------|----------|------|
| `1498e9c` | `fix(mcp)` | Tier 2 audit `file_count: 0` bug |
| `a063aaa` | `fix(audit)` | Typed events for refs/diff/pull (was `repo_clone`) |
| `5466c45` | `fix(protocol)` | Preserve request ID across InvalidRequest |
| `aec03e9` | `feat(mcp)` | Initialize-handshake observability + ignored-notification trace + 3 coverage tests folded via fixup |
| `09673a7` | `docs` | CHANGELOG entries |

## File-Level Coverage After This PR (cargo-llvm-cov local)

- `mcp/protocol.rs`: **99.62%** (47 tests)
- `mcp/server.rs`: **74.80%** (51 tests, up from 69.96% baseline)
- `security/audit.rs`: **94.54%** (25 tests, +4 new)

## Findings That Are NOT in This PR

- **Success/failed audit events for refs/diff/pull**: those tools
  currently log success via `tracing::info!` rather than audit events.
  Bringing them under the audit-event umbrella is a larger design
  choice (whether to require an audit event for read-only ops like
  `repo_refs`) — separate scope.

- **Subprocess-error branches in tool dispatch are uncovered**: paths
  that fire only when git2 itself errors require either real network
  access or a mock git2 layer. Inherent test-infrastructure gap, not
  worth investing in for diagnostic logging branches.

- **`call_repo_clone_*_tool` handlers are end-to-end uncovered**: they
  spawn real git2 fetches. Integration tests in `ci_main.yml`'s
  `coverage` job exercise these against the private fixture repo
  post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)