### PR TITLE
fix(diff): resolve short commit SHAs; cover the diff path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`git2_ops::diff` fetch/diff-path coverage.** The body of `generate_diff`
+  after the network fetch (commit resolution, tree diff, stats, patch
+  formatting) was untested. Extracted a private `generate_diff_inner` past
+  `validate_url` and drove it against a local `file://` remote with two commits:
+  the full diff (modified + added file, stats, full base/head SHAs), tag-ref
+  resolution, a missing-commit error, and a nonexistent-remote error. `diff.rs`
+  line coverage rose from 70.56 % to 90.88 %.
 - **`git2_ops::clone` fetch-path coverage.** `fetch_bare`'s body was untested
   (only `decode_default_branch` and the `validate_url` rejection were covered).
   Extracted a private `fetch_bare_inner` past the URL validation so tests drive
@@ -460,6 +467,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`repo_diff` could not resolve a short (abbreviated) commit SHA** despite
+  documenting "Short SHA (minimum 4 hex chars)" support. `resolve_commit` tried
+  `Oid::from_str` first and returned on success — but `Oid::from_str` *zero-pads*
+  a short hex string into a bogus full OID (e.g. `617b10e692` →
+  `617b10e692000…000`) rather than resolving the abbreviation, so it never
+  reached the `revparse_single` call that actually resolves short SHAs against
+  the repo. `find_commit` then failed with a misleading "commit not found". The
+  direct-OID fast path is now taken only for a full 40-char SHA; anything shorter
+  (and branch/tag/`HEAD~N` refs) goes through `revparse_single`. Regression-tested
+  by `resolve_commit_short_sha`.
 - **`repo_refs` reported a non-deterministic default branch when several
   branches shared the `HEAD` commit.** `list_remote_refs` derived
   `default_branch` by scanning the branch list for the first entry whose OID

--- a/src/git2_ops/diff.rs
+++ b/src/git2_ops/diff.rs
@@ -93,6 +93,19 @@ pub fn generate_diff(
     // Validate URL
     validate_url(url)?;
 
+    generate_diff_inner(url, base_commit, head_commit, proxy_url)
+}
+
+/// Fetches the repo and diffs `base_commit`..`head_commit` — the body of
+/// [`generate_diff`] after URL validation. Split out so tests can drive the
+/// fetch/resolve/diff path against a local `file://` remote; [`generate_diff`]
+/// still rejects `file://` via [`validate_url`] before delegating here.
+fn generate_diff_inner(
+    url: &str,
+    base_commit: &str,
+    head_commit: &str,
+    proxy_url: Option<&str>,
+) -> Result<DiffResult, Git2Error> {
     // Create temp directory for bare repo
     let temp_dir = TempDir::new().map_err(Git2Error::TempDirFailed)?;
 
@@ -228,12 +241,20 @@ pub fn generate_diff(
 /// - Branch names (looks up refs/heads/...)
 /// - Tag names (looks up refs/tags/...)
 fn resolve_commit(repo: &Repository, reference: &str) -> Result<Oid, Git2Error> {
-    // Try as direct OID first (full or short SHA)
-    if let Ok(oid) = Oid::from_str(reference) {
-        return Ok(oid);
+    // Try as a direct OID, but only for a full-length (40-char) SHA. A shorter
+    // hex string must NOT take this path: `Oid::from_str` zero-pads the missing
+    // nibbles into a bogus OID (e.g. "abc1" -> abc1000…0) rather than resolving
+    // the abbreviation, so it would never reach the `revparse_single` below
+    // (which does resolve short SHAs against the repo). A full SHA is parsed
+    // directly because the object may not be present yet — the caller verifies
+    // existence via `find_commit`.
+    if reference.len() == 40 {
+        if let Ok(oid) = Oid::from_str(reference) {
+            return Ok(oid);
+        }
     }
 
-    // Try revparse (handles branch names, tags, HEAD~N, etc.)
+    // Try revparse (handles full/abbreviated SHAs, branch names, tags, HEAD~N)
     if let Ok(obj) = repo.revparse_single(reference) {
         if let Some(commit) = obj.as_commit() {
             return Ok(commit.id());
@@ -425,6 +446,86 @@ mod tests {
         let (temp, _, _) = build_test_repo_with_two_commits();
         let repo = Repository::open_bare(temp.path()).unwrap();
         let result = resolve_commit(&repo, "not-a-sha-or-anything");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_commit_short_sha() {
+        let (temp, _, oid2) = build_test_repo_with_two_commits();
+        let repo = Repository::open_bare(temp.path()).unwrap();
+        let short = &oid2.to_string()[..10];
+        let resolved = resolve_commit(&repo, short).unwrap();
+        assert_eq!(
+            resolved, oid2,
+            "short SHA should resolve to the full commit"
+        );
+    }
+
+    /// Builds a `file://` URL for a local path (Windows-friendly).
+    fn local_file_url(path: &std::path::Path) -> String {
+        let raw = path.display().to_string();
+        if cfg!(windows) {
+            format!("file:///{}", raw.replace('\\', "/"))
+        } else {
+            format!("file://{raw}")
+        }
+    }
+
+    #[test]
+    fn generate_diff_inner_diffs_two_commits() {
+        // Drives the whole fetch/resolve/diff/format body against a local
+        // remote (bypassing validate_url's file:// rejection via the inner fn).
+        let (source, oid1, oid2) = build_test_repo_with_two_commits();
+        let result = generate_diff_inner(
+            &local_file_url(source.path()),
+            &oid1.to_string(),
+            &oid2.to_string(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(result.base_commit, oid1.to_string());
+        assert_eq!(result.head_commit, oid2.to_string());
+        // commit1 -> commit2: README.md modified + main.rs added.
+        assert_eq!(result.stats.files_changed, 2);
+        assert!(result.diff.contains("main.rs"), "diff: {}", result.diff);
+        assert!(result.diff.contains("# Test (updated)"));
+    }
+
+    #[test]
+    fn generate_diff_inner_resolves_tag_ref() {
+        // head given as a tag name exercises resolve_commit's revparse/tag path
+        // inside the fetch/diff flow.
+        let (source, oid1, oid2) = build_test_repo_with_two_commits();
+        let result = generate_diff_inner(
+            &local_file_url(source.path()),
+            &oid1.to_string(),
+            "v1.0",
+            None,
+        )
+        .unwrap();
+        assert_eq!(result.head_commit, oid2.to_string());
+    }
+
+    #[test]
+    fn generate_diff_inner_errors_on_missing_commit() {
+        // A well-formed but absent SHA resolves (Oid::from_str) yet isn't in the
+        // fetched repo, so find_commit fails with RefNotFound.
+        let (source, _, oid2) = build_test_repo_with_two_commits();
+        let result = generate_diff_inner(
+            &local_file_url(source.path()),
+            "0000000000000000000000000000000000000000",
+            &oid2.to_string(),
+            None,
+        );
+        assert!(matches!(result, Err(Git2Error::RefNotFound(_))));
+    }
+
+    #[test]
+    fn generate_diff_inner_errors_on_nonexistent_local_remote() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let missing = tmp.path().join("no-such-repo");
+        let result = generate_diff_inner(&local_file_url(&missing), "abc", "def", None);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Description

Third of the `src/git2_ops` series (diff). **Stacked on #182** (clone /
module-wide sanitisation) — based on `audit/clone`, so this PR's diff shows only
the diff.rs changes. GitHub will retarget it to `main` once #182 merges.

### Bug: short commit SHAs didn't resolve

`repo_diff` documents accepting a "Short SHA (minimum 4 hex chars)", but
`resolve_commit` tried `Oid::from_str` first and returned on success — and
`Oid::from_str` **zero-pads** a short hex into a bogus full OID
(`617b10e692` → `617b10e692000…000`) instead of resolving the abbreviation. It
therefore never reached `revparse_single` (which *does* resolve short SHAs
against the repo), and `find_commit` then failed with a misleading "commit not
found".

**Fix:** the direct-OID fast path is taken only for a full 40-char SHA; anything
shorter — plus branch/tag/`HEAD~N` refs — goes through `revparse_single`.
Regression-tested by `resolve_commit_short_sha` (which fails on the old code:
`left: 617b10e692000…000`, `right: 617b10e6928789…`).

### Coverage

`generate_diff`'s body after the network fetch (commit resolution, tree diff,
stats, patch formatting) was untested. Extracted a private `generate_diff_inner`
past `validate_url` so tests drive it against a local `file://` remote with two
commits. **`diff.rs` 70.56% → 90.88%.**

## Related Issue

Part of the `src/git2_ops` sweep (follows #180 refs, #182 clone).

## Type of Change

- [x] Bug fix (short-SHA resolution)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (unchanged)
- [x] Error messages don't leak sensitive information (the fetch error mapping from #182 carries over)

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test --all-features --workspace` — 652 lib tests)

New tests: `resolve_commit_short_sha` (the bug guard) and the
`generate_diff_inner` suite (two-commit diff with stats, tag-ref resolution,
missing-commit and nonexistent-remote errors).

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` clean
- [x] Documentation is updated (CHANGELOG: Fixed + Added)
- [x] CHANGELOG.md is updated

## Additional Notes

- **Merge #182 first** (this is based on it). If #182 merges before review here,
  GitHub auto-retargets this PR to `main`.
- `pull.rs` resolves `since_commit` with the same `Oid::from_str` call, but its
  contract is a full SHA from a prior response (not an abbreviation), so that's
  not a bug there — pull's own audit is the next step in the series.
- ~29 lines remain uncovered in `diff.rs` (the `remote_anonymous`-failure
  sanitiser arm and a few defensive tree/format error arms) — the same
  not-externally-triggerable pattern documented elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)