### PR TITLE
fix(push): sanitise git stderr + extract util + remove dead bundle code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`sanitize_for_log` extracted to a shared `src/util.rs` module.**
+  Previously a private helper in `mcp/server.rs` (added in PR #154 for
+  client-controlled `clientInfo` fields), the same hardening pattern
+  is now needed in `git2_ops/push.rs::unbundle` for git's stderr.
+  Rather than duplicate, exported via `pub mod util` with `pub fn
+  sanitize_for_log`. New module is small: one helper, one constant,
+  7 tests. No behaviour change.
+- **Removed dead `parse_bundle_info` + `BundleInfo` + `BundleRef`
+  from `streaming/bundle.rs`.** The function was exported and tested
+  but had no production callers — only its own 3 tests (2 unit + 1
+  integration). It also had subtle issues (header truncated at 512
+  bytes, ref-line detection trusts bundle content) that would have
+  needed addressing if it were ever wired up. 95 lines removed; no
+  production behaviour change. Bundle handling for `repo_push`
+  continues to work through `decode_bundle` + `validate_bundle` +
+  git's own unbundle parsing — all kept.
 - **MCP server observability for the `initialize` handshake and
   ignored notifications.** Three previously-silent paths are now
   traced:
@@ -222,6 +238,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`unbundle` included git's raw stderr in error messages without
+  sanitisation.** A maliciously-crafted bundle that triggered a
+  creative `git fetch --no-tags <bundle>` failure could produce stderr
+  with ANSI escape sequences, embedded newlines, or megabytes of
+  output — all of which then flowed into both `tracing::warn!` log
+  lines (operator's terminal) and the MCP response (returned to the
+  AI client). Without sanitisation, a single error from
+  `unbundle` could repaint the operator's terminal log reader, fake
+  log-line boundaries (e.g. "fatal: early EOF\nerror: index-pack
+  died\n" creates two log lines from one error), or flood the log
+  file. Now passes git's stderr through `crate::util::sanitize_for_log`
+  before formatting — same protection profile as PR #154's
+  client-controlled JSON sanitisation.
 - **Audit log misidentified blocked `repo_refs` / `repo_diff` /
   `repo_pull` operations as `repo_clone`.** `call_repo_refs_tool`,
   `call_repo_diff_tool`, and `call_repo_pull_tool` were all calling

--- a/src/git2_ops/push.rs
+++ b/src/git2_ops/push.rs
@@ -24,6 +24,7 @@ use tracing::{debug, info, warn};
 
 use super::auth::{create_callbacks, validate_url};
 use super::error::Git2Error;
+use crate::util::sanitize_for_log;
 
 /// Result of a successful push operation.
 #[derive(Debug, Clone)]
@@ -155,9 +156,18 @@ fn unbundle(repo: &Repository, bundle_path: &Path) -> Result<(), Git2Error> {
         .map_err(|e| Git2Error::BundleFailed(format!("failed to run git fetch: {e}")))?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        // git's stderr can include ANSI escapes, newlines, and arbitrary
+        // bytes from a maliciously-crafted bundle. Sanitise before
+        // including in our error message — the error flows into both
+        // tracing logs (operator's terminal) and the MCP response
+        // (returned to the client / AI). Without this, a bundle that
+        // triggers a creative git error could repaint terminal log
+        // readers, fake log-line boundaries, or flood the message
+        // with megabytes of output.
+        let stderr_raw = String::from_utf8_lossy(&output.stderr);
+        let stderr_safe = sanitize_for_log(&stderr_raw);
         return Err(Git2Error::BundleFailed(format!(
-            "git fetch from bundle failed: {stderr}"
+            "git fetch from bundle failed: {stderr_safe}"
         )));
     }
 
@@ -226,6 +236,50 @@ mod tests {
         assert!(!opts.force);
     }
 
-    // Integration tests would go here but require network access
-    // See tests/git2_integration.rs for full integration tests
+    #[test]
+    fn unbundle_sanitises_git_stderr_in_error() {
+        // Set up a bare repo + write a malformed bundle. The header is
+        // valid (passes `validate_bundle`'s magic check) but the
+        // declared ref points to an OID with no pack data behind it,
+        // so `git fetch --no-tags <bundle>` fails with multi-line
+        // stderr ("fatal: early EOF\nerror: index-pack died" or
+        // similar). The newlines are exactly the kind of byte that,
+        // unsanitised, would fake a log-line boundary. Verify the
+        // returned error has them escaped.
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_bare(temp.path()).unwrap();
+
+        let bundle_path = temp.path().join("bad.bundle");
+        std::fs::write(
+            &bundle_path,
+            b"# v2 git bundle\n\
+              0000000000000000000000000000000000000000 refs/heads/main\n\
+              \n",
+        )
+        .unwrap();
+
+        let err = unbundle(&repo, &bundle_path)
+            .expect_err("git fetch on a bundle with declared refs but no pack data must fail");
+        let msg = err.to_string();
+
+        // `Git2Error::BundleFailed`'s `Display` adds the prefix
+        // "bundle processing failed: ", and our `unbundle` adds
+        // "git fetch from bundle failed: " inside it.
+        assert!(
+            msg.contains("git fetch from bundle failed:"),
+            "expected our inner prefix, got: {msg:?}"
+        );
+        // The defining property: any newlines git emitted in stderr
+        // were escaped (rendered as `\\n`), so this single error
+        // message can't span multiple log lines.
+        assert!(
+            !msg.contains('\n'),
+            "raw newlines from git stderr must be escaped, got: {msg:?}"
+        );
+        // And no raw ESC either.
+        assert!(
+            !msg.contains('\x1b'),
+            "raw ESC bytes from git stderr must be escaped, got: {msg:?}"
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //! - [`security`] — Security guards and audit logging
 //! - [`session`] — Session management for tracking cloned repositories
 //! - [`streaming`] — In-memory tar/bundle streaming
+//! - [`util`] — Cross-cutting helpers (e.g. log-safe string sanitisation)
 
 pub mod config;
 pub mod error;
@@ -62,3 +63,4 @@ pub mod mcp;
 pub mod security;
 pub mod session;
 pub mod streaming;
+pub mod util;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -55,6 +55,7 @@ use crate::security::{
     ShutdownReason,
 };
 use crate::streaming::chunked::StreamingSessionManager;
+use crate::util::sanitize_for_log;
 
 /// Server state in the MCP lifecycle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -250,39 +251,6 @@ impl GitIdentity {
     pub const fn is_partial(&self) -> bool {
         self.name.is_some() || self.email.is_some()
     }
-}
-
-/// Maximum length (in bytes) for a client-controlled string before we
-/// truncate it for logging. Anything beyond this is replaced with `…`.
-/// 200 bytes is enough to be useful for debugging and small enough
-/// that a hostile or buggy client can't flood the log file with a
-/// huge `clientInfo.name`.
-const MAX_CLIENT_STRING_LOG_LEN: usize = 200;
-
-/// Sanitises a client-controlled string for safe logging.
-///
-/// Two protections, both targeting buggy or hostile clients (the local
-/// stdio peer):
-///
-/// - Control characters (newlines, ANSI escape sequences, NULs, etc.)
-///   are escaped via `char::escape_debug`, so a value like
-///   `"foo\x1b[31mEVIL\x1b[0m"` renders as the literal characters
-///   rather than disrupting the operator's terminal log reader.
-/// - Length is capped at `MAX_CLIENT_STRING_LOG_LEN` bytes to prevent
-///   a 1-MiB name from flooding the log file. Truncation appends `…`
-///   so the operator can see the value was cut.
-fn sanitize_for_log(s: &str) -> String {
-    let mut escaped: String = s.chars().flat_map(char::escape_debug).collect();
-    if escaped.len() > MAX_CLIENT_STRING_LOG_LEN {
-        // Truncate at a char boundary so we don't slice mid-codepoint.
-        let mut cut = MAX_CLIENT_STRING_LOG_LEN;
-        while !escaped.is_char_boundary(cut) {
-            cut -= 1;
-        }
-        escaped.truncate(cut);
-        escaped.push('…');
-    }
-    escaped
 }
 
 /// The MCP server.
@@ -1778,62 +1746,6 @@ mod tests {
         let req = make_request(1, "initialize", Some(json!("not an object")));
         let err = server.handle_initialize(&req).unwrap_err();
         assert_eq!(err.error.code, ErrorCode::InvalidParams.code());
-    }
-
-    #[test]
-    fn sanitize_for_log_passes_clean_strings_unchanged() {
-        assert_eq!(sanitize_for_log("Claude AI"), "Claude AI");
-        assert_eq!(sanitize_for_log(""), "");
-        assert_eq!(sanitize_for_log("v1.2.3-rc.1"), "v1.2.3-rc.1");
-    }
-
-    #[test]
-    fn sanitize_for_log_escapes_control_characters() {
-        // ANSI escape sequence — raw ESC must not pass through, or it
-        // could repaint the operator's terminal (and fake "harmless"
-        // log lines around an injected message).
-        let evil = "foo\x1b[31mEVIL\x1b[0m";
-        let sanitised = sanitize_for_log(evil);
-        assert!(!sanitised.contains('\x1b'), "raw ESC must be escaped");
-        // `char::escape_debug` renders `\x1b` as `\u{1b}`.
-        assert!(sanitised.contains("\\u{1b}"));
-
-        // Newline — must be escaped so it doesn't fake a log-line break.
-        assert_eq!(sanitize_for_log("a\nb"), "a\\nb");
-
-        // Tab and CR.
-        assert_eq!(sanitize_for_log("a\tb\rc"), "a\\tb\\rc");
-
-        // NUL — `escape_debug` uses the short form `\0` for NUL.
-        assert_eq!(sanitize_for_log("a\0b"), "a\\0b");
-    }
-
-    #[test]
-    fn sanitize_for_log_caps_length_to_prevent_log_flood() {
-        // 1 KiB of `a` — must be truncated.
-        let huge = "a".repeat(1024);
-        let sanitised = sanitize_for_log(&huge);
-        assert!(sanitised.len() <= MAX_CLIENT_STRING_LOG_LEN + "…".len());
-        assert!(
-            sanitised.ends_with('…'),
-            "truncation marker must be appended"
-        );
-    }
-
-    #[test]
-    fn sanitize_for_log_truncates_at_char_boundary() {
-        // String with multibyte chars right around the truncation point.
-        // `é` is 2 bytes in UTF-8. If MAX_CLIENT_STRING_LOG_LEN landed
-        // mid-codepoint we'd panic on `escaped.truncate(cut)` — this
-        // test pins the boundary-search loop.
-        let s = "é".repeat(150); // 300 bytes
-        let sanitised = sanitize_for_log(&s);
-        assert!(sanitised.ends_with('…'));
-        // Verify we didn't break a codepoint — the prefix before the
-        // truncation marker must be valid UTF-8 (it is by construction
-        // since `escaped` is a String, but assert it's well-formed anyway).
-        let prefix = &sanitised[..sanitised.len() - "…".len()];
-        assert!(prefix.is_char_boundary(prefix.len()));
     }
 
     #[test]

--- a/src/streaming/bundle.rs
+++ b/src/streaming/bundle.rs
@@ -67,82 +67,6 @@ pub fn validate_bundle(data: &[u8]) -> Result<(), Git2Error> {
     }
 }
 
-/// Bundle metadata extracted from the header.
-#[derive(Debug, Clone)]
-pub struct BundleInfo {
-    /// Bundle format version (2 or 3)
-    pub version: u8,
-    /// References included in the bundle
-    pub refs: Vec<BundleRef>,
-}
-
-/// A reference in a git bundle.
-#[derive(Debug, Clone)]
-pub struct BundleRef {
-    /// The object ID
-    pub oid: String,
-    /// The reference name (e.g., "refs/heads/main")
-    pub name: String,
-}
-
-/// Parse basic info from a git bundle header.
-///
-/// This is a best-effort parse of the bundle header to extract
-/// metadata without fully processing the bundle.
-///
-/// # Errors
-///
-/// Returns `BundleFailed` if the header is invalid UTF-8 or has an unknown version.
-pub fn parse_bundle_info(data: &[u8]) -> Result<BundleInfo, Git2Error> {
-    let header = std::str::from_utf8(data.get(..512).unwrap_or(data))
-        .map_err(|_| Git2Error::BundleFailed("invalid bundle header encoding".to_string()))?;
-
-    // Determine version (git >= 2.53 uses "# vN git bundle")
-    let version = if header.starts_with("# v3 bundle") || header.starts_with("# v3 git bundle") {
-        3
-    } else if header.starts_with("# v2 bundle") || header.starts_with("# v2 git bundle") {
-        2
-    } else {
-        return Err(Git2Error::BundleFailed(
-            "unknown bundle version".to_string(),
-        ));
-    };
-
-    // Parse references (lines after header, before empty line)
-    let mut refs = Vec::new();
-    let mut in_refs = false;
-
-    for line in header.lines() {
-        if line.starts_with("# v") {
-            in_refs = true;
-            continue;
-        }
-
-        if line.is_empty() {
-            break;
-        }
-
-        if in_refs && line.len() > 40 {
-            // Format: "<40-char-oid> <refname>"
-            let parts: Vec<&str> = line.splitn(2, ' ').collect();
-            if parts.len() == 2 {
-                refs.push(BundleRef {
-                    oid: parts[0].to_string(),
-                    name: parts[1].to_string(),
-                });
-            }
-        }
-    }
-
-    debug!(
-        version = version,
-        ref_count = refs.len(),
-        "parsed bundle info"
-    );
-
-    Ok(BundleInfo { version, refs })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,23 +113,5 @@ mod tests {
     fn validate_bundle_invalid() {
         let data = b"not a bundle";
         assert!(validate_bundle(data).is_err());
-    }
-
-    #[test]
-    fn parse_bundle_info_v2() {
-        let data = b"# v2 bundle\nabcd1234abcd1234abcd1234abcd1234abcd1234 refs/heads/main\n\n";
-        let info = parse_bundle_info(data).unwrap();
-        assert_eq!(info.version, 2);
-        assert_eq!(info.refs.len(), 1);
-        assert_eq!(info.refs[0].name, "refs/heads/main");
-    }
-
-    #[test]
-    fn parse_bundle_info_v2_git() {
-        let data = b"# v2 git bundle\nabcd1234abcd1234abcd1234abcd1234abcd1234 refs/heads/main\n\n";
-        let info = parse_bundle_info(data).unwrap();
-        assert_eq!(info.version, 2);
-        assert_eq!(info.refs.len(), 1);
-        assert_eq!(info.refs[0].name, "refs/heads/main");
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,118 @@
+//! Cross-cutting utility helpers.
+//!
+//! Small functions that don't belong to any specific module but are
+//! shared across multiple ones. Currently:
+//!
+//! - [`sanitize_for_log`] — escape control characters and cap length
+//!   on a string before logging it. Used for any value that crosses a
+//!   trust boundary (client-controlled JSON-RPC fields, subprocess
+//!   stderr, etc.) so a hostile or buggy producer can't disrupt the
+//!   operator's terminal log reader.
+
+/// Maximum length (in bytes) for a sanitised string before truncation.
+///
+/// 200 bytes is enough to be useful for debugging and small enough that
+/// a hostile or buggy producer can't flood the log file with a huge
+/// single value.
+pub const MAX_LOG_STRING_LEN: usize = 200;
+
+/// Sanitises a string for safe logging.
+///
+/// Two protections, both targeting buggy or hostile producers (e.g. a
+/// client sending `clientInfo.name`, or a subprocess emitting stderr):
+///
+/// - **Control characters** (newlines, ANSI escape sequences, NULs,
+///   etc.) are escaped via `char::escape_debug`, so a value like
+///   `"foo\x1b[31mEVIL\x1b[0m"` renders as the literal characters
+///   rather than disrupting the operator's terminal log reader. Each
+///   `char::escape_debug` output is ASCII-printable.
+/// - **Length** is capped at [`MAX_LOG_STRING_LEN`] bytes with a `…`
+///   truncation marker, at a UTF-8 char boundary so we never panic
+///   mid-codepoint.
+#[must_use]
+pub fn sanitize_for_log(s: &str) -> String {
+    let mut escaped: String = s.chars().flat_map(char::escape_debug).collect();
+    if escaped.len() > MAX_LOG_STRING_LEN {
+        // Truncate at a char boundary so we don't slice mid-codepoint.
+        let mut cut = MAX_LOG_STRING_LEN;
+        while !escaped.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        escaped.truncate(cut);
+        escaped.push('…');
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_clean_strings_unchanged() {
+        assert_eq!(sanitize_for_log("Claude AI"), "Claude AI");
+        assert_eq!(sanitize_for_log(""), "");
+        assert_eq!(sanitize_for_log("v1.2.3-rc.1"), "v1.2.3-rc.1");
+    }
+
+    #[test]
+    fn escapes_ansi_escape_sequences() {
+        // Raw ESC must not pass through, or it could repaint the
+        // operator's terminal (and fake "harmless" log lines around
+        // an injected message).
+        let evil = "foo\x1b[31mEVIL\x1b[0m";
+        let sanitised = sanitize_for_log(evil);
+        assert!(!sanitised.contains('\x1b'), "raw ESC must be escaped");
+        // `char::escape_debug` renders `\x1b` as `\u{1b}`.
+        assert!(sanitised.contains("\\u{1b}"));
+    }
+
+    #[test]
+    fn escapes_newline_tab_and_carriage_return() {
+        // Newlines are the highest-value escape — without them, a
+        // hostile producer can fake log-line boundaries.
+        assert_eq!(sanitize_for_log("a\nb"), "a\\nb");
+        assert_eq!(sanitize_for_log("a\tb\rc"), "a\\tb\\rc");
+    }
+
+    #[test]
+    fn escapes_nul_using_short_form() {
+        // `escape_debug` emits the short `\0` form for NUL rather than
+        // the verbose `\u{0}`.
+        assert_eq!(sanitize_for_log("a\0b"), "a\\0b");
+    }
+
+    #[test]
+    fn caps_length_to_prevent_log_flood() {
+        // 1 KiB of `a` — must be truncated.
+        let huge = "a".repeat(1024);
+        let sanitised = sanitize_for_log(&huge);
+        assert!(sanitised.len() <= MAX_LOG_STRING_LEN + "…".len());
+        assert!(
+            sanitised.ends_with('…'),
+            "truncation marker must be appended"
+        );
+    }
+
+    #[test]
+    fn truncates_at_char_boundary_for_multibyte_input() {
+        // String with multibyte chars right around the truncation
+        // point. `é` is 2 bytes in UTF-8. If `MAX_LOG_STRING_LEN`
+        // landed mid-codepoint we'd panic on `truncate` — this test
+        // pins the boundary-search loop.
+        let s = "é".repeat(150); // 300 bytes
+        let sanitised = sanitize_for_log(&s);
+        assert!(sanitised.ends_with('…'));
+        let prefix = &sanitised[..sanitised.len() - "…".len()];
+        assert!(prefix.is_char_boundary(prefix.len()));
+    }
+
+    #[test]
+    fn preserves_unicode_in_well_formed_short_strings() {
+        // A short string with non-ASCII characters should pass through
+        // (sans escaping for non-printable chars). Note that
+        // `char::escape_debug` does NOT escape printable Unicode.
+        assert_eq!(sanitize_for_log("héllo wörld"), "héllo wörld");
+        assert_eq!(sanitize_for_log("日本語"), "日本語");
+    }
+}

--- a/tests/streaming_tests.rs
+++ b/tests/streaming_tests.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use git_proxy_mcp::git2_ops::auth::{sanitize_url_for_logging, validate_url};
 use git_proxy_mcp::session::{SessionError, SessionManager};
-use git_proxy_mcp::streaming::bundle::{decode_bundle, parse_bundle_info, validate_bundle};
+use git_proxy_mcp::streaming::bundle::{decode_bundle, validate_bundle};
 use git_proxy_mcp::streaming::tar::encode_base64;
 
 // ============================================================================
@@ -127,16 +127,6 @@ fn test_validate_bundle_v3_format() {
 fn test_validate_bundle_invalid() {
     let not_a_bundle = b"this is not a git bundle";
     assert!(validate_bundle(not_a_bundle).is_err());
-}
-
-#[test]
-fn test_parse_bundle_info_v2() {
-    // Bundle format: "# v2 bundle\n<40-char-oid> <refname>\n\n"
-    let bundle_data = b"# v2 bundle\nabcd1234abcd1234abcd1234abcd1234abcd1234 refs/heads/main\n\n";
-    let info = parse_bundle_info(bundle_data).unwrap();
-    assert_eq!(info.version, 2);
-    assert_eq!(info.refs.len(), 1);
-    assert_eq!(info.refs[0].name, "refs/heads/main");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Deep review of the bundle handling stack: `streaming/bundle.rs` (211
lines), `git2_ops/push.rs` (231 lines), and `mcp/tools/repo_push.rs`
(305 lines) — the path that processes attacker-controlled git bundles
sent via `repo_push`. Found **one real defensive gap**, plus dead code
and a refactor opportunity. Four commits.

This is the next un-audited area per the audit-progress memory after
`mcp/server.rs`. Same risk profile that turned up bugs in PR #153
(auth) and PR #154 (mcp/server) — bundle data is fully under client
control before any of our validation runs.

## Related Issue

N/A — proactive audit per the progressive-audit cadence.

## Type of Change

- [x] Bug fix (defence-in-depth)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (rustdoc + CHANGELOG)
- [x] Refactoring (extract `sanitize_for_log` to shared module)
- [ ] CI/CD changes
- [x] Security improvement

## Security Checklist

- [x] No credentials, tokens, or secrets in code, comments, or tests
- [x] No new credential flows introduced
- [x] git stderr is now sanitised before flowing into MCP responses
      (a malformed bundle could previously inject ANSI escapes /
      newlines / large content into both logs and the AI-visible
      error message)

## The Real Defensive Gap

`unbundle` shells out to `git fetch --no-tags <bundle>` and, on
failure, included git's raw stderr in the returned `BundleFailed`
error. That error then flows into both `tracing::warn!` log lines
(operator's terminal log reader) AND the MCP response sent back to
the client / AI. git's stderr is mostly clean, but a maliciously-
crafted bundle that triggers a creative git error path can produce
stderr containing arbitrary bytes:

- ANSI escape sequences (could repaint operator terminal, or fake
  "harmless" log lines around an injected message)
- Embedded newlines (could fake log-line boundaries — e.g. the
  defining example "fatal: early EOF\nerror: index-pack died\n"
  creates two log lines from one error)
- Megabytes of output (could flood the log file)

Now passes git's stderr through `crate::util::sanitize_for_log`
before formatting. Same protection profile as PR #154's
client-controlled JSON sanitisation: `escape_debug` for control
chars, length capped at 200 bytes with `…` truncation marker.

One regression test (`unbundle_sanitises_git_stderr_in_error`)
constructs a bundle with valid v2 magic + a declared `refs/heads/main`
pointing to the all-zeros OID + no pack data → triggers git's
"fatal: early EOF\nerror: index-pack died\n" → asserts the resulting
error has no raw `\n` or `\x1b` bytes.

## Refactor + Cleanup

- **Extracted `sanitize_for_log` to `src/util.rs`.** Was a private
  helper in `mcp/server.rs` (added in PR #154); now a `pub fn` in a
  new shared `util` module so both `mcp/server.rs` and
  `git2_ops/push.rs` can use it. 7 tests covering clean passthrough,
  ANSI escapes, newlines / tabs / CR / NUL escaping, length cap,
  and UTF-8 boundary safety.

- **Removed dead `parse_bundle_info` + `BundleInfo` + `BundleRef`
  from `streaming/bundle.rs`.** Function was exported and tested
  but had no production callers. Also had subtle issues that would
  have needed addressing if it were ever wired up: header truncated
  at 512 bytes (silently drops refs in larger headers), ref-line
  detection (`line.len() > 40`) trusts bundle content. 95 lines
  removed. If a future feature wants to display bundle metadata
  before pushing, the right implementation is `git bundle list-heads`
  rather than re-parsing the header in our code.

## Testing

- [x] Tested locally: `cargo fmt --all --check`, `cargo clippy
      --all-targets --all-features -- -D warnings`, `cargo test
      --all-features --workspace` (555 unit + 82 other = 637 tests),
      `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps
      --document-private-items`, `markdownlint-cli2 "**/*.md"` (12
      files, 0 errors), `bash .github/scripts/check-toolchain-pin.sh`
- [x] One new regression test on the real bug
      (`unbundle_sanitises_git_stderr_in_error`)
- [x] 7 tests for the extracted helper in `util.rs`
- [x] 3 tests removed (the dead `parse_bundle_info` ones)
- [x] Full bundle-handling unit test count: 7 (was 9 — net -2 from
      removed dead code, +1 new regression)

## Code Quality

- [x] Code compiles without warnings
- [x] Clippy passes (`-D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean — caught one MD004/MD007 mid-commit
      where a line wrap put `+` at the start of a continuation line
      (looks like a list marker to the linter); restructured to use
      commas before the push
- [x] Toolchain pin is consistent
- [x] CHANGELOG.md updated (`[Unreleased]` § Fixed × 1 + § Changed × 2)
- [x] STYLE.md and CONTRIBUTING.md conventions followed (British
      spelling, conventional commits, 4-space indentation, 170-char
      line limit)

## Commit Map

| Commit | Category | What |
|--------|----------|------|
| `0938c18` | `refactor(bundle)` | Remove dead `parse_bundle_info` + types + 3 tests |
| `8723856` | `refactor` | Extract `sanitize_for_log` to `src/util.rs` (no behaviour change) |
| `7a50cca` | `fix(push)` | Sanitise git stderr in `unbundle` (the real bug) + regression test |
| `dc9918b` | `docs` | CHANGELOG entries |

## Findings That Are NOT in This PR

- **`unbundle` subprocess has no timeout.** A bundle that hangs
  `git fetch` (rather than failing fast) would block the server
  until external action. Real DoS vector but adding a timeout
  requires either the `wait-timeout` crate as a new dependency or
  significant async refactoring (push.rs is sync code wrapped by
  the async runtime). Worth a separate PR.

- **The 1-GiB bundle size limit + ~2.4 GiB peak memory** during
  decode (encoded base64 + decoded bytes both in memory before
  validation). Documented; fixing means streaming the decode,
  which is a meaningful refactor. Out of scope.

- **`handle_repo_push_with_oversized_bundle` test allocates 2 GiB**
  to test a size check that just looks at `len()`. Wasteful on dev
  machines but functional on CI runners (7 GiB). Not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)