### PR TITLE
feat(config): validate value ranges on load (reject panic/brick configs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,9 +195,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rejected: `submodules.max_concurrent` (clamped to ≥ 1 by the fetcher),
   `submodules.max_failures` of 0, `lfs.retry_max_attempts` of 0 (the retry loop
   always makes one attempt), and `lfs.max_object_size` of 0 (every object kept
-  as a pointer). Seven new unit tests cover every rejected and every
-  deliberately-accepted case. `validate` is no longer `const fn` (it now builds
-  error strings); no other API change.
+  as a pointer). Eight new unit tests cover every rejected and every
+  deliberately-accepted case, and confirm `load_config` surfaces the
+  `ValidationError` (i.e. validation is wired into the load path). `validate` is
+  no longer `const fn` (it now builds error strings); no other API change.
 - **`git2` requirement bumped 0.20.4 → 0.21.0** (cargo-dependencies group).
   0.21 ships two breaking changes that touched this crate:
     1. **`default` features are now empty** (0.20 enabled `ssh` + `https`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,10 +179,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     2. **`rate_limits.max_burst` of zero** — the token bucket starts empty and
        never refills past zero, so *every* operation is blocked forever.
     3. **A non-finite or negative `rate_limits.refill_rate_per_sec`** — this is
-       the one that was not merely a foot-gun: `NaN`/`±∞` reaches
+       the one that was not merely a foot-gun: `NaN` reaches
        `RateLimiter::time_until_available`, whose `Duration::from_secs_f64`
-       **panics** on a non-finite value. `0.0` is still accepted (the supported
-       "burst once, never refill" mode).
+       **panics** on a non-finite value. The infinities and negatives don't
+       panic but break the token-bucket maths (permanent block, or effectively
+       no throttling). `0.0` is still accepted (the supported "burst once,
+       never refill" mode).
     4. **Zero session limits** — `sessions.timeout_secs` (sessions expire
        instantly), `sessions.max_streaming_sessions` and
        `sessions.max_repo_sessions` (no session can ever be created).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`Config::validate` now range-checks the configuration instead of being a
+  no-op.** Previously every value that parsed was accepted; a handful of
+  out-of-range values then silently broke a subsystem — or panicked. `validate`
+  (run by `load_config` at startup) now rejects, with a `ValidationError` that
+  names the offending field:
+    1. **Zero timeouts** — `timeouts.request_timeout_secs` and the three
+       `lfs.*_timeout_secs`. `Duration::from_secs(0)` makes the corresponding
+       git command or LFS HTTP request fail immediately.
+    2. **`rate_limits.max_burst` of zero** — the token bucket starts empty and
+       never refills past zero, so *every* operation is blocked forever.
+    3. **A non-finite or negative `rate_limits.refill_rate_per_sec`** — this is
+       the one that was not merely a foot-gun: `NaN`/`±∞` reaches
+       `RateLimiter::time_until_available`, whose `Duration::from_secs_f64`
+       **panics** on a non-finite value. `0.0` is still accepted (the supported
+       "burst once, never refill" mode).
+    4. **Zero session limits** — `sessions.timeout_secs` (sessions expire
+       instantly), `sessions.max_streaming_sessions` and
+       `sessions.max_repo_sessions` (no session can ever be created).
+    5. **An unrecognised `logging.level`** — previously any unknown string
+       silently became `warn`; a typo (`"verbsoe"`, `"WARNING"`) is now rejected
+       with the list of valid levels.
+  Values that the consuming code already handles are deliberately *not*
+  rejected: `submodules.max_concurrent` (clamped to ≥ 1 by the fetcher),
+  `submodules.max_failures` of 0, `lfs.retry_max_attempts` of 0 (the retry loop
+  always makes one attempt), and `lfs.max_object_size` of 0 (every object kept
+  as a pointer). Seven new unit tests cover every rejected and every
+  deliberately-accepted case. `validate` is no longer `const fn` (it now builds
+  error strings); no other API change.
 - **`git2` requirement bumped 0.20.4 → 0.21.0** (cargo-dependencies group).
   0.21 ships two breaking changes that touched this crate:
     1. **`default` features are now empty** (0.20 enabled `ssh` + `https`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,8 +189,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
        instantly), `sessions.max_streaming_sessions` and
        `sessions.max_repo_sessions` (no session can ever be created).
     5. **An unrecognised `logging.level`** — previously any unknown string
-       silently became `warn`; a typo (`"verbsoe"`, `"WARNING"`) is now rejected
-       with the list of valid levels.
+       silently became `warn`; a mistake such as `"verbose"` or `"warning"`
+       (the level is `warn`, not `warning`) is now rejected with the list of
+       valid levels.
   Values that the consuming code already handles are deliberately *not*
   rejected: `submodules.max_concurrent` (clamped to ≥ 1 by the fetcher),
   `submodules.max_failures` of 0, `lfs.retry_max_attempts` of 0 (the retry loop

--- a/README.md
+++ b/README.md
@@ -485,6 +485,19 @@ For a fully-populated example showing every section and option, see [`config/exa
 | `submodules` | `include_patterns` | Glob patterns to include (default: null — all submodules allowed) |
 | `submodules` | `exclude_patterns` | Glob patterns to exclude (default: null — nothing excluded) |
 
+### Validation
+
+The configuration is validated when it loads; an invalid value aborts startup
+with a `configuration validation failed: …` message naming the offending field.
+The checks reject only values that would render a subsystem unusable: a zero
+`timeouts.request_timeout_secs` or any of the `lfs.*_timeout_secs` (every request
+would time out immediately), `rate_limits.max_burst` of `0` (every operation
+blocked forever), a non-finite or negative `rate_limits.refill_rate_per_sec`
+(`0.0` is allowed — it means "burst once, never refill"), a zero
+`sessions.timeout_secs` / `sessions.max_streaming_sessions` /
+`sessions.max_repo_sessions`, and a `logging.level` outside
+`trace`/`debug`/`info`/`warn`/`error`.
+
 ---
 
 ## Contributing

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -82,10 +82,32 @@ These errors occur when loading or validating the configuration file.
 
 | Error | Message Format | Cause |
 |-------|---------------|-------|
-| Read error | `failed to read configuration file: {path}` | Cannot read the file (permissions, IO error) |
-| Parse error | `failed to parse configuration file: {path}` | Invalid JSON syntax in config file |
+| Read error | `failed to read configuration file: {path}` | Cannot read the file (permissions, IO error, or the path is a directory) |
+| Parse error | `failed to parse configuration file: {path}` | Invalid JSON syntax, or an unknown/mistyped field (every section uses `deny_unknown_fields`) |
 | Not found | `configuration file not found: {path}` | Config file doesn't exist at specified path |
-| Validation error | `configuration validation failed: {message}` | Configuration values are invalid |
+| Validation error | `configuration validation failed: {message}` | A value is out of range — see below |
+
+### Validation rules
+
+After parsing, the configuration is range-checked. The `{message}` names the
+offending field. Only values that would render a subsystem unusable (or panic)
+are rejected; values the consuming code already handles (`submodules.max_concurrent`,
+`submodules.max_failures`, `lfs.retry_max_attempts`, `lfs.max_object_size`) are
+accepted as-is.
+
+| Field(s) | Rule | Why |
+|----------|------|-----|
+| `timeouts.request_timeout_secs`, `lfs.request_timeout_secs`, `lfs.connect_timeout_secs`, `lfs.download_timeout_secs` | must be > 0 | a zero `Duration` makes every request time out immediately |
+| `rate_limits.max_burst` | must be > 0 | the token bucket would never hand out a token, blocking every operation |
+| `rate_limits.refill_rate_per_sec` | finite and ≥ 0 | `NaN`/`±∞` would panic in `time_until_available`; `0.0` is allowed ("burst once, never refill") |
+| `sessions.timeout_secs`, `sessions.max_streaming_sessions`, `sessions.max_repo_sessions` | must be > 0 | sessions would expire instantly or never be creatable |
+| `logging.level` | one of `trace`, `debug`, `info`, `warn`, `error` (case-insensitive) | an unknown level would otherwise silently fall back to `warn`, masking a typo |
+
+#### Example
+
+```text
+configuration validation failed: rate_limits.max_burst must be greater than 0
+```
 
 ---
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -99,7 +99,7 @@ accepted as-is.
 |----------|------|-----|
 | `timeouts.request_timeout_secs`, `lfs.request_timeout_secs`, `lfs.connect_timeout_secs`, `lfs.download_timeout_secs` | must be > 0 | a zero `Duration` makes every request time out immediately |
 | `rate_limits.max_burst` | must be > 0 | the token bucket would never hand out a token, blocking every operation |
-| `rate_limits.refill_rate_per_sec` | finite and ≥ 0 | `NaN`/`±∞` would panic in `time_until_available`; `0.0` is allowed ("burst once, never refill") |
+| `rate_limits.refill_rate_per_sec` | finite and ≥ 0 | `NaN` panics in `time_until_available`; `±∞`/negatives break the token-bucket maths; `0.0` is allowed ("burst once, never refill") |
 | `sessions.timeout_secs`, `sessions.max_streaming_sessions`, `sessions.max_repo_sessions` | must be > 0 | sessions would expire instantly or never be creatable |
 | `logging.level` | one of `trace`, `debug`, `info`, `warn`, `error` (case-insensitive) | an unknown level would otherwise silently fall back to `warn`, masking a typo |
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -179,6 +179,22 @@ mod tests {
     }
 
     #[test]
+    fn load_config_rejects_out_of_range_value() {
+        // A value that parses but fails Config::validate must surface as a
+        // ValidationError — proving validation is wired into the load path,
+        // not merely callable in isolation. (The per-field rules themselves are
+        // covered in settings.rs.)
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), r#"{"rate_limits": {"max_burst": 0}}"#).unwrap();
+        let err = load_config(Some(temp.path())).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::ValidationError { .. }),
+            "expected ValidationError, got {err:?}"
+        );
+        assert!(err.to_string().contains("max_burst"));
+    }
+
+    #[test]
     fn load_config_with_directory_path_returns_read_error() {
         // `Path::exists()` is true for a directory, so the existence check
         // passes — but `read_to_string` cannot read a directory as a file.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,9 @@
 //!
 //! The MCP server does NOT store credentials. It relies on the user's
 //! existing Git configuration (credential helpers, SSH agent, etc.).
-//! The config file only contains security and logging settings.
+//! The config file holds only non-secret operational settings — git identity,
+//! security guards, logging, timeouts, limits, rate limits, proxy, session
+//! management, LFS, and submodule options.
 //!
 //! # Configuration File Locations
 //!
@@ -57,8 +59,8 @@ pub fn default_config_path() -> Option<PathBuf> {
 /// Returns an error if:
 /// - The configuration file cannot be found
 /// - The file cannot be read
-/// - The JSON is malformed
-/// - Required fields are missing or invalid
+/// - The JSON is malformed (unknown or mistyped fields are rejected)
+/// - A configured value is out of range (see [`Config::validate`])
 pub fn load_config(path: Option<&Path>) -> Result<Config, ConfigError> {
     let config_path = match path {
         Some(p) => p.to_path_buf(),

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -93,9 +93,11 @@ impl Config {
     ///   immediately;
     /// - `rate_limits.max_burst` of zero — the token bucket can then never hand
     ///   out a token, blocking every operation forever;
-    /// - a non-finite or negative `rate_limits.refill_rate_per_sec` — `NaN` and
-    ///   the infinities would otherwise panic in
-    ///   `RateLimiter::time_until_available` via `Duration::from_secs_f64`;
+    /// - a non-finite or negative `rate_limits.refill_rate_per_sec` — `NaN`
+    ///   panics in `RateLimiter::time_until_available` (`Duration::from_secs_f64`
+    ///   rejects non-finite input), and the infinities/negatives break the
+    ///   token-bucket maths (permanent block, or effectively no throttling).
+    ///   `0.0` stays allowed — the supported "burst once, never refill" mode;
     /// - zero session limits (`sessions.timeout_secs`,
     ///   `sessions.max_streaming_sessions`, `sessions.max_repo_sessions`) —
     ///   sessions would expire instantly or never be creatable;
@@ -1306,8 +1308,9 @@ mod tests {
 
     #[test]
     fn validate_rejects_non_finite_or_negative_refill_rate() {
-        // A non-finite refill rate would panic downstream in
-        // RateLimiter::time_until_available (Duration::from_secs_f64).
+        // NaN panics downstream in RateLimiter::time_until_available
+        // (Duration::from_secs_f64); the infinities and negatives break the
+        // token-bucket maths instead. All are rejected (0.0 is allowed).
         for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -0.1, -1.0] {
             let mut config: Config = serde_json::from_str("{}").unwrap();
             config.rate_limits.refill_rate_per_sec = bad;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -78,14 +78,95 @@ pub struct Config {
 }
 
 impl Config {
-    /// Validates the configuration.
+    /// Validates the configuration after deserialisation.
+    ///
+    /// Most fields need no validation — they are booleans, free-form strings,
+    /// or numbers that degrade gracefully (for example `submodules.max_concurrent`
+    /// is clamped to a minimum of one by the fetcher, the LFS retry loop always
+    /// makes one attempt regardless of `lfs.retry_max_attempts`, and a
+    /// `rate_limits.refill_rate_per_sec` of `0.0` is a supported "burst once,
+    /// never refill" mode). This method rejects only values that would make a
+    /// subsystem unusable or trigger a panic downstream:
+    ///
+    /// - zero timeouts (`timeouts.request_timeout_secs` and the three
+    ///   `lfs.*_timeout_secs`) — a `Duration` of zero makes every request fail
+    ///   immediately;
+    /// - `rate_limits.max_burst` of zero — the token bucket can then never hand
+    ///   out a token, blocking every operation forever;
+    /// - a non-finite or negative `rate_limits.refill_rate_per_sec` — `NaN` and
+    ///   the infinities would otherwise panic in
+    ///   `RateLimiter::time_until_available` via `Duration::from_secs_f64`;
+    /// - zero session limits (`sessions.timeout_secs`,
+    ///   `sessions.max_streaming_sessions`, `sessions.max_repo_sessions`) —
+    ///   sessions would expire instantly or never be creatable;
+    /// - an unrecognised `logging.level` — otherwise it silently falls back to
+    ///   `warn`, masking a typo.
     ///
     /// # Errors
     ///
-    /// Returns an error if any validation checks fail.
-    pub const fn validate(&self) -> Result<(), ConfigError> {
-        // Currently no validation required for security/logging settings
-        // as they all have sensible defaults
+    /// Returns [`ConfigError::ValidationError`] naming the first out-of-range
+    /// field encountered.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        fn reject(message: impl Into<String>) -> ConfigError {
+            ConfigError::ValidationError {
+                message: message.into(),
+            }
+        }
+
+        // Durations and counts that brick a subsystem when zero. They parse
+        // fine (serde does not range-check), so they are caught here.
+        let nonzero_u64: [(u64, &str); 5] = [
+            (
+                self.timeouts.request_timeout_secs,
+                "timeouts.request_timeout_secs",
+            ),
+            (self.sessions.timeout_secs, "sessions.timeout_secs"),
+            (self.lfs.request_timeout_secs, "lfs.request_timeout_secs"),
+            (self.lfs.connect_timeout_secs, "lfs.connect_timeout_secs"),
+            (self.lfs.download_timeout_secs, "lfs.download_timeout_secs"),
+        ];
+        for (value, field) in nonzero_u64 {
+            if value == 0 {
+                return Err(reject(format!("{field} must be greater than 0")));
+            }
+        }
+
+        let nonzero_usize: [(usize, &str); 3] = [
+            (self.limits.max_output_bytes, "limits.max_output_bytes"),
+            (
+                self.sessions.max_streaming_sessions,
+                "sessions.max_streaming_sessions",
+            ),
+            (
+                self.sessions.max_repo_sessions,
+                "sessions.max_repo_sessions",
+            ),
+        ];
+        for (value, field) in nonzero_usize {
+            if value == 0 {
+                return Err(reject(format!("{field} must be greater than 0")));
+            }
+        }
+
+        if self.rate_limits.max_burst == 0 {
+            return Err(reject("rate_limits.max_burst must be greater than 0"));
+        }
+
+        let refill = self.rate_limits.refill_rate_per_sec;
+        if !refill.is_finite() || refill < 0.0 {
+            return Err(reject(
+                "rate_limits.refill_rate_per_sec must be a finite, non-negative number",
+            ));
+        }
+
+        let level = self.logging.level.to_lowercase();
+        if !VALID_LOG_LEVELS.contains(&level.as_str()) {
+            return Err(reject(format!(
+                "logging.level must be one of trace, debug, info, warn, error (got {:?})",
+                self.logging.level
+            )));
+        }
+
         Ok(())
     }
 }
@@ -169,6 +250,13 @@ impl Default for LoggingConfig {
 fn default_log_level() -> String {
     "warn".to_string()
 }
+
+/// Log levels accepted by `logging.level` (compared case-insensitively).
+///
+/// Mirrors the arms of `get_log_level` in `src/main.rs`; an unrecognised level
+/// there silently falls back to `warn`, so `Config::validate` rejects anything
+/// outside this set to surface typos at load time instead.
+const VALID_LOG_LEVELS: [&str; 5] = ["trace", "debug", "info", "warn", "error"];
 
 /// Default request timeout in seconds.
 const fn default_request_timeout_secs() -> u64 {
@@ -1163,5 +1251,131 @@ mod tests {
             config.submodules.exclude_patterns,
             Some(vec!["vendor/*".to_string()])
         );
+    }
+
+    #[test]
+    fn validate_rejects_zero_valued_critical_fields() {
+        // Each is a duration or count that makes a subsystem unusable when
+        // zero. They parse fine (serde does not range-check), so validate()
+        // must reject them and name the offending field.
+        type Mutator = fn(&mut Config);
+        let cases: [(&str, Mutator); 9] = [
+            ("timeouts.request_timeout_secs", |c| {
+                c.timeouts.request_timeout_secs = 0;
+            }),
+            ("limits.max_output_bytes", |c| {
+                c.limits.max_output_bytes = 0;
+            }),
+            ("rate_limits.max_burst", |c| {
+                c.rate_limits.max_burst = 0;
+            }),
+            ("sessions.timeout_secs", |c| {
+                c.sessions.timeout_secs = 0;
+            }),
+            ("sessions.max_streaming_sessions", |c| {
+                c.sessions.max_streaming_sessions = 0;
+            }),
+            ("sessions.max_repo_sessions", |c| {
+                c.sessions.max_repo_sessions = 0;
+            }),
+            ("lfs.request_timeout_secs", |c| {
+                c.lfs.request_timeout_secs = 0;
+            }),
+            ("lfs.connect_timeout_secs", |c| {
+                c.lfs.connect_timeout_secs = 0;
+            }),
+            ("lfs.download_timeout_secs", |c| {
+                c.lfs.download_timeout_secs = 0;
+            }),
+        ];
+
+        for (field, mutate) in cases {
+            let mut config: Config = serde_json::from_str("{}").unwrap();
+            mutate(&mut config);
+            let err = config.validate().unwrap_err();
+            assert!(
+                matches!(err, ConfigError::ValidationError { .. }),
+                "{field}: expected ValidationError, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains(field),
+                "{field}: error should name the field, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_or_negative_refill_rate() {
+        // A non-finite refill rate would panic downstream in
+        // RateLimiter::time_until_available (Duration::from_secs_f64).
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -0.1, -1.0] {
+            let mut config: Config = serde_json::from_str("{}").unwrap();
+            config.rate_limits.refill_rate_per_sec = bad;
+            let err = config.validate().unwrap_err();
+            assert!(
+                err.to_string().contains("refill_rate_per_sec"),
+                "refill_rate_per_sec = {bad} should be rejected, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_allows_zero_refill_rate() {
+        // 0.0 is the supported "burst once, never refill" mode (RateLimiter
+        // special-cases refill_rate <= 0.0), so it must NOT be rejected.
+        let mut config: Config = serde_json::from_str("{}").unwrap();
+        config.rate_limits.refill_rate_per_sec = 0.0;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_log_level() {
+        let mut config: Config = serde_json::from_str("{}").unwrap();
+        config.logging.level = "verbose".to_string();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("logging.level"));
+    }
+
+    #[test]
+    fn validate_accepts_known_log_levels_case_insensitively() {
+        for level in ["trace", "DEBUG", "Info", "warn", "ERROR"] {
+            let mut config: Config = serde_json::from_str("{}").unwrap();
+            config.logging.level = level.to_string();
+            assert!(
+                config.validate().is_ok(),
+                "log level {level:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_allows_values_handled_gracefully_downstream() {
+        // These zeros are intentionally NOT rejected because the consuming code
+        // copes with them: the submodule fetcher clamps max_concurrent to >= 1,
+        // max_failures of 0 is a valid "stop on first failure" choice, the LFS
+        // retry loop always makes one attempt regardless of retry_max_attempts,
+        // and max_object_size of 0 simply keeps every LFS object as a pointer.
+        let mut config: Config = serde_json::from_str("{}").unwrap();
+        config.submodules.max_concurrent = 0;
+        config.submodules.max_failures = 0;
+        config.lfs.retry_max_attempts = 0;
+        config.lfs.max_object_size = Some(0);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_allows_minimal_positive_values() {
+        let mut config: Config = serde_json::from_str("{}").unwrap();
+        config.timeouts.request_timeout_secs = 1;
+        config.limits.max_output_bytes = 1;
+        config.rate_limits.max_burst = 1;
+        config.rate_limits.refill_rate_per_sec = 0.0;
+        config.sessions.timeout_secs = 1;
+        config.sessions.max_streaming_sessions = 1;
+        config.sessions.max_repo_sessions = 1;
+        config.lfs.request_timeout_secs = 1;
+        config.lfs.connect_timeout_secs = 1;
+        config.lfs.download_timeout_secs = 1;
+        assert!(config.validate().is_ok());
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1333,10 +1333,18 @@ mod tests {
 
     #[test]
     fn validate_rejects_unknown_log_level() {
-        let mut config: Config = serde_json::from_str("{}").unwrap();
-        config.logging.level = "verbose".to_string();
-        let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("logging.level"));
+        // "warning" (Python style) and "verbose" are common mistakes; the empty
+        // string is the degenerate case. All previously fell through to `warn`
+        // in get_log_level; now they are rejected.
+        for bad in ["verbose", "warning", ""] {
+            let mut config: Config = serde_json::from_str("{}").unwrap();
+            config.logging.level = bad.to_string();
+            let err = config.validate().unwrap_err();
+            assert!(
+                err.to_string().contains("logging.level"),
+                "log level {bad:?} should be rejected, got: {err}"
+            );
+        }
     }
 
     #[test]
@@ -1367,7 +1375,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_allows_minimal_positive_values() {
+    fn validate_allows_minimal_valid_values() {
+        // Smallest value each field accepts: 1 for the counts/timeouts, and
+        // 0.0 for the refill rate (the burst-only mode).
         let mut config: Config = serde_json::from_str("{}").unwrap();
         config.timeouts.request_timeout_secs = 1;
         config.limits.max_output_bytes = 1;


### PR DESCRIPTION
## Description

Follow-up to #177. Turns `Config::validate()` from a no-op into a real
range-check, and fixes two pre-existing doc inaccuracies in `src/config`. Scope
is `src/config` only — no consuming module is changed; bad values are caught at
the config layer.

### The bug

`Config::validate()` (run by `load_config` at startup) accepted every value
that parsed. A handful of out-of-range values then silently broke a subsystem —
or **panicked**:

- A non-finite `rate_limits.refill_rate_per_sec` is the one genuine crash:
  `NaN` reaches `RateLimiter::time_until_available`, whose
  `Duration::from_secs_f64` **panics** on a non-finite value. (`±∞` and
  negatives don't panic — the `refill_rate <= 0.0` guard catches `-∞`, and `+∞`
  yields `0.0` — but they break the token-bucket maths: permanent block or no
  throttling, so they're rejected too.)
- Zero timeouts (`timeouts.request_timeout_secs`, the three `lfs.*_timeout_secs`)
  make every git command / LFS request fail immediately (`Duration::from_secs(0)`).
- `rate_limits.max_burst: 0` empties the token bucket forever — every operation
  blocked.
- Zero `sessions.timeout_secs` / `max_streaming_sessions` / `max_repo_sessions`
  make sessions expire instantly or uncreatable.
- An unrecognised `logging.level` silently degrades to `warn`, masking a typo.

`validate` now rejects each with a `ValidationError` naming the field. `0.0`
refill is still accepted (the supported "burst once, never refill" mode).

### Verified-safe values that are deliberately NOT rejected

Checking the consumers first avoided three wrong rules:

- `submodules.max_concurrent: 0` — the fetcher does `max_concurrent.max(1)`.
- `rate_limits.refill_rate_per_sec: 0.0` — a supported "burst once, never refill"
  mode (`RateLimiter` special-cases `<= 0.0`); only non-finite/negative is rejected.
- `lfs.retry_max_attempts: 0` — the retry loop always makes one attempt, so `0`
  behaves like `1`.

`submodules.max_failures: 0` and `lfs.max_object_size: 0` are likewise accepted.
Proxy-URL and glob-pattern validity are already enforced at their consumers, so
re-checking them here would be wrong duplication.

### Cosmetic doc fixes (pre-existing)

- `mod.rs` module doc claimed the config "only contains security and logging
  settings" — it has held ten sections since v1.1.0.
- `load_config`'s `# Errors` listed "Required fields are missing" — there are
  none (every section has a serde default).

## Related Issue

Follow-up to the "Findings that are NOT in this PR" note on #177.

## Type of Change

- [x] Bug fix (rejects values that panic / brick a subsystem)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

_Behavioural note: a config that previously loaded with one of the rejected
values will now fail fast at startup with a clear message. `Config::validate`
is no longer `const fn` (it builds error strings) — a theoretical break for a
downstream caller using it in a const context; there is none in-tree._

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (N/A — no credential handling touched)
- [x] Error messages don't leak sensitive information (messages name fields, never values beyond the log level string)

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

Eight new unit tests cover every rejected field, the non-finite/negative refill
cases, the allowed `0.0` refill, accepted log levels (case-insensitive) and
rejected ones (`verbose`/`warning`/empty), the deliberately-accepted "safe"
zeros, an all-minimum-valid config, and — in `config/mod.rs` — that `load_config`
surfaces the `ValidationError` (validation is wired into the load path).
`cargo llvm-cov`: `config/settings.rs` stays at **100% line coverage**;
`config/mod.rs` 97.97% → 98.08% (only the `home_dir() == None` arm remains,
unreachable in a test).

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` clean
- [x] Documentation is updated (CHANGELOG, README, docs/errors.md, rustdoc)
- [x] CHANGELOG.md is updated

## Additional Notes

### Commit map

- `012e8f1` — `feat(config): reject out-of-range values in Config::validate`
  (validation + `VALID_LOG_LEVELS` const + tests; CHANGELOG/README/errors.md).
- `5e5f2e4` — `docs(config): correct inaccurate module and load_config doc comments`.
- `449f296` — `docs(config): scope refill-rate failure mode to the NaN panic`
  (self-review fix: only `NaN` panics; `±∞`/negatives break the token-bucket
  maths, not panic).
- `3b0d6c5` — `test(config): prove load_config rejects bad values; tighten validate tests`
  (load-path wiring test; `verbose`/`warning`/empty log levels; test rename).
- `5a1ad64` — `docs(changelog): use clearer log-level typo examples`.

### Findings that are NOT in this PR

- **Validation is intentionally minimal.** It rejects only values that brick a
  subsystem or panic, not every "odd but harmless" value (e.g. a huge
  `retry_max_backoff_ms`, or `max_object_size: 0`). Widening it further risks
  rejecting legitimate edge configs.
- **No new field-level constraints across modules.** Enforcing, say, that
  `retry_max_backoff_ms >= retry_initial_backoff_ms` would be cross-field policy
  with no current failure mode; left out deliberately.
- **`logging.level` is matched exactly (after lowercasing), not trimmed.** A
  stray space (`"warn "`) is rejected rather than silently coerced, matching the
  explicit valid-level set; this is intentional fail-fast behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)