### PR TITLE
fix(refs): resolve default branch from HEAD symref, not OID match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,6 +451,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`repo_refs` reported a non-deterministic default branch when several
+  branches shared the `HEAD` commit.** `list_remote_refs` derived
+  `default_branch` by scanning the branch list for the first entry whose OID
+  equalled `HEAD`'s OID — but that scan ran over the remote's *advertised* ref
+  order (before the alphabetical sort), so a repo where, say, `develop` and
+  `main` both point at the same commit (a freshly-cut branch off `main`) could
+  report whichever the remote happened to list first. It now uses the remote's
+  advertised `HEAD` symref via `Remote::default_branch()` (the same
+  authoritative source `clone.rs`'s `fetch_bare` already relies on), falling
+  back to `"main"` only when no symref is advertised. The OID-matching logic is
+  gone. As part of the fix, the connect/list/parse body was split into a private
+  `list_refs_inner` helper so the path can be exercised against a local
+  `file://` remote (`list_remote_refs` still rejects `file://` via
+  `validate_url` before delegating), and the default-branch resolution is now a
+  pure `resolve_default_branch` helper. `git2_ops/refs.rs` line coverage rose
+  from 49.53 % to 99.04 % (15 tests, up from 4): a local-remote integration test
+  (branches, lightweight + annotated tags with `^{}` peeled entries skipped,
+  HEAD excluded, the same-commit ambiguity that the bug mishandled), seven
+  `resolve_default_branch` cases, and proxy/empty-repo/unreachable-remote paths.
 - **`is_lfs_pointer` would have misclassified a hypothetical future
   `spec/v10` (or `v11`, `v100`, …) as a v1 pointer.** The previous
   check was `starts_with("version https://git-lfs.github.com/spec/v1")`,

--- a/src/git2_ops/refs.rs
+++ b/src/git2_ops/refs.rs
@@ -72,46 +72,59 @@ pub struct RefsResult {
 pub fn list_remote_refs(url: &str, proxy_url: Option<&str>) -> Result<RefsResult, Git2Error> {
     info!(url = %sanitize_url_for_logging(url), "listing remote refs");
 
-    // Validate URL
+    // Validate URL (rejects file://, ext::, and other non-network schemes).
     validate_url(url)?;
 
-    // Create a temporary repository for the remote connection (auto-cleaned on drop)
+    list_refs_inner(url, proxy_url)
+}
+
+/// Connects to `url` and lists its refs — the body of [`list_remote_refs`].
+///
+/// Split out so tests can exercise the connect/list/parse path against a local
+/// `file://` remote: [`list_remote_refs`] rejects non-network URLs via
+/// [`validate_url`] before reaching here, but this helper does not, so a test
+/// can point it at a local bare repository without weakening that guard.
+fn list_refs_inner(url: &str, proxy_url: Option<&str>) -> Result<RefsResult, Git2Error> {
+    // Temporary repository for the remote connection (auto-cleaned on drop).
     let temp_dir = TempDir::new().map_err(Git2Error::TempDirFailed)?;
     let repo = Repository::init_bare(temp_dir.path())?;
 
-    let (mut branches, mut tags, default_branch, head_oid) = {
-        // Create remote with callbacks in a scope so it gets dropped before repo
+    let (mut branches, mut tags, default_branch) = {
+        // Create remote with callbacks in a scope so it gets dropped before repo.
         let mut remote = repo.remote_anonymous(url)?;
         let callbacks = create_callbacks();
 
         let mut proxy_opts = git2::ProxyOptions::new();
-        if let Some(url) = proxy_url {
-            proxy_opts.url(url);
+        if let Some(proxy) = proxy_url {
+            proxy_opts.url(proxy);
         } else {
             proxy_opts.auto();
         }
 
-        // Connect to remote and get refs
         debug!("connecting to remote");
         remote.connect_auth(Direction::Fetch, Some(callbacks), Some(proxy_opts))?;
+
+        // The remote's advertised HEAD symref (e.g. b"refs/heads/main") is the
+        // authoritative default branch. Matching HEAD's OID against the branch
+        // list instead is ambiguous when several branches point at the same
+        // commit (e.g. a freshly-created branch off the default).
+        let default_branch = resolve_default_branch(remote.default_branch().ok().as_deref());
 
         let remote_refs = remote.list()?;
 
         let mut branches = Vec::new();
         let mut tags = Vec::new();
-        let mut head_oid: Option<String> = None;
 
         for head in remote_refs {
             let name = head.name();
             let oid = head.oid();
 
-            // Capture HEAD's OID for default branch detection
+            // HEAD is resolved via the symref above, not listed as a branch.
             if name == "HEAD" {
-                head_oid = Some(oid.to_string());
                 continue;
             }
 
-            // Parse the reference type
+            // Parse the reference type.
             if let Some(branch_name) = name.strip_prefix("refs/heads/") {
                 branches.push(RefInfo {
                     name: name.to_string(),
@@ -119,7 +132,7 @@ pub fn list_remote_refs(url: &str, proxy_url: Option<&str>) -> Result<RefsResult
                     commit: oid.to_string(),
                 });
             } else if let Some(tag_name) = name.strip_prefix("refs/tags/") {
-                // Skip ^{} peeled refs (they're duplicates for annotated tags)
+                // Skip ^{} peeled refs (duplicates emitted for annotated tags).
                 if !tag_name.ends_with("^{}") {
                     tags.push(RefInfo {
                         name: name.to_string(),
@@ -130,38 +143,21 @@ pub fn list_remote_refs(url: &str, proxy_url: Option<&str>) -> Result<RefsResult
             }
         }
 
-        // Determine default branch from HEAD OID
-        #[allow(clippy::option_if_let_else)]
-        let default_branch = if let Some(ref head_commit) = head_oid {
-            branches
-                .iter()
-                .find(|b| &b.commit == head_commit)
-                .map_or_else(|| "main".to_string(), |b| b.short_name.clone())
-        } else {
-            "main".to_string()
-        };
-
-        (branches, tags, default_branch, head_oid)
+        (branches, tags, default_branch)
     };
     // remote is now dropped, repo can be dropped
 
-    // Sort branches and tags alphabetically
+    // Sort branches and tags alphabetically by short name.
     branches.sort_by(|a, b| a.short_name.cmp(&b.short_name));
     tags.sort_by(|a, b| a.short_name.cmp(&b.short_name));
 
     let total_refs = branches.len() + tags.len();
 
-    // Clean up: drop repo first, then temp_dir cleans itself
+    // Clean up: drop repo first, then temp_dir cleans itself.
     drop(repo);
     drop(temp_dir);
 
-    info!(
-        branches = branches.len(),
-        tags = tags.len(),
-        default_branch = %default_branch,
-        head_oid = ?head_oid,
-        "refs listing complete"
-    );
+    info!(branches = branches.len(), tags = tags.len(), default_branch = %default_branch, "refs listing complete");
 
     Ok(RefsResult {
         branches,
@@ -171,9 +167,34 @@ pub fn list_remote_refs(url: &str, proxy_url: Option<&str>) -> Result<RefsResult
     })
 }
 
+/// Resolves the default branch name from the remote's advertised `HEAD` symref.
+///
+/// `head_symref` is the raw bytes returned by [`git2::Remote::default_branch`]
+/// (e.g. `b"refs/heads/main"`). Falls back to `"main"` when the symref is
+/// absent, non-UTF-8, not under `refs/heads/`, or empty.
+fn resolve_default_branch(head_symref: Option<&[u8]>) -> String {
+    head_symref
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+        .map(str::trim)
+        .and_then(|name| name.strip_prefix("refs/heads/"))
+        .filter(|name| !name.is_empty())
+        .map_or_else(|| "main".to_string(), ToString::to_string)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Builds a `file://` URL for a local repository path, translating Windows
+    /// backslashes (mirrors the helper in `clone.rs`'s tests).
+    fn local_file_url(path: &std::path::Path) -> String {
+        let raw = path.display().to_string();
+        if cfg!(windows) {
+            format!("file:///{}", raw.replace('\\', "/"))
+        } else {
+            format!("file://{raw}")
+        }
+    }
 
     #[test]
     fn ref_info_serializes() {
@@ -219,5 +240,147 @@ mod tests {
     fn list_remote_refs_rejects_file_url() {
         let result = list_remote_refs("file:///etc/passwd", None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_default_branch_uses_head_symref() {
+        assert_eq!(
+            resolve_default_branch(Some(b"refs/heads/develop")),
+            "develop"
+        );
+    }
+
+    #[test]
+    fn resolve_default_branch_keeps_nested_branch_name() {
+        assert_eq!(
+            resolve_default_branch(Some(b"refs/heads/feature/login")),
+            "feature/login"
+        );
+    }
+
+    #[test]
+    fn resolve_default_branch_trims_trailing_noise() {
+        assert_eq!(resolve_default_branch(Some(b"refs/heads/main\n")), "main");
+    }
+
+    #[test]
+    fn resolve_default_branch_falls_back_when_absent() {
+        assert_eq!(resolve_default_branch(None), "main");
+    }
+
+    #[test]
+    fn resolve_default_branch_falls_back_on_non_heads_ref() {
+        assert_eq!(resolve_default_branch(Some(b"refs/tags/v1.0")), "main");
+    }
+
+    #[test]
+    fn resolve_default_branch_falls_back_on_invalid_utf8() {
+        assert_eq!(resolve_default_branch(Some(&[0xff, 0xfe, 0x00])), "main");
+    }
+
+    #[test]
+    fn resolve_default_branch_falls_back_on_empty_branch_name() {
+        assert_eq!(resolve_default_branch(Some(b"refs/heads/")), "main");
+    }
+
+    #[test]
+    fn list_refs_inner_reads_branches_tags_and_default_branch() {
+        // Build a bare "remote" with HEAD -> main, a develop branch pointing at
+        // the same commit as main, a lightweight tag and an annotated tag; then
+        // list its refs over file:// (mirroring clone.rs's local-remote test).
+        // Calling the inner helper directly bypasses validate_url's file://
+        // rejection without weakening it.
+        let source = TempDir::new().unwrap();
+        let repo = Repository::init_bare(source.path()).unwrap();
+        repo.set_head("refs/heads/main").unwrap();
+
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_oid = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let commit_oid = repo
+            .commit(Some("refs/heads/main"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+
+        // A second branch at the SAME commit as main. The old OID-matching
+        // default-branch logic could pick this one (it sorts before "main");
+        // the symref-based logic must still resolve to "main".
+        repo.reference("refs/heads/develop", commit_oid, true, "create develop")
+            .unwrap();
+
+        let commit_obj = repo.find_object(commit_oid, None).unwrap();
+        repo.tag_lightweight("v1.0", &commit_obj, false).unwrap();
+        repo.tag("v2.0", &commit_obj, &sig, "release 2.0", false)
+            .unwrap();
+
+        let result = list_refs_inner(&local_file_url(source.path()), None).unwrap();
+
+        // Branches sorted by short name, HEAD excluded.
+        let branch_names: Vec<&str> = result
+            .branches
+            .iter()
+            .map(|b| b.short_name.as_str())
+            .collect();
+        assert_eq!(branch_names, ["develop", "main"]);
+
+        // Lightweight + annotated tags, sorted, with ^{} peeled entries skipped.
+        let tag_names: Vec<&str> = result.tags.iter().map(|t| t.short_name.as_str()).collect();
+        assert_eq!(tag_names, ["v1.0", "v2.0"]);
+
+        // Default branch comes from HEAD's symref, not OID matching.
+        assert_eq!(result.default_branch, "main");
+        assert_eq!(result.total_refs, 4);
+
+        // Full ref names preserved; the lightweight tag points straight at the
+        // commit.
+        let main = result
+            .branches
+            .iter()
+            .find(|b| b.short_name == "main")
+            .unwrap();
+        assert_eq!(main.name, "refs/heads/main");
+        assert_eq!(main.commit, commit_oid.to_string());
+        let v1 = result.tags.iter().find(|t| t.short_name == "v1.0").unwrap();
+        assert_eq!(v1.commit, commit_oid.to_string());
+    }
+
+    #[test]
+    fn list_refs_inner_handles_remote_with_no_refs() {
+        let source = TempDir::new().unwrap();
+        Repository::init_bare(source.path()).unwrap();
+
+        let result = list_refs_inner(&local_file_url(source.path()), None).unwrap();
+        assert!(result.branches.is_empty());
+        assert!(result.tags.is_empty());
+        assert_eq!(result.total_refs, 0);
+        // Nothing advertised -> "main" fallback.
+        assert_eq!(result.default_branch, "main");
+    }
+
+    #[test]
+    fn list_refs_inner_errors_on_nonexistent_local_remote() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        let result = list_refs_inner(&local_file_url(&missing), None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn list_refs_inner_accepts_proxy_url() {
+        // Exercises the proxy-configuration branch. For local file:// transport
+        // the proxy is irrelevant (it only applies to HTTP), so listing still
+        // succeeds — we just need the `Some(proxy)` arm to run.
+        let source = TempDir::new().unwrap();
+        let repo = Repository::init_bare(source.path()).unwrap();
+        repo.set_head("refs/heads/main").unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_oid = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        repo.commit(Some("refs/heads/main"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+
+        let result =
+            list_refs_inner(&local_file_url(source.path()), Some("http://127.0.0.1:9")).unwrap();
+        assert_eq!(result.default_branch, "main");
+        assert_eq!(result.branches.len(), 1);
     }
 }


### PR DESCRIPTION
## Description

First of the `src/git2_ops` audit series (refs → clone → pull → diff →
submodule). `refs.rs` had the lowest coverage in the module (49.53%) and the
audit turned up a real bug.

### The bug

`list_remote_refs` derived `default_branch` by scanning the branch list for the
first entry whose OID equalled `HEAD`'s OID. That scan ran over the remote's
**advertised ref order** (the sort happens afterwards), so when several branches
point at `HEAD`'s commit — e.g. a freshly-cut branch off `main` — it could
report whichever branch the remote listed first. Non-deterministic, and often
wrong (`develop` instead of `main`).

**Fix:** use the remote's advertised `HEAD` symref via
`Remote::default_branch()` — the authoritative source `clone.rs`'s `fetch_bare`
already relies on — falling back to `"main"` only when no symref is advertised.
The OID-matching logic is removed.

### Refactor for testability

The whole connect/list/parse body was untested (only `validate_url` rejection +
struct serialisation were). Split out:

- `list_refs_inner` — the post-validation body. `list_remote_refs` still calls
  `validate_url` before delegating, so `file://` stays rejected on the public
  path; tests point the inner helper at a local `file://` bare repo (the same
  technique `clone.rs`'s test uses).
- `resolve_default_branch(Option<&[u8]>) -> String` — pure HEAD-symref decoding,
  unit-tested for every fallback (absent / non-UTF-8 / non-`refs/heads/` /
  empty).

## Related Issue

Part of the `src/git2_ops` coverage + bug-hunt sweep.

## Type of Change

- [x] Bug fix (non-deterministic default branch)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (unchanged — same `create_callbacks`)
- [x] Error messages don't leak sensitive information (URLs still go through `sanitize_url_for_logging`)

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

`refs.rs` line coverage **49.53% → 99.04%** (15 tests, up from 4). The
integration test builds a bare remote where `develop` shares `main`'s commit and
asserts the default resolves to `main` — a direct regression guard for the bug.

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` clean
- [x] Documentation is updated if needed (CHANGELOG)
- [x] CHANGELOG.md is updated

## Additional Notes

### Findings that are NOT in this PR

- **Annotated tags report the tag-object OID, not the peeled commit OID.** The
  loop keeps the non-`^{}` advertised ref, so an annotated tag's `commit` field
  is the tag object's SHA. This matches what the non-peeled `git ls-remote` line
  shows and is unchanged behaviour; peeling to the underlying commit would be a
  separate, deliberate change.
- **2 lines remain uncovered, both inherent:** the `^{}` peeled-tag skip branch
  (libgit2's local transport doesn't advertise peeled refs, so it can't be hit
  without a real smart-protocol server) and the `cfg!(windows)` arm of the test
  URL helper (the other platform's arm is dead on any given OS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)