### PR TITLE
test(util): cover boundary-search loop in sanitize_for_log (100%)

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -96,15 +96,44 @@ mod tests {
 
     #[test]
     fn truncates_at_char_boundary_for_multibyte_input() {
-        // String with multibyte chars right around the truncation
-        // point. `é` is 2 bytes in UTF-8. If `MAX_LOG_STRING_LEN`
-        // landed mid-codepoint we'd panic on `truncate` — this test
-        // pins the boundary-search loop.
+        // 2-byte chars: `é` is 2 bytes in UTF-8, and 200 (= `MAX_LOG_STRING_LEN`)
+        // is divisible by 2, so byte 200 lands cleanly on a char boundary
+        // and the boundary-search loop body doesn't actually fire here.
+        // This test is the no-panic invariant; the loop-body coverage
+        // test below uses a 3-byte char that forces the back-up.
         let s = "é".repeat(150); // 300 bytes
         let sanitised = sanitize_for_log(&s);
         assert!(sanitised.ends_with('…'));
         let prefix = &sanitised[..sanitised.len() - "…".len()];
         assert!(prefix.is_char_boundary(prefix.len()));
+    }
+
+    #[test]
+    fn boundary_search_loop_backs_up_when_cut_lands_mid_codepoint() {
+        // Coverage gap fix: the boundary-search `while` loop body
+        // (`cut -= 1`) only fires when the initial cut at byte
+        // `MAX_LOG_STRING_LEN` is NOT on a char boundary. The "a" and
+        // "é" tests don't exercise this — both line up cleanly on byte
+        // 200. We need a codepoint whose byte-width doesn't divide 200.
+        //
+        // `€` (Euro sign) is 3 bytes in UTF-8. With `"€".repeat(70)`
+        // = 210 bytes, byte 200 falls mid-codepoint:
+        //   - 66 × 3 = 198 (start of the 67th `€`)
+        //   - bytes 199, 200 are continuation bytes of that char
+        //   - 67 × 3 = 201 (start of the 68th `€`)
+        // The loop must back up: cut=200 → not boundary → cut=199 →
+        // not boundary → cut=198 → boundary → truncate at 198.
+        // Without the back-up, `String::truncate(200)` would panic
+        // with "byte index 200 is not a char boundary".
+        let s = "€".repeat(70); // 210 bytes
+        let sanitised = sanitize_for_log(&s);
+        assert!(sanitised.ends_with('…'));
+        // The truncated prefix must be 198 bytes (66 full `€` chars).
+        let prefix_len = sanitised.len() - "…".len();
+        assert_eq!(prefix_len, 198, "expected back-up to byte 198");
+        // And it must be valid UTF-8 (we'd have panicked otherwise,
+        // but assert explicitly for documentation).
+        assert!(sanitised[..prefix_len].is_char_boundary(prefix_len));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Tiny coverage fix flagged by Codecov on PR #155: the boundary-search
`while` loop body inside `sanitize_for_log` was uncovered. One new
test exercises it; `util.rs` is now 100% line-covered.

## Related Issue

N/A — coverage gap flagged by Codecov annotation on the merged
PR #155 diff (visible on `src/mcp/server.rs` lines 280-281 in the
old location, now `src/util.rs` after the extraction).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD changes
- [ ] Security improvement
- [x] Test-only addition (single new unit test + clarifying comment)

## Root Cause

My existing tests for the truncation path used 1-byte ASCII
(`"a".repeat(1024)`) and 2-byte UTF-8 (`"é".repeat(150)`). Both
happen to land cleanly on byte 200 (the initial cut position):

- 1-byte chars: every byte position is a char boundary
- 2-byte chars: 200 = 100 × 2, exactly on a boundary

So `is_char_boundary(200)` returned true on the first check and the
back-up loop body (`cut -= 1`) never fired.

## The Fix

Added `boundary_search_loop_backs_up_when_cut_lands_mid_codepoint`
using `"€".repeat(70)` (3-byte chars, 210 bytes total). Byte 200
falls 2 bytes into the 67th `€`:

- 66 × 3 = 198 (start of 67th `€`)
- bytes 199, 200 are continuation bytes
- 67 × 3 = 201 (start of 68th `€`)

The loop must back up: `cut=200` → not boundary → `cut=199` → not
boundary → `cut=198` → boundary → truncate at 198. Without this
back-up, `String::truncate(200)` would panic with "byte index 200
is not a char boundary".

Test asserts the truncated prefix is exactly 198 bytes (proving
the loop ran twice). Also updated the 2-byte test's comment to
clarify WHY it's a separate "no-panic" invariant rather than a
loop-body exercise — the comment previously claimed it pinned the
loop body, but that wasn't true.

## Testing

- `cargo test --lib util::` — 8 tests pass (was 7, +1 new)
- `cargo llvm-cov --summary-only`: `util.rs` 117/117 lines = **100%**
- `cargo fmt --all --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- Full test suite: 556 unit + 82 other = 638 tests, all green

## Code Quality

- [x] Code compiles without warnings
- [x] Clippy passes
- [x] Code is formatted
- [x] No CHANGELOG entry needed (test-only, no user-facing change)
- [x] STYLE.md and CONTRIBUTING.md conventions followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)