### PR TITLE
fix(security): make rate limiter panic-safe and drain-proof; cover untested paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`mcp::transport` line-framing coverage.** The read/write paths were only
+  exercised by the Python integration suite because stdin/stdout were hardcoded.
+  Following the testability refactor, new unit tests cover LF / CRLF / EOF /
+  no-trailing-newline / empty-line reads and newline-terminated writes, taking
+  `transport.rs` unit line coverage from 40.86 % to ~78 % (the remainder is the
+  thin stdin/stdout glue, still integration-covered).
 - **`security::rate_limit` poison-recovery coverage.** The mutex poison-recovery
   arms in `lock_tokens` / `lock_last_refill` (which fall back to `into_inner()`
   when a thread panicked while holding the lock) had no test. Added unit tests
@@ -215,6 +221,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`mcp::transport` line framing refactored for unit-testability; concurrency
+  docs corrected** (no behaviour change):
+    1. The `\n` / `\r\n` stripping and the read/write framing were extracted into
+       a pure `strip_trailing_newline` helper and generic `read_message_line` /
+       `write_message_line` helpers (over any `AsyncBufRead` / `AsyncWrite`), so
+       the framing can be tested without real stdin/stdout. `read_line` and
+       `write_raw` delegate to them.
+    2. The module's "Thread Safety" section claimed reads and writes run on
+       separate tasks for concurrent operation; in fact the server drives a
+       single `StdioTransport` from one `tokio::select!` loop, so reads and
+       writes are sequential on one task. Reworded to describe the real
+       single-task model.
+    3. Documented that `read_line` is intentionally unbounded — `repo_push`
+       sends its bundle inline as base64 (up to the ~1 GiB bundle-size limit),
+       so a per-line length cap would break large pushes.
 - **Security guards now share consistent pattern- and force-push detection.**
   Two helpers are shared across the guards so they behave alike:
     1. `BranchGuard::is_protected` honours `*` anywhere in a protected-branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`security::rate_limit` poison-recovery coverage.** The mutex poison-recovery
+  arms in `lock_tokens` / `lock_last_refill` (which fall back to `into_inner()`
+  when a thread panicked while holding the lock) had no test. Added unit tests
+  that poison each mutex — panicking while holding the lock, contained with
+  `catch_unwind` on the test thread — and assert the limiter keeps operating.
 - **`streaming::tar` coverage for previously-untested branches.** New unit
   tests drive the file-progress callback (`ProgressSender` configured), the
   `submodule_depth == 0` early skip, and both LFS-client-setup fallbacks
@@ -517,6 +522,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`RateLimiter::time_until_available` could panic on a config-valid input.**
+  It computed `Duration::from_secs_f64(1.0 / refill_rate)`, which panics when the
+  result overflows `Duration`. A finite, positive but minuscule
+  `rate_limits.refill_rate_per_sec` (e.g. `1e-20`) passes `Config::validate`
+  (which only rejects non-finite or negative rates) yet overflows here. The
+  method now uses `try_from_secs_f64` and saturates to `Duration::MAX`
+  ("effectively never"). The running server only calls `try_acquire`, so this
+  was a latent panic in the public library API rather than a live crash.
+  Regression-tested by `time_until_available_saturates_on_tiny_refill_rate`.
+- **A negative `refill_rate` drained the token bucket instead of being inert.**
+  `RateLimiter::refill` multiplied elapsed time by `refill_rate`
+  unconditionally, so a negative rate subtracted tokens on every call.
+  `Config::validate` rejects negative rates, but the public `RateLimiter::new`
+  does not, so a direct library caller hit this. `refill` now returns early for
+  non-positive rates — matching `time_until_available`'s "rate of zero or less
+  means never available" contract — and as a bonus no longer locks the tokens
+  mutex in the supported `0.0` "burst once, never refill" mode.
+  Regression-tested by `refill_does_not_drain_tokens_with_negative_rate`.
+- **`RateLimiterStats::block_rate` used an unchecked addition.**
+  `total_allowed + total_blocked` would panic on overflow in debug builds — only
+  after roughly `1.8e19` lifetime operations, but free to make correct with
+  `saturating_add`.
 - **`create_tar_from_tree` silently dropped files whose path was too long for
   a tar header.** The tar builder set the entry path via `tar::Header::set_path`
   and then `append`, but `set_path` fails for any path that doesn't fit the

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -93,10 +93,13 @@ impl Config {
     ///   immediately;
     /// - `rate_limits.max_burst` of zero — the token bucket can then never hand
     ///   out a token, blocking every operation forever;
-    /// - a non-finite or negative `rate_limits.refill_rate_per_sec` — `NaN`
-    ///   panics in `RateLimiter::time_until_available` (`Duration::from_secs_f64`
-    ///   rejects non-finite input), and the infinities/negatives break the
-    ///   token-bucket maths (permanent block, or effectively no throttling).
+    /// - a non-finite or negative `rate_limits.refill_rate_per_sec` — such a
+    ///   rate has no sensible meaning (negatives would drain the bucket,
+    ///   `NaN`/infinities make the refill maths nonsensical), so it is rejected
+    ///   early with a clear error. `RateLimiter` is itself hardened against
+    ///   these (`refill` skips non-positive rates; `time_until_available`
+    ///   saturates rather than calling `Duration::from_secs_f64`, which panics
+    ///   on overflow), but the config layer still refuses them up front.
     ///   `0.0` stays allowed — the supported "burst once, never refill" mode;
     /// - zero session limits (`sessions.timeout_secs`,
     ///   `sessions.max_streaming_sessions`, `sessions.max_repo_sessions`) —

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -9,14 +9,21 @@
 //! - stdout: sends messages to client
 //! - stderr: may be used for logging (not MCP messages)
 //!
-//! # Thread Safety
+//! # Concurrency model
 //!
-//! The transport uses async I/O with Tokio. Reading and writing are
-//! handled through separate tasks to allow concurrent operation.
+//! The transport uses async I/O with Tokio but is driven from a single task:
+//! the server owns one [`StdioTransport`] and its main loop `tokio::select!`s
+//! on [`StdioTransport::read_line`] alongside shutdown signals, writing each
+//! response inline on the same task. Reads and writes are therefore sequential,
+//! not concurrent — the `&mut self` methods reflect that single-owner model.
+//!
+//! Because `read_line` is polled inside `select!`, it may be cancelled when a
+//! shutdown signal fires; that is safe here because the server then exits
+//! rather than resuming the partially-read line.
 
 use std::io;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
 use crate::mcp::protocol::{JsonRpcError, JsonRpcResponse, OutgoingNotification};
 
@@ -42,29 +49,21 @@ impl StdioTransport {
 
     /// Reads the next message line from stdin.
     ///
-    /// Returns `None` if stdin is closed (EOF).
+    /// Returns `None` if stdin is closed (EOF). A trailing `\n` or `\r\n` is
+    /// stripped before the line is returned.
+    ///
+    /// The read is intentionally unbounded: `repo_push` carries its git bundle
+    /// as base64 inline in a single JSON-RPC request (up to the configured
+    /// bundle-size limit, on the order of 1 GiB), so one message line can
+    /// legitimately be hundreds of megabytes. Capping the line length here
+    /// would break large pushes.
     ///
     /// # Errors
     ///
-    /// Returns an error if reading from stdin fails.
+    /// Returns an error if reading from stdin fails, including a line that is
+    /// not valid UTF-8.
     pub async fn read_line(&mut self) -> io::Result<Option<String>> {
-        let mut line = String::new();
-        let bytes_read = self.reader.read_line(&mut line).await?;
-
-        if bytes_read == 0 {
-            // EOF - stdin closed
-            return Ok(None);
-        }
-
-        // Remove the trailing newline
-        if line.ends_with('\n') {
-            line.pop();
-            if line.ends_with('\r') {
-                line.pop();
-            }
-        }
-
-        Ok(Some(line))
+        read_message_line(&mut self.reader).await
     }
 
     /// Writes a JSON-RPC response to stdout.
@@ -116,17 +115,7 @@ impl StdioTransport {
     ///
     /// Returns an error if writing fails.
     async fn write_raw(&mut self, json: &str) -> io::Result<()> {
-        // MCP spec: messages must not contain embedded newlines
-        debug_assert!(
-            !json.contains('\n'),
-            "JSON message must not contain embedded newlines"
-        );
-
-        self.writer.write_all(json.as_bytes()).await?;
-        self.writer.write_all(b"\n").await?;
-        self.writer.flush().await?;
-
-        Ok(())
+        write_message_line(&mut self.writer, json).await
     }
 
     /// Writes an arbitrary JSON value to stdout.
@@ -148,6 +137,59 @@ impl Default for StdioTransport {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Strips a single trailing line terminator (`\n` or `\r\n`) in place.
+///
+/// A lone `\r` (old-Mac style) is not a JSON-RPC delimiter, so it is left
+/// intact.
+fn strip_trailing_newline(line: &mut String) {
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+}
+
+/// Reads one newline-delimited message from `reader`, returning `None` at EOF.
+///
+/// Generic over the reader so the line framing can be unit-tested without real
+/// stdin; [`StdioTransport::read_line`] delegates here. See that method for why
+/// the read is intentionally unbounded.
+async fn read_message_line<R>(reader: &mut R) -> io::Result<Option<String>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut line = String::new();
+    if reader.read_line(&mut line).await? == 0 {
+        // EOF - stream closed
+        return Ok(None);
+    }
+
+    strip_trailing_newline(&mut line);
+    Ok(Some(line))
+}
+
+/// Writes `json` to `writer`, terminates it with a newline, and flushes.
+///
+/// Generic over the writer so the framing can be unit-tested without real
+/// stdout; [`StdioTransport::write_raw`] delegates here.
+async fn write_message_line<W>(writer: &mut W, json: &str) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    // MCP spec: messages must not contain embedded newlines
+    debug_assert!(
+        !json.contains('\n'),
+        "JSON message must not contain embedded newlines"
+    );
+
+    writer.write_all(json.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -188,5 +230,92 @@ mod tests {
             !json.contains('\n'),
             "Serialised JSON should not contain newlines"
         );
+    }
+
+    #[test]
+    fn strip_trailing_newline_handles_lf_crlf_and_bare() {
+        let mut lf = String::from("hello\n");
+        strip_trailing_newline(&mut lf);
+        assert_eq!(lf, "hello");
+
+        let mut crlf = String::from("hello\r\n");
+        strip_trailing_newline(&mut crlf);
+        assert_eq!(crlf, "hello");
+
+        // No terminator: unchanged.
+        let mut bare = String::from("hello");
+        strip_trailing_newline(&mut bare);
+        assert_eq!(bare, "hello");
+
+        // A lone CR is not a JSON-RPC delimiter and is preserved.
+        let mut cr = String::from("hello\r");
+        strip_trailing_newline(&mut cr);
+        assert_eq!(cr, "hello\r");
+
+        // Empty line stays empty.
+        let mut empty = String::new();
+        strip_trailing_newline(&mut empty);
+        assert_eq!(empty, "");
+    }
+
+    #[tokio::test]
+    async fn read_message_line_strips_lf_and_crlf_across_messages() {
+        let mut reader = BufReader::new(&b"first\nsecond\r\n"[..]);
+
+        assert_eq!(
+            read_message_line(&mut reader).await.unwrap(),
+            Some("first".to_string())
+        );
+        assert_eq!(
+            read_message_line(&mut reader).await.unwrap(),
+            Some("second".to_string())
+        );
+        // Stream exhausted -> EOF.
+        assert_eq!(read_message_line(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_message_line_returns_final_line_without_newline() {
+        // A final line with no trailing newline is still returned, then EOF.
+        let mut reader = BufReader::new(&b"no-newline"[..]);
+        assert_eq!(
+            read_message_line(&mut reader).await.unwrap(),
+            Some("no-newline".to_string())
+        );
+        assert_eq!(read_message_line(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_message_line_empty_input_is_eof() {
+        let mut reader = BufReader::new(&b""[..]);
+        assert_eq!(read_message_line(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_message_line_preserves_empty_message() {
+        // A bare newline is an empty (but present) message, not EOF.
+        let mut reader = BufReader::new(&b"\n"[..]);
+        assert_eq!(
+            read_message_line(&mut reader).await.unwrap(),
+            Some(String::new())
+        );
+        assert_eq!(read_message_line(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn write_message_line_appends_single_newline() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_message_line(&mut buf, r#"{"jsonrpc":"2.0"}"#)
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "{\"jsonrpc\":\"2.0\"}\n");
+    }
+
+    #[tokio::test]
+    async fn write_message_line_frames_each_message_separately() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_message_line(&mut buf, "a").await.unwrap();
+        write_message_line(&mut buf, "b").await.unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "a\nb\n");
     }
 }

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -196,6 +196,16 @@ impl RateLimiter {
     #[allow(clippy::significant_drop_tightening)] // Lock ordering is intentional
     #[allow(clippy::cast_precision_loss)] // max_burst as f64 is acceptable
     fn refill(&self) {
+        // A non-positive refill rate means the bucket never refills: 0.0 is the
+        // supported "burst once" mode, and a negative rate (rejected by config
+        // but accepted by the public constructor) would otherwise *drain*
+        // tokens, since `elapsed * negative` is negative. Skip entirely — this
+        // matches `time_until_available`'s "rate <= 0 means never available"
+        // contract and avoids locking the tokens mutex in the 0.0 mode.
+        if self.refill_rate <= 0.0 {
+            return;
+        }
+
         let now = Instant::now();
 
         let mut last_refill = self.lock_last_refill();
@@ -450,5 +460,19 @@ mod tests {
         assert!(limiter.try_acquire());
 
         assert_eq!(limiter.time_until_available(), Duration::MAX);
+    }
+
+    #[test]
+    fn refill_does_not_drain_tokens_with_negative_rate() {
+        // A negative refill_rate is rejected by Config::validate, but the public
+        // RateLimiter::new accepts it. refill() must not *remove* tokens
+        // (`elapsed * negative` is negative); it no-ops for non-positive rates.
+        let limiter = RateLimiter::new(3, -100.0);
+
+        thread::sleep(Duration::from_millis(20));
+
+        // Tokens stay at the full burst rather than draining below 3.
+        assert!((limiter.available_tokens() - 3.0).abs() < f64::EPSILON);
+        assert!(limiter.would_allow());
     }
 }

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -163,7 +163,10 @@ impl RateLimiter {
 
     /// Returns time until the next token is available.
     ///
-    /// Returns `Duration::ZERO` if tokens are currently available.
+    /// Returns `Duration::ZERO` if tokens are currently available, and
+    /// `Duration::MAX` ("effectively never") when the bucket cannot refill — a
+    /// `refill_rate` of zero or less, or a rate so small that the computed wait
+    /// would overflow `Duration`.
     ///
     /// # Mutex Poisoning
     ///

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -184,7 +184,11 @@ impl RateLimiter {
         } else {
             let tokens_needed = 1.0 - current_tokens;
             let seconds = tokens_needed / self.refill_rate;
-            Duration::from_secs_f64(seconds)
+            // A minuscule (but config-valid: finite and positive) refill_rate
+            // makes `seconds` exceed Duration's range, and `from_secs_f64`
+            // panics on overflow/non-finite input. Saturate to `Duration::MAX`
+            // — semantically "effectively never" — instead of crashing.
+            Duration::try_from_secs_f64(seconds).unwrap_or(Duration::MAX)
         }
     }
 
@@ -431,6 +435,20 @@ mod tests {
         limiter.try_acquire();
 
         // With zero refill rate, should return Duration::MAX
+        assert_eq!(limiter.time_until_available(), Duration::MAX);
+    }
+
+    #[test]
+    fn time_until_available_saturates_on_tiny_refill_rate() {
+        // A finite, positive but minuscule refill_rate passes config validation
+        // (`Config::validate` only rejects non-finite/negative), yet makes
+        // `seconds = 1.0 / refill_rate` overflow Duration's range. The method
+        // must saturate to Duration::MAX rather than panic in from_secs_f64.
+        let limiter = RateLimiter::new(1, f64::MIN_POSITIVE);
+
+        // Drain the single token so the else-branch (refill_rate > 0) is taken.
+        assert!(limiter.try_acquire());
+
         assert_eq!(limiter.time_until_available(), Duration::MAX);
     }
 }

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -477,4 +477,35 @@ mod tests {
         assert!((limiter.available_tokens() - 3.0).abs() < f64::EPSILON);
         assert!(limiter.would_allow());
     }
+
+    #[test]
+    fn try_acquire_recovers_from_poisoned_tokens_mutex() {
+        let limiter = RateLimiter::new(5, 1.0);
+
+        // Poison the tokens mutex by panicking while holding it. catch_unwind
+        // keeps the deliberate panic on this (output-captured) test thread.
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = limiter.tokens.lock().unwrap();
+            panic!("intentionally poisoning the tokens mutex");
+        }));
+        assert!(poisoned.is_err());
+
+        // lock_tokens() must recover via into_inner() rather than propagating
+        // the poison (which would panic on .unwrap()).
+        assert!(limiter.try_acquire());
+    }
+
+    #[test]
+    fn refill_recovers_from_poisoned_last_refill_mutex() {
+        let limiter = RateLimiter::new(5, 10.0);
+
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = limiter.last_refill.lock().unwrap();
+            panic!("intentionally poisoning the last_refill mutex");
+        }));
+        assert!(poisoned.is_err());
+
+        // refill() (invoked by try_acquire) must recover the last_refill lock.
+        assert!(limiter.try_acquire());
+    }
 }

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -288,7 +288,9 @@ impl RateLimiterStats {
     #[must_use]
     #[allow(clippy::cast_precision_loss)] // Percentage calculation is acceptable
     pub fn block_rate(&self) -> f64 {
-        let total = self.total_allowed + self.total_blocked;
+        // saturating_add: the sum only overflows after ~1.8e19 lifetime
+        // operations, but an unchecked add would panic there in debug builds.
+        let total = self.total_allowed.saturating_add(self.total_blocked);
         if total == 0 {
             0.0
         } else {

--- a/src/security/rate_limit.rs
+++ b/src/security/rate_limit.rs
@@ -429,6 +429,14 @@ mod tests {
     }
 
     #[test]
+    fn rate_limiter_default_impl_delegates_to_ai_defaults() {
+        // The Default impl just forwards to default_for_ai().
+        let limiter = RateLimiter::default();
+        assert_eq!(limiter.max_burst, 20);
+        assert!((limiter.refill_rate - 5.0).abs() < 0.01);
+    }
+
+    #[test]
     fn block_rate_with_no_operations() {
         let limiter = RateLimiter::new(10, 1.0);
         let stats = limiter.stats();


### PR DESCRIPTION
## Description

Focused audit of `src/security/rate_limit.rs` (the token-bucket rate limiter),
continuing the per-file security/quality sweep. Three correctness/robustness
fixes plus coverage for previously-untested paths. `rate_limit.rs` goes from
98.64 % to 100 % line coverage.

The limiter is wired into the server (`McpServer::rate_limiter`) and gates all
six network tools via `try_acquire`. Notably, **only `try_acquire` is called in
production** — `time_until_available`, `would_allow`, `available_tokens`,
`stats`, and `reset` are public library surface exercised only by tests. That
scopes finding #1 below as a *latent* panic in the public API rather than a live
server crash.

Findings:

1. **Bug (latent panic).** `time_until_available` computed
   `Duration::from_secs_f64(1.0 / refill_rate)`, which panics on overflow. A
   finite, positive but minuscule `refill_rate` (e.g. `1e-20`) passes
   `Config::validate` (which only rejects non-finite/negative rates) yet
   overflows here. Now uses `try_from_secs_f64` and saturates to `Duration::MAX`.
   The `Config::validate` doc comment that flagged this exact panic is updated to
   match the now-panic-safe behaviour (the guard is kept — it still rejects
   nonsensical rates early with a clear error).
2. **Hardening.** A negative `refill_rate` made `refill` *drain* the bucket
   (`elapsed * negative` is negative) on every call. `Config::validate` rejects
   negatives, but the public `RateLimiter::new` does not, so a direct library
   caller hit it. `refill` now returns early for non-positive rates — matching
   `time_until_available`'s "rate of zero or less ⇒ never available" contract,
   and as a bonus skipping the tokens lock in the supported `0.0` burst-once mode.
3. **Hygiene.** `RateLimiterStats::block_rate` summed `total_allowed +
   total_blocked` with an unchecked `+` (debug-build overflow panic at ~`1.8e19`
   lifetime ops); now `saturating_add`.

Coverage: added tests for the mutex poison-recovery arms (`lock_tokens` /
`lock_last_refill`), the overflow-saturation path, the negative-rate no-drain
behaviour, and the `Default` impl.

## Related Issue

N/A — proactive audit, no tracking issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (`Config::validate` comment + `time_until_available` doc)
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [x] Security improvement (panic-safety / drain-proofing of a security control)

## Security Checklist ⚠️

Since this is a credential-handling project:

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`)
- [x] Error messages don't leak sensitive information

This module handles no credentials. The only log line touched conceptually is
the existing poison-recovery `warn!`, which contains no sensitive data.

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

`cargo test --all-features --workspace` green. `rate_limit.rs` 100 % line-covered
(verified via `cargo llvm-cov`); the only changed-and-executable lines outside
tests are all directly exercised, so `codecov/patch` is satisfied.

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] Documentation is updated if needed (`Config::validate` comment)
- [x] CHANGELOG.md is updated for user-facing changes

## Commit Map

1. `fix(rate-limit): saturate time_until_available instead of panicking` — finding #1 + regression test + `Config::validate` comment.
2. `fix(rate-limit): skip refill for non-positive rates so negatives cannot drain tokens` — finding #2 + regression test.
3. `fix(rate-limit): avoid unchecked add in block_rate denominator` — finding #3.
4. `test(rate-limit): cover mutex poison-recovery paths` — poison `tokens` / `last_refill`, assert recovery.
5. `docs(changelog): record rate-limit panic-safety, drain, and coverage work`.
6. `test(rate-limit): cover the Default impl` — pre-existing uncovered `default()`; takes the file to 100 %.
7. `docs(rate-limit): document the Duration::MAX sentinel in time_until_available` — self-review follow-up; documents the "effectively never" return.

## Findings That Are NOT in This PR

- **`Config::validate` was deliberately not tightened to reject minuscule
  positive `refill_rate`.** Now that `time_until_available` saturates, there is
  no panic to prevent and no principled threshold to pick. The existing
  non-finite/negative rejection stays (clear early error for nonsensical config).
- **The public read-only methods unused by the server were left as-is.**
  `would_allow` / `available_tokens` / `stats` / `reset` / `time_until_available`
  are legitimate library API; not dead-code-removal candidates.
- **`refill` then `try_acquire` is not atomic across the two lock acquisitions.**
  This is fine: the token check-and-decrement is fully serialised under the
  tokens mutex, so tokens are never over-issued; the only effect of the gap is a
  benign extra refill computation. Not changed.

## Additional Notes

Branched off `main` (rate-limit surface is disjoint from the recently-merged
`audit/security-guards` #187, so no stacking needed).
