### PR TITLE
fix(git2_ops): sanitise network git2 error messages; cover clone.rs fetch path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`git2_ops::clone` fetch-path coverage.** `fetch_bare`'s body was untested
+  (only `decode_default_branch` and the `validate_url` rejection were covered).
+  Extracted a private `fetch_bare_inner` past the URL validation so tests drive
+  the connect/fetch path against a local `file://` remote (`fetch_bare` still
+  rejects `file://` on the public path): default-branch fetch, explicit-branch
+  fetch, depth, proxy, missing-branch and nonexistent-remote errors, plus
+  full-path `validate_url` rejection and an unreachable-host (`127.0.0.1:1`)
+  test. `clone.rs` line coverage rose from 51.50 % to 93.57 %.
+
 - **9 new `config` regression tests** taking `config/mod.rs` line
   coverage from 91.40 % to 97.97 % and adding drift guards around the
   configuration schema. `config/settings.rs` was already at 100 %; the
@@ -945,6 +954,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Network git2 error messages are now routed through a credential-safe
+  sanitiser instead of being wrapped raw.** The connect/fetch/push call sites in
+  `git2_ops::{clone,diff,pull,push}` mapped errors with
+  `FetchFailed(e.message().to_string())` / `PushFailed(...)`, bypassing the
+  sanitising `From<git2::Error>` impl. A git2 error that echoed a URL with
+  embedded userinfo (e.g. `https://user:token@host`) would then reach the
+  operator's logs and the MCP response unredacted. Two credential-safe
+  constructors — `Git2Error::from_fetch` and `from_push` — now collapse
+  auth-class errors to the detail-free `AuthenticationFailed` and run any other
+  message through `sanitize_error_message`, which additionally redacts the
+  userinfo of any `scheme://user:secret@host` substring (the existing
+  keyword-line filter would miss a token embedded in a URL). The local-object
+  error sites (tree/commit/diff/revwalk/peel) are intentionally unchanged — they
+  cannot contain credentials. `From`'s behaviour is unchanged (refactored to
+  share an `is_auth_error` helper). Regression-tested with `redact_url_userinfo`,
+  `from_fetch`/`from_push`, and unreachable-host tests for clone/diff/pull.
 - **LFS download size now bounded against the *actual* response body,
   not just the pre-flight pointer size.** The previous
   `pointer.size > max_object_size` check was necessary but not sufficient:

--- a/src/git2_ops/clone.rs
+++ b/src/git2_ops/clone.rs
@@ -22,7 +22,7 @@ use tempfile::TempDir;
 use tracing::{debug, info};
 
 use super::auth::{create_callbacks_with_progress, validate_url};
-use super::error::Git2Error;
+use super::error::{sanitize_error_message, Git2Error};
 use crate::mcp::ProgressSender;
 
 /// Result of a successful fetch operation.
@@ -118,12 +118,16 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
     // Validate URL before doing anything
     validate_url(url)?;
 
-    info!(
-        url = %super::auth::sanitize_url_for_logging(url),
-        branch = options.branch.as_deref().unwrap_or("(remote default)"),
-        "starting bare fetch"
-    );
+    info!(url = %super::auth::sanitize_url_for_logging(url), branch = options.branch.as_deref().unwrap_or("(remote default)"), "starting bare fetch");
 
+    fetch_bare_inner(url, &options)
+}
+
+/// Fetches into a fresh bare repo — the body of [`fetch_bare`] after URL
+/// validation. Split out so tests can drive the connect/fetch path against a
+/// local `file://` remote; [`fetch_bare`] still rejects non-network URLs via
+/// [`validate_url`] before delegating here.
+fn fetch_bare_inner(url: &str, options: &FetchOptions2) -> Result<FetchResult, Git2Error> {
     // Create temp directory for bare repo
     let temp_dir = TempDir::new().map_err(Git2Error::TempDirFailed)?;
 
@@ -138,9 +142,12 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
     // Resolve the branch name and fetch in a single connection. Scope the
     // remote so it's dropped before we return the repo.
     let branch_name = {
-        let mut remote = repo
-            .remote_anonymous(url)
-            .map_err(|e| Git2Error::InitFailed(format!("failed to create remote: {e}")))?;
+        let mut remote = repo.remote_anonymous(url).map_err(|e| {
+            Git2Error::InitFailed(format!(
+                "failed to create remote: {}",
+                sanitize_error_message(e.message())
+            ))
+        })?;
 
         // Connect once so we can both query the default branch (when the
         // caller didn't pass one) and reuse the same connection for fetch.
@@ -157,7 +164,7 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
                 Some(connect_callbacks),
                 Some(connect_proxy),
             )
-            .map_err(|e| Git2Error::FetchFailed(e.message().to_string()))?;
+            .map_err(|e| Git2Error::from_fetch(&e))?;
 
         // Resolve branch: caller-supplied wins; otherwise ask the connected
         // remote for its default. We never fall back to a hard-coded "main"
@@ -168,7 +175,7 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
             let default_buf = remote.default_branch().map_err(|e| {
                 Git2Error::FetchFailed(format!(
                     "could not determine remote's default branch: {}",
-                    e.message()
+                    sanitize_error_message(e.message())
                 ))
             })?;
             let resolved = decode_default_branch(&default_buf)?;
@@ -203,7 +210,7 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
 
         remote
             .fetch(&[&refspec], Some(&mut fetch_opts), None)
-            .map_err(|e| Git2Error::FetchFailed(e.message().to_string()))?;
+            .map_err(|e| Git2Error::from_fetch(&e))?;
 
         branch_name
     };
@@ -220,11 +227,7 @@ pub fn fetch_bare(url: &str, options: Option<FetchOptions2>) -> Result<FetchResu
             .id()
     };
 
-    info!(
-        commit = %head_commit,
-        branch = %branch_name,
-        "fetch complete"
-    );
+    info!(commit = %head_commit, branch = %branch_name, "fetch complete");
 
     Ok(FetchResult {
         repo,
@@ -347,19 +350,171 @@ mod tests {
         let dest = tempfile::TempDir::new().unwrap();
         let dest_repo = Repository::init_bare(dest.path()).unwrap();
 
-        // file:// URL form, with Windows-friendly path translation.
-        let raw_path = source.path().display().to_string();
-        let url = if cfg!(windows) {
-            format!("file:///{}", raw_path.replace('\\', "/"))
-        } else {
-            format!("file://{raw_path}")
-        };
-
-        let mut remote = dest_repo.remote_anonymous(&url).unwrap();
+        let mut remote = dest_repo
+            .remote_anonymous(&local_file_url(source.path()))
+            .unwrap();
         remote.connect(Direction::Fetch).unwrap();
         let buf = remote.default_branch().unwrap();
 
         let resolved = decode_default_branch(&buf).unwrap();
         assert_eq!(resolved, "develop");
+    }
+
+    /// Builds a `file://` URL for a local path (Windows-friendly).
+    fn local_file_url(path: &std::path::Path) -> String {
+        let raw = path.display().to_string();
+        if cfg!(windows) {
+            format!("file:///{}", raw.replace('\\', "/"))
+        } else {
+            format!("file://{raw}")
+        }
+    }
+
+    /// Creates a bare source repo with one commit on `branch` (set as HEAD) and
+    /// returns the temp dir (kept alive by the caller) plus the commit id.
+    fn make_source_repo(branch: &str) -> (TempDir, Oid) {
+        let source = TempDir::new().unwrap();
+        let repo = Repository::init_bare(source.path()).unwrap();
+        repo.set_head(&format!("refs/heads/{branch}")).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_oid = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let commit = repo
+            .commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+        (source, commit)
+    }
+
+    #[test]
+    fn fetch_bare_rejects_file_url() {
+        assert!(matches!(
+            fetch_bare("file:///etc/passwd", None),
+            Err(Git2Error::InvalidUrl)
+        ));
+    }
+
+    #[test]
+    fn fetch_bare_rejects_invalid_url() {
+        assert!(matches!(
+            fetch_bare("/local/path", None),
+            Err(Git2Error::InvalidUrl)
+        ));
+    }
+
+    #[test]
+    fn fetch_bare_fails_fast_on_unreachable_host() {
+        // Exercises the full public path (validate -> info -> fetch_bare_inner
+        // -> connect) via a host that RSTs immediately, so there's no slow
+        // timeout. A refused connection is not an auth error, so it surfaces as
+        // FetchFailed.
+        // `FetchResult` isn't `Debug`, so inspect the error (which is).
+        let err = fetch_bare("https://127.0.0.1:1/owner/repo.git", None).err();
+        assert!(
+            matches!(err, Some(Git2Error::FetchFailed(_))),
+            "expected FetchFailed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn fetch_bare_inner_fetches_default_branch() {
+        let (source, commit) = make_source_repo("main");
+        let result =
+            fetch_bare_inner(&local_file_url(source.path()), &FetchOptions2::default()).unwrap();
+        assert_eq!(result.branch, "main");
+        assert_eq!(result.head_commit, commit);
+        // The branch ref was fetched into the bare repo.
+        assert!(result.repo.find_reference("refs/heads/main").is_ok());
+    }
+
+    #[test]
+    fn fetch_bare_inner_fetches_explicit_branch() {
+        // Source has `main` (default) plus a `feature` branch at its own commit.
+        let source = TempDir::new().unwrap();
+        let repo = Repository::init_bare(source.path()).unwrap();
+        repo.set_head("refs/heads/main").unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_oid = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let main_commit = repo
+            .commit(Some("refs/heads/main"), &sig, &sig, "on main", &tree, &[])
+            .unwrap();
+        let main_obj = repo.find_commit(main_commit).unwrap();
+        let feature_commit = repo
+            .commit(
+                Some("refs/heads/feature"),
+                &sig,
+                &sig,
+                "on feature",
+                &tree,
+                &[&main_obj],
+            )
+            .unwrap();
+
+        let result = fetch_bare_inner(
+            &local_file_url(source.path()),
+            &FetchOptions2 {
+                branch: Some("feature".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(result.branch, "feature");
+        assert_eq!(result.head_commit, feature_commit);
+    }
+
+    #[test]
+    fn fetch_bare_inner_accepts_depth_option() {
+        let (source, commit) = make_source_repo("main");
+        // Shallow support over the local transport varies by libgit2 build, so
+        // we only require the depth path not to break the call; when the fetch
+        // succeeds the head must still be the tip commit.
+        if let Ok(result) = fetch_bare_inner(
+            &local_file_url(source.path()),
+            &FetchOptions2 {
+                branch: Some("main".to_string()),
+                depth: Some(1),
+                ..Default::default()
+            },
+        ) {
+            assert_eq!(result.head_commit, commit);
+        }
+    }
+
+    #[test]
+    fn fetch_bare_inner_accepts_proxy_option() {
+        // The proxy is irrelevant to local file:// transport, so the fetch still
+        // succeeds — this just exercises the proxy-configuration branch.
+        let (source, commit) = make_source_repo("main");
+        let result = fetch_bare_inner(
+            &local_file_url(source.path()),
+            &FetchOptions2 {
+                branch: Some("main".to_string()),
+                proxy_url: Some("http://127.0.0.1:9".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(result.head_commit, commit);
+    }
+
+    #[test]
+    fn fetch_bare_inner_fails_for_missing_branch() {
+        let (source, _) = make_source_repo("main");
+        let result = fetch_bare_inner(
+            &local_file_url(source.path()),
+            &FetchOptions2 {
+                branch: Some("does-not-exist".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_bare_inner_errors_on_nonexistent_local_remote() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("no-such-repo");
+        let result = fetch_bare_inner(&local_file_url(&missing), &FetchOptions2::default());
+        assert!(result.is_err());
     }
 }

--- a/src/git2_ops/diff.rs
+++ b/src/git2_ops/diff.rs
@@ -17,7 +17,7 @@ use tempfile::TempDir;
 use tracing::{debug, info};
 
 use super::auth::{create_callbacks, sanitize_url_for_logging, validate_url};
-use super::error::Git2Error;
+use super::error::{sanitize_error_message, Git2Error};
 
 /// Statistics about the diff.
 #[derive(Debug, Clone, Serialize, Default)]
@@ -105,9 +105,12 @@ pub fn generate_diff(
     // Fetch all refs to ensure we have both commits
     // Using +refs/*:refs/* to get all branches and tags
     {
-        let mut remote = repo
-            .remote_anonymous(url)
-            .map_err(|e| Git2Error::InitFailed(format!("failed to create remote: {e}")))?;
+        let mut remote = repo.remote_anonymous(url).map_err(|e| {
+            Git2Error::InitFailed(format!(
+                "failed to create remote: {}",
+                sanitize_error_message(e.message())
+            ))
+        })?;
 
         let callbacks = create_callbacks();
         let mut fetch_opts = FetchOptions::new();
@@ -130,7 +133,7 @@ pub fn generate_diff(
                 Some(&mut fetch_opts),
                 None,
             )
-            .map_err(|e| Git2Error::FetchFailed(e.message().to_string()))?;
+            .map_err(|e| Git2Error::from_fetch(&e))?;
     }
 
     debug!("fetch complete, looking up commits");
@@ -312,6 +315,14 @@ mod tests {
     fn generate_diff_rejects_file_url() {
         let result = generate_diff("file:///etc/passwd", "abc", "def", None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn generate_diff_fails_fast_on_unreachable_host() {
+        // Reaches the fetch (past validate_url) against a host that RSTs
+        // immediately, exercising the credential-safe fetch error mapping.
+        let result = generate_diff("https://127.0.0.1:1/o/r.git", "abc", "def", None);
+        assert!(matches!(result, Err(Git2Error::FetchFailed(_))));
     }
 
     /// Helper: build a test bare repo with two commits, return temp dir + commit OIDs.

--- a/src/git2_ops/error.rs
+++ b/src/git2_ops/error.rs
@@ -55,29 +55,61 @@ pub enum Git2Error {
 
 impl From<git2::Error> for Git2Error {
     fn from(err: git2::Error) -> Self {
-        // Sanitise the error message to avoid credential leakage
-        let message = err.message();
-
-        // Check for authentication-related errors
-        if err.class() == git2::ErrorClass::Ssh
-            || err.class() == git2::ErrorClass::Http
-            || message.contains("auth")
-            || message.contains("credential")
-            || message.contains("password")
-            || message.contains("token")
-        {
-            return Self::AuthenticationFailed;
+        if is_auth_error(&err) {
+            Self::AuthenticationFailed
+        } else {
+            Self::Git2(sanitize_error_message(err.message()))
         }
-
-        // Generic sanitised error
-        Self::Git2(sanitize_error_message(message))
     }
 }
 
-/// Sanitise an error message to remove potential credential information.
-fn sanitize_error_message(message: &str) -> String {
-    // Remove anything that looks like a token or password
-    // This is a basic implementation — extend as needed
+impl Git2Error {
+    /// Credential-safe mapping for a git2 error from a *network* operation
+    /// (`connect` / `fetch`). Auth-class or auth-keyword errors collapse to
+    /// [`Self::AuthenticationFailed`] (no detail leaked); any other message is
+    /// run through [`sanitize_error_message`] and wrapped in
+    /// [`Self::FetchFailed`].
+    ///
+    /// Prefer this over `FetchFailed(err.message().to_string())`, which would
+    /// let a credential-bearing git2 message (e.g. a URL with embedded
+    /// userinfo) reach logs and the client unmodified.
+    #[must_use]
+    pub(crate) fn from_fetch(err: &git2::Error) -> Self {
+        if is_auth_error(err) {
+            Self::AuthenticationFailed
+        } else {
+            Self::FetchFailed(sanitize_error_message(err.message()))
+        }
+    }
+
+    /// As [`Self::from_fetch`], but non-auth messages are wrapped in
+    /// [`Self::PushFailed`].
+    #[must_use]
+    pub(crate) fn from_push(err: &git2::Error) -> Self {
+        if is_auth_error(err) {
+            Self::AuthenticationFailed
+        } else {
+            Self::PushFailed(sanitize_error_message(err.message()))
+        }
+    }
+}
+
+/// Returns `true` if a git2 error is authentication-related, so its message
+/// must not be surfaced (it may name the credential helper, an SSH key, or an
+/// `Authorization` header).
+fn is_auth_error(err: &git2::Error) -> bool {
+    let message = err.message();
+    matches!(err.class(), git2::ErrorClass::Ssh | git2::ErrorClass::Http)
+        || message.contains("auth")
+        || message.contains("credential")
+        || message.contains("password")
+        || message.contains("token")
+}
+
+/// Sanitise an error message to remove potential credential information: drops
+/// whole lines naming a secret keyword, and redacts the userinfo of any
+/// `scheme://user:secret@host` URL the message happened to echo.
+pub(crate) fn sanitize_error_message(message: &str) -> String {
     let sanitized = message
         .lines()
         .filter(|line| {
@@ -88,6 +120,7 @@ fn sanitize_error_message(message: &str) -> String {
                 && !lower.contains("bearer")
                 && !lower.contains("authorization")
         })
+        .map(redact_url_userinfo)
         .collect::<Vec<_>>()
         .join(" ");
 
@@ -96,6 +129,32 @@ fn sanitize_error_message(message: &str) -> String {
     } else {
         sanitized
     }
+}
+
+/// Replace the userinfo of any `scheme://userinfo@host` substring with `***`,
+/// so credentials embedded in a URL that a git2 error echoed never survive.
+fn redact_url_userinfo(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut remaining = text;
+    while let Some(idx) = remaining.find("://") {
+        let scheme_end = idx + 3;
+        out.push_str(&remaining[..scheme_end]);
+        let after = &remaining[scheme_end..];
+        // The authority ends at the first '/', '?', '#', or whitespace.
+        let auth_end = after
+            .find(|c: char| matches!(c, '/' | '?' | '#') || c.is_whitespace())
+            .unwrap_or(after.len());
+        let authority = &after[..auth_end];
+        if let Some(at) = authority.rfind('@') {
+            out.push_str("***");
+            out.push_str(&authority[at..]);
+        } else {
+            out.push_str(authority);
+        }
+        remaining = &after[auth_end..];
+    }
+    out.push_str(remaining);
+    out
 }
 
 #[cfg(test)]
@@ -266,5 +325,111 @@ mod tests {
             }
             other => panic!("expected TempDirFailed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn redact_url_userinfo_strips_credentials() {
+        let redacted =
+            redact_url_userinfo("unable to access 'https://user:ghp_secret@github.com/o/r.git/'");
+        assert!(!redacted.contains("ghp_secret"));
+        assert!(!redacted.contains("user:"));
+        assert!(redacted.contains("***@github.com"));
+        assert!(redacted.contains("github.com/o/r.git"));
+    }
+
+    #[test]
+    fn redact_url_userinfo_leaves_clean_url_untouched() {
+        let text = "failed to connect to https://github.com/o/r.git";
+        assert_eq!(redact_url_userinfo(text), text);
+    }
+
+    #[test]
+    fn redact_url_userinfo_handles_text_without_url() {
+        assert_eq!(redact_url_userinfo("object not found"), "object not found");
+    }
+
+    #[test]
+    fn redact_url_userinfo_redacts_ssh_scheme_userinfo() {
+        let redacted = redact_url_userinfo("ssh://git:tok@example.com:22/repo");
+        assert!(!redacted.contains("tok"));
+        assert!(redacted.contains("***@example.com:22/repo"));
+    }
+
+    #[test]
+    fn redact_url_userinfo_handles_multiple_urls() {
+        let redacted = redact_url_userinfo("from https://a:b@h1/x to https://c:d@h2/y");
+        assert!(!redacted.contains("a:b"));
+        assert!(!redacted.contains("c:d"));
+        assert_eq!(redacted.matches("***@").count(), 2);
+    }
+
+    #[test]
+    fn sanitize_error_message_redacts_embedded_url_credentials() {
+        // The keyword filter would NOT catch a token embedded in a URL; the
+        // userinfo redaction does.
+        let sanitized =
+            sanitize_error_message("unable to access https://u:ghp_x@github.com/o/r.git");
+        assert!(!sanitized.contains("ghp_x"));
+        assert!(sanitized.contains("***@github.com"));
+    }
+
+    #[test]
+    fn from_fetch_auth_class_collapses_to_authentication_failed() {
+        let err = git2::Error::new(git2::ErrorCode::Auth, git2::ErrorClass::Http, "401");
+        assert!(matches!(
+            Git2Error::from_fetch(&err),
+            Git2Error::AuthenticationFailed
+        ));
+    }
+
+    #[test]
+    fn from_fetch_non_auth_is_sanitised_fetch_failed() {
+        let err = git2::Error::new(
+            git2::ErrorCode::GenericError,
+            git2::ErrorClass::Net,
+            "connection refused",
+        );
+        match Git2Error::from_fetch(&err) {
+            Git2Error::FetchFailed(msg) => assert!(msg.contains("connection refused")),
+            other => panic!("expected FetchFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_fetch_redacts_url_credentials_in_message() {
+        let err = git2::Error::new(
+            git2::ErrorCode::GenericError,
+            git2::ErrorClass::Net,
+            "failed to resolve https://u:ghp_x@github.com/o/r.git",
+        );
+        match Git2Error::from_fetch(&err) {
+            Git2Error::FetchFailed(msg) => {
+                assert!(!msg.contains("ghp_x"));
+                assert!(msg.contains("***@github.com"));
+            }
+            other => panic!("expected FetchFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_push_non_auth_is_push_failed() {
+        let err = git2::Error::new(
+            git2::ErrorCode::GenericError,
+            git2::ErrorClass::Net,
+            "remote rejected",
+        );
+        match Git2Error::from_push(&err) {
+            Git2Error::PushFailed(msg) => assert!(msg.contains("remote rejected")),
+            other => panic!("expected PushFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_push_auth_collapses_to_authentication_failed() {
+        let err = git2::Error::new(git2::ErrorCode::Auth, git2::ErrorClass::Ssh, "auth");
+        assert!(matches!(
+            Git2Error::from_push(&err),
+            Git2Error::AuthenticationFailed
+        ));
     }
 }

--- a/src/git2_ops/pull.rs
+++ b/src/git2_ops/pull.rs
@@ -28,7 +28,7 @@ use tempfile::TempDir;
 use tracing::{debug, info, warn};
 
 use super::auth::{create_callbacks, sanitize_url_for_logging, validate_url};
-use super::error::Git2Error;
+use super::error::{sanitize_error_message, Git2Error};
 
 /// Statistics about the incremental sync.
 #[derive(Debug, Clone, Serialize, Default)]
@@ -156,9 +156,12 @@ pub fn pull_changes(
     // Fetch the branch
     let refspec = format!("+refs/heads/{branch}:refs/heads/{branch}");
     {
-        let mut remote = repo
-            .remote_anonymous(url)
-            .map_err(|e| Git2Error::InitFailed(format!("failed to create remote: {e}")))?;
+        let mut remote = repo.remote_anonymous(url).map_err(|e| {
+            Git2Error::InitFailed(format!(
+                "failed to create remote: {}",
+                sanitize_error_message(e.message())
+            ))
+        })?;
 
         let callbacks = create_callbacks();
         let mut fetch_opts = FetchOptions::new();
@@ -176,7 +179,7 @@ pub fn pull_changes(
 
         remote
             .fetch(&[&refspec], Some(&mut fetch_opts), None)
-            .map_err(|e| Git2Error::FetchFailed(e.message().to_string()))?;
+            .map_err(|e| Git2Error::from_fetch(&e))?;
     }
 
     debug!("fetch complete, looking up commits");
@@ -523,6 +526,14 @@ mod tests {
     fn pull_changes_rejects_file_url() {
         let result = pull_changes("file:///etc/passwd", "main", "abc123", None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn pull_changes_fails_fast_on_unreachable_host() {
+        // Reaches the fetch (past validate_url) against a host that RSTs
+        // immediately, exercising the credential-safe fetch error mapping.
+        let result = pull_changes("https://127.0.0.1:1/o/r.git", "main", "abc123", None);
+        assert!(matches!(result, Err(Git2Error::FetchFailed(_))));
     }
 
     /// Helper: build a test bare repo with commits, return temp dir + commit OIDs.

--- a/src/git2_ops/push.rs
+++ b/src/git2_ops/push.rs
@@ -23,7 +23,7 @@ use tempfile::TempDir;
 use tracing::{debug, info, warn};
 
 use super::auth::{create_callbacks, validate_url};
-use super::error::Git2Error;
+use super::error::{sanitize_error_message, Git2Error};
 use crate::util::sanitize_for_log;
 
 /// Result of a successful push operation.
@@ -200,9 +200,12 @@ fn push_to_remote(
         "pushing to remote"
     );
 
-    let mut remote = repo
-        .remote_anonymous(remote_url)
-        .map_err(|e| Git2Error::PushFailed(format!("failed to create remote: {e}")))?;
+    let mut remote = repo.remote_anonymous(remote_url).map_err(|e| {
+        Git2Error::PushFailed(format!(
+            "failed to create remote: {}",
+            sanitize_error_message(e.message())
+        ))
+    })?;
 
     let callbacks = create_callbacks();
 
@@ -227,7 +230,7 @@ fn push_to_remote(
 
     remote
         .push(&[&refspec], Some(&mut push_opts))
-        .map_err(|e| Git2Error::PushFailed(e.message().to_string()))?;
+        .map_err(|e| Git2Error::from_push(&e))?;
 
     debug!("push complete");
     Ok(())


### PR DESCRIPTION
## Description

Second of the `src/git2_ops` series (clone). The clone audit turned up a
**module-wide credential-safety gap**, which I've fixed across the module rather
than flagging it — plus the planned clone.rs coverage.

### Bug: network git2 error messages bypassed the sanitiser

The connect/fetch/push call sites in `clone`/`diff`/`pull`/`push` wrapped raw
git2 messages — `FetchFailed(e.message().to_string())`, `PushFailed(...)` —
which **bypasses** the sanitising `From<git2::Error>` impl. A git2 error that
echoed a URL with embedded userinfo (`https://user:token@host`) would then reach
the operator's logs and the MCP response unredacted.

**Fix (in `error.rs`):**

- `Git2Error::from_fetch` / `from_push` — credential-safe constructors: auth-class
  or auth-keyword errors collapse to the detail-free `AuthenticationFailed`;
  everything else is wrapped (Fetch/Push) with a sanitised message.
- `sanitize_error_message` now also **redacts `scheme://user:secret@host`
  userinfo** — the existing keyword-line filter would miss a token embedded in a
  URL. `From` is refactored to share an `is_auth_error` helper (no behaviour
  change; all existing `From` tests still pass).

Applied at the connect/fetch/push sites in clone/diff/pull/push. The
**local-object** error sites (tree/commit/diff/revwalk/peel) are deliberately
left as-is — they operate on local objects and cannot contain credentials, so
changing them would be churn, not a fix.

### Coverage: clone.rs

`fetch_bare`'s body was untested. Split out a private `fetch_bare_inner` past
the URL validation (the public `fetch_bare` still rejects `file://` via
`validate_url` before delegating) so tests drive the connect/fetch path against
a local `file://` remote. **`clone.rs` 51.50% → 93.57%.**

## Related Issue

Part of the `src/git2_ops` coverage + bug-hunt sweep (follows #180 refs).

## Type of Change

- [x] Bug fix (credential leak via unsanitised error message)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [x] Security improvement

_Behavioural note: an **auth** failure during connect/fetch/push now surfaces as
the clean `AuthenticationFailed` rather than `FetchFailed(<git2 message>)`.
Non-auth failures (e.g. connection refused) stay `FetchFailed`/`PushFailed`, so
the existing unreachable-host push tests are unaffected._

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (unchanged)
- [x] Error messages don't leak sensitive information — **this PR tightens exactly this**

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test --all-features --workspace` — 647 lib tests green)

New tests: `error.rs` (`redact_url_userinfo`, `from_fetch`/`from_push`,
URL-credential redaction through `sanitize_error_message`); the `clone.rs`
`fetch_bare_inner` suite (default/explicit branch, depth, proxy, missing-branch,
nonexistent-remote, validate-rejection, unreachable-host); and unreachable-host
tests for `diff`/`pull` that exercise the new fetch error mapping.

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` clean
- [x] Documentation is updated (CHANGELOG: Security + Added)
- [x] CHANGELOG.md is updated

## Additional Notes

### Findings that are NOT in this PR

- **The `remote_anonymous`-failure sanitiser arms are uncovered.** For a URL
  that already passed `validate_url`, `remote_anonymous` succeeds, so the
  failure arm is a defensive, not-externally-triggerable path — the same
  pattern push.rs already documents for its `TempDir`/`init_bare` arms.
- **`diff.rs` and `pull.rs` are still below target** (≈69% / ≈59%). This PR only
  adds the fix + a single fetch-error test to each; their full coverage audits
  are the next steps in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)