### PR TITLE
fix(security): enforce repo filter on diff, protect branches from force push, harden guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Security guards now share consistent pattern- and force-push detection.**
+  Two helpers are shared across the guards so they behave alike:
+    1. `BranchGuard::is_protected` honours `*` anywhere in a protected-branch
+       pattern (e.g. `*/hotfix`), not just a trailing `*` — the same matcher
+       `RepoFilter` uses for repository patterns. Previously a non-trailing `*`
+       in `security.protected_branches` silently never matched.
+    2. Force-push detection (`-f` / `--force` / `--force-with-lease[=<ref>]`) is
+       unified between `BranchGuard` and `PushGuard`; `BranchGuard` previously
+       missed the `--force-with-lease=<ref>` form. The MCP server's enforcement
+       is unchanged (it uses the structured `check_force_push` / `is_protected`
+       directly); this tightens the `SecurityGuard::check` CLI-argument path and
+       the protected-branch matching.
 - **`streaming::tar` test and doc hygiene** (no behaviour change):
     1. `is_binary`'s doc-comment claimed its heuristic is "similar to what Git
        uses internally" — Git's core check is only NUL-in-first-8000-bytes; the
@@ -1061,6 +1073,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Force pushes to protected branches were not blocked when force push was
+  globally enabled.** `repo_push` called `BranchGuard::check("push", &[branch])`,
+  but that CLI-arg form expects a full `git push` argument vector: given only a
+  bare branch name it could neither locate the target branch (its parser skips
+  the remote and takes the *second* non-flag argument) nor see a `--force` flag,
+  so it always returned `Allowed`. With `security.allow_force_push: true` the
+  `PushGuard` then also allowed the push, leaving `security.protected_branches`
+  with no effect against force pushes — the exact thing it exists to prevent.
+  Added a structured `BranchGuard::check_force_push(branch, is_force)` (the
+  `SecurityGuard::check` CLI form now delegates to it) and switched the server
+  to call it with the branch and force flag it already holds. Force pushes to a
+  protected branch are now blocked regardless of the global force-push setting.
+- **`repo_diff` bypassed the repository allow/blocklist.** The server passed the
+  command string `"diff"` to `RepoFilter::check`, but `diff` was not in the
+  filter's set of remote commands (nor in its URL extractor), so the check
+  returned `Allowed` without consulting the policy — a blocklisted (or
+  non-allowlisted) repository could still be fetched and diffed. `diff` is now
+  treated like `clone`/`pull`/`fetch`, so `repo_diff` is filtered the same as
+  every other remote-accessing tool.
+- **Multi-`*` repository patterns silently never matched.** `RepoFilter`'s
+  pattern matcher only handled a single `*` (it required the split on `*` to
+  yield exactly two parts) and otherwise fell through to a literal prefix match,
+  so a pattern such as `github.com/*/secret-*` matched nothing — a blocklist
+  entry using it silently failed to block. The matcher now supports any number
+  of `*` (each matching an arbitrary run of characters, anchored at both ends);
+  single-`*` patterns behave exactly as before.
+- **`RepoFilter` credential stripping could drop the host and bypass the
+  blocklist.** `normalise_url` removed credentials by cutting everything before
+  the *first* `@` anywhere in the URL, so a repository under a blocked path that
+  happened to contain a later `@` (e.g. `github.com/secret/sub@x/y`) normalised
+  to just the trailing fragment and no longer matched the blocklist entry.
+  Credentials are now stripped only from the authority component (before the
+  first `/`), so a `@` in the path is preserved and the block still applies —
+  the same bug class as the `auth.rs` URL-sanitisation fix in PR #153.
 - **Network git2 error messages are now routed through a credential-safe
   sanitiser instead of being wrapped raw.** The connect/fetch/push call sites in
   `git2_ops::{clone,diff,pull,push}` mapped errors with

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1138,10 +1138,13 @@ impl McpServer {
             return ToolCallResult::error(reason.to_string());
         }
 
-        // Check branch guard (protected branches)
+        // Check branch guard (block force pushes to protected branches). The
+        // server knows the branch and force flag directly, so it uses the
+        // structured check rather than the CLI-arg form (which can't see the
+        // force flag from a lone branch name).
         if let Some(reason) = self
             .branch_guard
-            .check("push", std::slice::from_ref(&args.branch))
+            .check_force_push(&args.branch, args.force)
             .reason()
         {
             self.audit_logger.log_silent(&AuditEvent::repo_push_blocked(

--- a/src/security/guards.rs
+++ b/src/security/guards.rs
@@ -60,6 +60,50 @@ pub trait SecurityGuard {
     fn check(&self, command: &str, args: &[String]) -> SecurityCheckResult;
 }
 
+/// Matches `text` against a `*`-wildcard `pattern`.
+///
+/// Each `*` matches any (possibly empty) run of characters; the pattern is
+/// anchored at both ends (no implicit leading/trailing wildcard). Supports any
+/// number of `*`. The cursor only advances past a substring just matched within
+/// `text`, so slicing stays on UTF-8 boundaries. Shared by [`RepoFilter`] (repo
+/// URL patterns) and [`BranchGuard`] (protected-branch patterns) so both behave
+/// alike.
+fn wildcard_match(text: &str, pattern: &str) -> bool {
+    let mut segments = pattern.split('*').peekable();
+    // `str::split` always yields at least one segment.
+    let first = segments.next().unwrap_or("");
+    let Some(mut rest) = text.strip_prefix(first) else {
+        return false;
+    };
+    while let Some(segment) = segments.next() {
+        if segments.peek().is_none() {
+            // The segment after the final `*` must be a suffix of what remains.
+            return rest.ends_with(segment);
+        }
+        // A middle segment must occur in the remaining text; consume up to and
+        // including its first occurrence.
+        match rest.find(segment) {
+            Some(idx) => rest = &rest[idx + segment.len()..],
+            None => return false,
+        }
+    }
+    // Reached only when the pattern had no `*` (callers guard against that);
+    // then the prefix had to consume the whole string.
+    rest.is_empty()
+}
+
+/// Returns `true` if a `git push` argument vector requests a force push, via
+/// `-f`, `--force`, or `--force-with-lease[=<ref>]`. Shared by [`BranchGuard`]
+/// and [`PushGuard`] so both recognise the same flags.
+fn is_force_push(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        a == "-f"
+            || a == "--force"
+            || a == "--force-with-lease"
+            || a.starts_with("--force-with-lease=")
+    })
+}
+
 /// Guard that protects specific branches from modifications.
 #[derive(Debug, Clone)]
 pub struct BranchGuard {
@@ -105,16 +149,38 @@ impl BranchGuard {
             return true;
         }
 
-        // Check for wildcard patterns (e.g., "release/*")
+        // Wildcard patterns (e.g. "release/*", "*/hotfix"). Shares the matcher
+        // with RepoFilter so branch and repo patterns behave consistently;
+        // previously only a trailing `*` was honoured.
         for pattern in &self.protected_branches {
-            if let Some(prefix) = pattern.strip_suffix('*') {
-                if branch.starts_with(prefix) {
-                    return true;
-                }
+            if pattern.contains('*') && wildcard_match(branch, pattern) {
+                return true;
             }
         }
 
         false
+    }
+
+    /// Checks a push against the protected-branch policy.
+    ///
+    /// Returns [`SecurityCheckResult::Blocked`] when `is_force` is true and
+    /// `branch` is protected (a force push to a protected branch); normal,
+    /// non-force pushes are always allowed by this guard.
+    ///
+    /// This is the structured entry point the MCP server uses — it knows the
+    /// target branch and force flag directly and does not shell out to `git`,
+    /// so it cannot rely on the CLI-arg parsing in [`SecurityGuard::check`]
+    /// (which expects a full `git push` argument vector). The `check`
+    /// implementation delegates here once it has parsed the branch and flag.
+    #[must_use]
+    pub fn check_force_push(&self, branch: &str, is_force: bool) -> SecurityCheckResult {
+        if is_force && self.is_protected(branch) {
+            SecurityCheckResult::Blocked {
+                reason: format!("Cannot force push to protected branch '{branch}'"),
+            }
+        } else {
+            SecurityCheckResult::Allowed
+        }
     }
 
     /// Extracts branch name from command arguments.
@@ -188,19 +254,11 @@ impl SecurityGuard for BranchGuard {
             return SecurityCheckResult::Allowed;
         }
 
-        // For push, check the target branch
+        // For push, block a force push to a protected branch (delegating to the
+        // structured `check_force_push` so the CLI and server paths share logic).
         if command == "push" {
             if let Some(branch) = Self::extract_branch_from_args(command, args) {
-                // Check for force push to protected branch
-                let is_force = args
-                    .iter()
-                    .any(|a| a == "-f" || a == "--force" || a == "--force-with-lease");
-
-                if is_force && self.is_protected(&branch) {
-                    return SecurityCheckResult::Blocked {
-                        reason: format!("Cannot force push to protected branch '{branch}'"),
-                    };
-                }
+                return self.check_force_push(&branch, is_force_push(args));
             }
         }
 
@@ -263,12 +321,7 @@ impl SecurityGuard for PushGuard {
         }
 
         // Check for force push flags
-        let is_force = args.iter().any(|a| {
-            a == "-f"
-                || a == "--force"
-                || a == "--force-with-lease"
-                || a.starts_with("--force-with-lease=")
-        });
+        let is_force = is_force_push(args);
 
         if !is_force {
             return SecurityCheckResult::Allowed;
@@ -396,9 +449,15 @@ impl RepoFilter {
         if let Some(rest) = normalised.strip_prefix("git@") {
             // Replace first : with / (separates host from path in SSH URLs)
             normalised = rest.replacen(':', "/", 1);
-        } else if let Some((_creds, rest)) = normalised.split_once('@') {
-            // Remove credentials if present (user:pass@host format)
-            normalised = rest.to_string();
+        } else {
+            // Remove credentials (user[:pass]@) only when the `@` is in the
+            // authority (before the first `/`), not when it appears in the path
+            // — otherwise a URL like `host/a@b/c` would lose its host and could
+            // slip past a blocklist.
+            let authority_end = normalised.find('/').unwrap_or(normalised.len());
+            if let Some(at) = normalised[..authority_end].rfind('@') {
+                normalised = normalised[at + 1..].to_string();
+            }
         }
 
         // Remove .git suffix (case-insensitive, UTF-8 safe)
@@ -423,16 +482,13 @@ impl RepoFilter {
             return true;
         }
 
-        // Wildcard matching
+        // Wildcard matching — each `*` matches any (possibly empty) run of
+        // characters, anchored at both ends. Handles any number of `*`; the
+        // previous implementation only matched a single `*` (`parts.len() == 2`)
+        // and silently fell through for multi-`*` patterns, so a blocklist entry
+        // such as `github.com/*/secret-*` never matched and never blocked.
         if normalised_pattern.contains('*') {
-            let parts: Vec<&str> = normalised_pattern.split('*').collect();
-
-            if parts.len() == 2 {
-                let prefix = parts[0];
-                let suffix = parts[1];
-
-                return url.starts_with(prefix) && url.ends_with(suffix);
-            }
+            return wildcard_match(url, &normalised_pattern);
         }
 
         // Prefix matching (e.g., "github.com/org" matches "github.com/org/repo")
@@ -451,7 +507,7 @@ impl RepoFilter {
                 // clone <url> [directory]
                 args.first().cloned()
             }
-            "push" | "pull" | "fetch" | "ls-remote" => {
+            "push" | "pull" | "fetch" | "ls-remote" | "diff" => {
                 // First non-flag argument might be the remote
                 args.iter().find(|a| !a.starts_with('-')).cloned()
             }
@@ -476,8 +532,18 @@ impl Default for RepoFilter {
 
 impl SecurityGuard for RepoFilter {
     fn check(&self, command: &str, args: &[String]) -> SecurityCheckResult {
-        // Only check commands that access remote repositories
-        let remote_commands = ["clone", "push", "pull", "fetch", "ls-remote", "remote"];
+        // Only check commands that access remote repositories. `diff` is
+        // included because `repo_diff` fetches the remote before diffing, so it
+        // must be subject to the same allow/blocklist as clone/pull/fetch.
+        let remote_commands = [
+            "clone",
+            "push",
+            "pull",
+            "fetch",
+            "ls-remote",
+            "remote",
+            "diff",
+        ];
 
         if !remote_commands.contains(&command) {
             return SecurityCheckResult::Allowed;
@@ -692,5 +758,151 @@ mod tests {
         assert!(!blocked.is_allowed());
         assert!(blocked.is_blocked());
         assert_eq!(blocked.reason(), Some("test"));
+    }
+
+    #[test]
+    fn branch_guard_check_force_push_blocks_protected() {
+        let guard = BranchGuard::with_defaults();
+        // Force push to a protected branch is blocked — this is what the MCP
+        // server relies on, independent of the global force-push setting.
+        assert!(guard.check_force_push("main", true).is_blocked());
+        // Force push to a non-protected branch is allowed by this guard.
+        assert!(guard.check_force_push("feature/x", true).is_allowed());
+        // A normal (non-force) push to a protected branch is allowed here:
+        // protected branches block force pushes and deletions, not all pushes.
+        assert!(guard.check_force_push("main", false).is_allowed());
+    }
+
+    #[test]
+    fn repo_filter_blocks_diff_command() {
+        // `repo_diff` fetches the remote, so the allow/blocklist must apply to
+        // the `diff` command too — it was previously unrecognised and bypassed
+        // the filter entirely.
+        let mut filter = RepoFilter::blocklist_mode();
+        filter.block("github.com/blocked/repo");
+
+        assert!(filter
+            .check("diff", &["https://github.com/blocked/repo.git".to_string()])
+            .is_blocked());
+        assert!(filter
+            .check("diff", &["https://github.com/ok/repo.git".to_string()])
+            .is_allowed());
+    }
+
+    #[test]
+    fn repo_filter_diff_respects_allowlist() {
+        let mut filter = RepoFilter::allowlist_mode();
+        filter.allow("github.com/myorg/*");
+        assert!(filter
+            .check("diff", &["https://github.com/myorg/repo.git".to_string()])
+            .is_allowed());
+        assert!(filter
+            .check("diff", &["https://github.com/other/repo.git".to_string()])
+            .is_blocked());
+    }
+
+    #[test]
+    fn repo_filter_multi_wildcard_pattern() {
+        // A pattern with more than one `*` must match. Previously it fell
+        // through to a literal prefix-match and never matched, so the block
+        // silently did nothing.
+        let mut filter = RepoFilter::blocklist_mode();
+        filter.block("github.com/*/secret-*");
+
+        assert!(!filter.is_allowed("https://github.com/org/secret-data.git"));
+        assert!(!filter.is_allowed("https://github.com/team/secret-keys"));
+        // Allowed: the middle and trailing segments aren't both present.
+        assert!(filter.is_allowed("https://github.com/org/public.git"));
+        assert!(filter.is_allowed("https://github.com/org/data-secret.git"));
+    }
+
+    #[test]
+    fn repo_filter_leading_and_trailing_wildcards() {
+        // Leading `*` (pure suffix match) and trailing `*` (pure prefix match).
+        let mut filter = RepoFilter::blocklist_mode();
+        filter.block("*/internal-repo");
+        filter.block("github.com/secret/*");
+
+        assert!(!filter.is_allowed("https://github.com/org/internal-repo.git"));
+        assert!(!filter.is_allowed("https://github.com/secret/anything.git"));
+        assert!(filter.is_allowed("https://github.com/org/public-repo.git"));
+    }
+
+    #[test]
+    fn wildcard_match_covers_all_positions() {
+        // Single `*` in the middle (matches any run, including empty).
+        assert!(wildcard_match("abc", "a*c"));
+        assert!(wildcard_match("aXYZc", "a*c"));
+        assert!(wildcard_match("ac", "a*c"));
+        assert!(!wildcard_match("abd", "a*c"));
+        // Multiple `*` — middle segments must appear in order.
+        assert!(wildcard_match("aXbYc", "a*b*c"));
+        assert!(!wildcard_match("aXc", "a*b*c"));
+        // Leading `*` (pure suffix) and trailing `*` (pure prefix).
+        assert!(wildcard_match("anything", "*"));
+        assert!(wildcard_match("the-end", "*end"));
+        assert!(!wildcard_match("the-end-x", "*end"));
+        assert!(wildcard_match("start-here", "start*"));
+        assert!(!wildcard_match("nope", "start*"));
+        // No `*`: the prefix must consume the whole string (exact match) — the
+        // post-loop fall-through. `matches_pattern` never calls this path, but
+        // the helper handles it correctly.
+        assert!(wildcard_match("exact", "exact"));
+        assert!(!wildcard_match("exactly", "exact"));
+    }
+
+    #[test]
+    fn branch_guard_protects_non_suffix_wildcard() {
+        // Branch protection now honours `*` anywhere in the pattern (previously
+        // only a trailing `*`), matching RepoFilter's behaviour.
+        let mut guard = BranchGuard::new(std::iter::empty::<String>());
+        guard.protect("*/hotfix");
+        assert!(guard.is_protected("release/hotfix"));
+        assert!(guard.is_protected("team/hotfix"));
+        assert!(!guard.is_protected("hotfix")); // no leading "<segment>/"
+        assert!(!guard.is_protected("release/feature"));
+    }
+
+    #[test]
+    fn branch_guard_detects_force_with_lease_value() {
+        // `--force-with-lease=<ref>` must be recognised as a force push.
+        // Previously BranchGuard missed it (it only matched the bare flag),
+        // even though PushGuard caught it.
+        let guard = BranchGuard::with_defaults();
+        let result = guard.check(
+            "push",
+            &[
+                "--force-with-lease=origin/main".to_string(),
+                "origin".to_string(),
+                "main".to_string(),
+            ],
+        );
+        assert!(result.is_blocked());
+    }
+
+    #[test]
+    fn push_guard_detects_force_with_lease_value() {
+        let guard = PushGuard::block_force_push();
+        let result = guard.check(
+            "push",
+            &["--force-with-lease=abc".to_string(), "origin".to_string()],
+        );
+        assert!(result.is_blocked());
+    }
+
+    #[test]
+    fn repo_filter_strips_credentials_only_in_authority() {
+        let mut filter = RepoFilter::blocklist_mode();
+        filter.block("github.com/secret");
+
+        // A repo under the blocked path with a later `@` in the path must still
+        // be blocked — previously `normalise_url` cut everything before the
+        // first `@`, dropping the host and org and bypassing the block.
+        assert!(!filter.is_allowed("https://github.com/secret/sub@x/y.git"));
+        // Real credentials in the authority are still stripped, so the block
+        // continues to apply.
+        assert!(!filter.is_allowed("https://user:tok@github.com/secret/repo.git"));
+        // A genuinely different repo is unaffected.
+        assert!(filter.is_allowed("https://github.com/public/repo.git"));
     }
 }


### PR DESCRIPTION
## Description

Per-file audit of `src/security/guards.rs` (branch protection, force-push guard,
repo allow/blocklist). The guards expose a git-CLI `check(command, args)`
interface, but the MCP server (which uses git2, not the CLI) calls them with
structured single-element arrays — so several protections were **silently
ineffective**. Plus a few pre-existing matching bugs.

**Enforcement fixes (affect the running server):**

1. **`repo_diff` bypassed the repo allow/blocklist.** The server passed the
   command `"diff"` to `RepoFilter::check`, but `"diff"` wasn't a recognised
   remote command, so the check returned `Allowed` without consulting the
   policy — a blocklisted (or non-allowlisted) repo could still be fetched and
   diffed. `"diff"` is now treated like `clone`/`pull`/`fetch`.
2. **Force pushes to protected branches were not blocked when force push was
   globally enabled.** `repo_push` called `BranchGuard::check("push", &[branch])`,
   whose CLI parser expects a full `git push` argument vector — given a lone
   branch name it could neither see a `--force` flag nor locate the branch, so
   it always returned `Allowed`. With `allow_force_push: true`, `protected_branches`
   gave **no** force-push protection. Added a structured
   `BranchGuard::check_force_push(branch, is_force)` (the CLI `check` delegates
   to it) and wired the server to call it with the branch + force flag it holds.
3. **Multi-`*` repo patterns never matched.** `RepoFilter` required the split on
   `*` to yield exactly two parts, so a blocklist entry like
   `github.com/*/secret-*` silently failed to block. The matcher now supports
   any number of `*`.

**Pre-existing hardening (requested):**

4. **`normalise_url` could drop the host and bypass the blocklist.** It stripped
   credentials by cutting before the *first* `@` anywhere, so a path-embedded
   `@` (e.g. `github.com/secret/sub@x/y`) reduced the URL to a trailing fragment
   that no longer matched. It now strips only the authority's userinfo (same bug
   class as the `auth.rs` fix in PR #153).
5. **Unified force-flag detection** (`is_force_push`) across `BranchGuard` and
   `PushGuard`; `BranchGuard` previously missed `--force-with-lease=<ref>`.
6. **`BranchGuard::is_protected` honours `*` anywhere** in a pattern (shared
   `wildcard_match`), not just a trailing `*`.

## Related Issue

N/A — proactive `security/guards.rs` audit (continues the per-file sweep:
`config`, `git2_ops`, `streaming/tar`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [x] Security improvement

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests (tests use obvious fakes like `user:tok`)
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (this PR touches no credential handling)
- [x] Error messages don't leak sensitive information (block reasons contain only the branch/URL the caller supplied)

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove the fixes (diff filtering, force-push-to-protected via `check_force_push`, multi-`*` patterns, `--force-with-lease=` detection, authority-only credential stripping, non-suffix branch wildcards, and a direct `wildcard_match` test)
- [x] New and existing tests pass (`cargo test --all-features --workspace` — 772 passed, 0 failed; the existing `security_tests.rs` still pass, confirming the CLI `check` behaviour is preserved via delegation)

`guards.rs` line coverage ~90% → ~92%. The remaining uncovered lines are
pre-existing untested public methods (`unprotect`, `RepoFilter::new`, the
`extract_branch_from_args` refspec/merge arms) — not part of this diff.

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] Documentation is updated if needed
- [x] CHANGELOG.md is updated for user-facing changes

## Additional Notes

### Findings deliberately NOT in this PR

- **`+`-refspec force syntax** (`git push origin +main`) is still not detected
  as a force push. Deliberately left: the server passes an explicit force flag
  (never `+`-refspecs), so this only affects the `SecurityGuard::check` CLI path
  — which has no production caller — and detecting it cleanly also needs the
  branch extractor to strip the leading `+`.
- **`extract_branch_from_args`'s push parser is heuristic** (handles
  `[remote] [branch]` and a single `local:remote` refspec). It's only used by
  the CLI `check` path, not the server's structured `check_force_push`.
- **A few public methods are unused by the server** (`RepoFilter::new` vs
  `blocklist_mode`, `unprotect`, `PushGuard::allow_force_push_to`). They're part
  of the public guard API, so left as-is rather than removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)