### PR TITLE
chore: ignore cargo-llvm-cov coverage artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ Cargo.lock
 nul
 __pycache__/
 .env.local
+
+# Coverage artefacts (cargo-llvm-cov --output-path; HTML reports land under target/)
+*.lcov
+lcov.info


### PR DESCRIPTION
## Description

Add `*.lcov` and `lcov.info` to `.gitignore`. Local coverage runs write lcov
reports to the repo root via `cargo llvm-cov --lcov --output-path <file>` —
`CONTRIBUTING.md` documents `lcov.info`, and ad-hoc runs use names like
`cov.lcov`. These were showing up as untracked clutter and could be committed by
accident. The HTML reports already live under the ignored `target/`.

## Related Issue

None — repo hygiene.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD changes (build/coverage tooling hygiene)
- [ ] Security improvement

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (N/A)
- [x] Error messages don't leak sensitive information (N/A)

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix/feature works (N/A — `.gitignore` only)
- [x] New and existing tests pass (`cargo test`) — unaffected

Verified with `git check-ignore -v cov.lcov` → matched by `.gitignore:9:*.lcov`,
and `git status` no longer lists the file.

## Code Quality

- [x] Code compiles without warnings (N/A — no code change)
- [x] Clippy passes (N/A)
- [x] Code is formatted (N/A)
- [x] Markdown is lint-clean (N/A — no Markdown change)
- [x] Toolchain pin is consistent (unchanged)
- [x] Documentation is updated if needed (none needed)
- [x] CHANGELOG.md is updated (not a user-facing change — local dev artefacts only)

## Additional Notes

`.gitignore`-only change; no CHANGELOG entry since it affects contributors' local
coverage artefacts, not the shipped software.

🤖 Generated with [Claude Code](https://claude.com/claude-code)