### PR TITLE
docs(readme): drop misplaced/inaccurate Rust toolchain block from Installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,9 @@ When submitting:
 
 ### Prerequisites
 
-- Rust 1.75+ minimum (`Cargo.toml`); CI and local dev use the exact version pinned in `rust-toolchain.toml`
+- Rust — the toolchain is pinned to 1.95.0 in `rust-toolchain.toml` and auto-installed by
+  rustup when you run any `cargo` command in the repo (`Cargo.toml`'s `rust-version = 1.75`
+  records the minimum the code compiles against)
 - Git 2.x (must be in PATH)
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -349,17 +349,6 @@ credentials via the OS credential helper — see `src/git2_ops/auth.rs`) and `gi
 Any reasonably modern git (2.x) on `PATH` works; bundles produced by git ≥ 2.53 (with the
 `# v3 git bundle` header) are also accepted.
 
-#### Rust toolchain
-
-- **Minimum supported Rust version (MSRV):** 1.75 — declared in `Cargo.toml` as `rust-version`.
-  Anyone consuming git-proxy-mcp as a library only needs 1.75 or newer.
-- **Pinned development version:** 1.95.0 — declared in `rust-toolchain.toml`. CI builds, releases,
-  and the `target/release/` binary you produce locally all use this exact version. Running any
-  `cargo` command inside the repo auto-installs it via rustup.
-
-This two-tier approach (loose MSRV + strict pin) gives reproducibility for our builds without forcing
-downstream consumers onto a specific point release.
-
 #### Git authentication
 
 Configure Git to authenticate without prompting:


### PR DESCRIPTION
## Description

Two related README fixes you flagged:

1. **False "library" framing.** The Installation › Prerequisites › *Rust
   toolchain* block said *"Anyone consuming git-proxy-mcp as a library only
   needs 1.75 or newer"* and justified the MSRV/pin split by *"not forcing
   downstream consumers onto a specific point release."* git-proxy-mcp is an
   **MCP server executable**, not a library anyone depends on — the `[lib]`
   target in `Cargo.toml` exists only so the test crates can
   `use git_proxy_mcp::…` internally; it is not a published API. So there are
   no "downstream consumers", and the framing was simply wrong.
2. **Misplaced section.** That block is build/dev detail (MSRV, pinned
   toolchain, the two-tier rationale) — it doesn't belong under *Installation*,
   which covers runtime/setup prerequisites.

### Change

- Removed the *Rust toolchain* subsection from the README's Installation
  section. The runtime prerequisites that DO belong there — **Git CLI** and
  **Git authentication** — are untouched.
- Relocated the accurate, non-library part to `CONTRIBUTING.md` › Development
  Setup (its canonical home per STYLE.md's single-source-of-truth rule): the
  toolchain is pinned to 1.95.0 in `rust-toolchain.toml` and auto-installed by
  rustup; `Cargo.toml`'s `rust-version = 1.75` records the compile minimum.

No code or behaviour change.

## Related Issue

Reported during README review.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (N/A)
- [x] Error messages don't leak sensitive information (N/A)

## Testing

- [x] I have tested these changes locally (`markdownlint-cli2` clean)
- [ ] I have added tests that prove my fix/feature works (N/A — docs only)
- [x] New and existing tests pass (`cargo test`) — unaffected (no code change)

## Code Quality

- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Documentation is updated (README + CONTRIBUTING)
- [x] CHANGELOG.md is updated (not needed — internal docs wording, no user-facing/behaviour change)

## Additional Notes

I grepped all `*.md` for `library`/`downstream`/`consum`/`MSRV` to be sure this
was the only spot with the wrong framing — every other hit refers to the *git2*
dependency ("git2 library") or internal module consumers, which are correct.

Possible follow-up (not in this PR): `Cargo.toml` still carries
`rust-version = "1.75"`. It's harmless metadata, but since there are no external
library consumers it's arguably moot — happy to revisit if you'd like it dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)