### PR TITLE
refactor(transport): make line framing unit-testable; fix concurrency docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`mcp::transport` line-framing coverage.** The read/write paths were only
+  exercised by the Python integration suite because stdin/stdout were hardcoded.
+  Following the testability refactor, new unit tests cover LF / CRLF / EOF /
+  no-trailing-newline / empty-line reads and newline-terminated writes, taking
+  `transport.rs` unit line coverage from 40.86 % to ~78 % (the remainder is the
+  thin stdin/stdout glue, still integration-covered).
 - **`security::rate_limit` poison-recovery coverage.** The mutex poison-recovery
   arms in `lock_tokens` / `lock_last_refill` (which fall back to `into_inner()`
   when a thread panicked while holding the lock) had no test. Added unit tests
@@ -215,6 +221,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`mcp::transport` line framing refactored for unit-testability; concurrency
+  docs corrected** (no behaviour change):
+    1. The `\n` / `\r\n` stripping and the read/write framing were extracted into
+       a pure `strip_trailing_newline` helper and generic `read_message_line` /
+       `write_message_line` helpers (over any `AsyncBufRead` / `AsyncWrite`), so
+       the framing can be tested without real stdin/stdout. `read_line` and
+       `write_raw` delegate to them.
+    2. The module's "Thread Safety" section claimed reads and writes run on
+       separate tasks for concurrent operation; in fact the server drives a
+       single `StdioTransport` from one `tokio::select!` loop, so reads and
+       writes are sequential on one task. Reworded to describe the real
+       single-task model.
+    3. Documented that `read_line` is intentionally unbounded — `repo_push`
+       sends its bundle inline as base64 (up to the ~1 GiB bundle-size limit),
+       so a per-line length cap would break large pushes.
 - **Security guards now share consistent pattern- and force-push detection.**
   Two helpers are shared across the guards so they behave alike:
     1. `BranchGuard::is_protected` honours `*` anywhere in a protected-branch

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -9,14 +9,21 @@
 //! - stdout: sends messages to client
 //! - stderr: may be used for logging (not MCP messages)
 //!
-//! # Thread Safety
+//! # Concurrency model
 //!
-//! The transport uses async I/O with Tokio. Reading and writing are
-//! handled through separate tasks to allow concurrent operation.
+//! The transport uses async I/O with Tokio but is driven from a single task:
+//! the server owns one [`StdioTransport`] and its main loop `tokio::select!`s
+//! on [`StdioTransport::read_line`] alongside shutdown signals, writing each
+//! response inline on the same task. Reads and writes are therefore sequential,
+//! not concurrent — the `&mut self` methods reflect that single-owner model.
+//!
+//! Because `read_line` is polled inside `select!`, it may be cancelled when a
+//! shutdown signal fires; that is safe here because the server then exits
+//! rather than resuming the partially-read line.
 
 use std::io;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
 use crate::mcp::protocol::{JsonRpcError, JsonRpcResponse, OutgoingNotification};
 
@@ -42,29 +49,21 @@ impl StdioTransport {
 
     /// Reads the next message line from stdin.
     ///
-    /// Returns `None` if stdin is closed (EOF).
+    /// Returns `None` if stdin is closed (EOF). A trailing `\n` or `\r\n` is
+    /// stripped before the line is returned.
+    ///
+    /// The read is intentionally unbounded: `repo_push` carries its git bundle
+    /// as base64 inline in a single JSON-RPC request (up to the configured
+    /// bundle-size limit, on the order of 1 GiB), so one message line can
+    /// legitimately be hundreds of megabytes. Capping the line length here
+    /// would break large pushes.
     ///
     /// # Errors
     ///
-    /// Returns an error if reading from stdin fails.
+    /// Returns an error if reading from stdin fails, including a line that is
+    /// not valid UTF-8.
     pub async fn read_line(&mut self) -> io::Result<Option<String>> {
-        let mut line = String::new();
-        let bytes_read = self.reader.read_line(&mut line).await?;
-
-        if bytes_read == 0 {
-            // EOF - stdin closed
-            return Ok(None);
-        }
-
-        // Remove the trailing newline
-        if line.ends_with('\n') {
-            line.pop();
-            if line.ends_with('\r') {
-                line.pop();
-            }
-        }
-
-        Ok(Some(line))
+        read_message_line(&mut self.reader).await
     }
 
     /// Writes a JSON-RPC response to stdout.
@@ -116,17 +115,7 @@ impl StdioTransport {
     ///
     /// Returns an error if writing fails.
     async fn write_raw(&mut self, json: &str) -> io::Result<()> {
-        // MCP spec: messages must not contain embedded newlines
-        debug_assert!(
-            !json.contains('\n'),
-            "JSON message must not contain embedded newlines"
-        );
-
-        self.writer.write_all(json.as_bytes()).await?;
-        self.writer.write_all(b"\n").await?;
-        self.writer.flush().await?;
-
-        Ok(())
+        write_message_line(&mut self.writer, json).await
     }
 
     /// Writes an arbitrary JSON value to stdout.
@@ -148,6 +137,59 @@ impl Default for StdioTransport {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Strips a single trailing line terminator (`\n` or `\r\n`) in place.
+///
+/// A lone `\r` (old-Mac style) is not a JSON-RPC delimiter, so it is left
+/// intact.
+fn strip_trailing_newline(line: &mut String) {
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+}
+
+/// Reads one newline-delimited message from `reader`, returning `None` at EOF.
+///
+/// Generic over the reader so the line framing can be unit-tested without real
+/// stdin; [`StdioTransport::read_line`] delegates here. See that method for why
+/// the read is intentionally unbounded.
+async fn read_message_line<R>(reader: &mut R) -> io::Result<Option<String>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut line = String::new();
+    if reader.read_line(&mut line).await? == 0 {
+        // EOF - stream closed
+        return Ok(None);
+    }
+
+    strip_trailing_newline(&mut line);
+    Ok(Some(line))
+}
+
+/// Writes `json` to `writer`, terminates it with a newline, and flushes.
+///
+/// Generic over the writer so the framing can be unit-tested without real
+/// stdout; [`StdioTransport::write_raw`] delegates here.
+async fn write_message_line<W>(writer: &mut W, json: &str) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    // MCP spec: messages must not contain embedded newlines
+    debug_assert!(
+        !json.contains('\n'),
+        "JSON message must not contain embedded newlines"
+    );
+
+    writer.write_all(json.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -188,5 +230,92 @@ mod tests {
             !json.contains('\n'),
             "Serialised JSON should not contain newlines"
         );
+    }
+
+    #[test]
+    fn strip_trailing_newline_handles_lf_crlf_and_bare() {
+        let mut lf = String::from("hello\n");
+        strip_trailing_newline(&mut lf);
+        assert_eq!(lf, "hello");
+
+        let mut crlf = String::from("hello\r\n");
+        strip_trailing_newline(&mut crlf);
+        assert_eq!(crlf, "hello");
+
+        // No terminator: unchanged.
+        let mut bare = String::from("hello");
+        strip_trailing_newline(&mut bare);
+        assert_eq!(bare, "hello");
+
+        // A lone CR is not a JSON-RPC delimiter and is preserved.
+        let mut cr = String::from("hello\r");
+        strip_trailing_newline(&mut cr);
+        assert_eq!(cr, "hello\r");
+
+        // Empty line stays empty.
+        let mut empty = String::new();
+        strip_trailing_newline(&mut empty);
+        assert_eq!(empty, "");
+    }
+
+    #[tokio::test]
+    async fn read_message_line_strips_lf_and_crlf_across_messages() {
+        let mut reader = BufReader::new(&b"first\nsecond\r\n"[..]);
+
+        assert_eq!(
+            read_message_line(&mut reader).await.unwrap(),
+            Some("first".to_string())
+        );
+        assert_eq!(
+            read_message_line(&mut reader).await.unwrap(),
+            Some("second".to_string())
+        );
+        // Stream exhausted -> EOF.
+        assert_eq!(read_message_line(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_message_line_returns_final_line_without_newline() {
+        // A final line with no trailing newline is still returned, then EOF.
+        let mut reader = BufReader::new(&b"no-newline"[..]);
+        assert_eq!(
+            read_message_line(&mut reader).await.unwrap(),
+            Some("no-newline".to_string())
+        );
+        assert_eq!(read_message_line(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_message_line_empty_input_is_eof() {
+        let mut reader = BufReader::new(&b""[..]);
+        assert_eq!(read_message_line(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_message_line_preserves_empty_message() {
+        // A bare newline is an empty (but present) message, not EOF.
+        let mut reader = BufReader::new(&b"\n"[..]);
+        assert_eq!(
+            read_message_line(&mut reader).await.unwrap(),
+            Some(String::new())
+        );
+        assert_eq!(read_message_line(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn write_message_line_appends_single_newline() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_message_line(&mut buf, r#"{"jsonrpc":"2.0"}"#)
+            .await
+            .unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "{\"jsonrpc\":\"2.0\"}\n");
+    }
+
+    #[tokio::test]
+    async fn write_message_line_frames_each_message_separately() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_message_line(&mut buf, "a").await.unwrap();
+        write_message_line(&mut buf, "b").await.unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "a\nb\n");
     }
 }


### PR DESCRIPTION
## Description

Final file in the per-file security/quality sweep: `src/mcp/transport.rs` (the
stdio JSON-RPC transport). **No behaviour change** — the audit found no logic
bugs (the transport is correct). It delivers two documentation corrections and a
testability refactor that closes a real unit-coverage gap.

> **Stacked on #188** (`audit/rate-limit`). Base is `audit/rate-limit` so the
> diff shows only the transport changes; will rebase onto `main` once #188
> merges. Both PRs touch `CHANGELOG.md`, which is why this is stacked rather than
> branched off `main`.

Findings:

1. **Doc — inaccurate concurrency claim.** The module's "# Thread Safety" section
   said reads and writes are "handled through separate tasks to allow concurrent
   operation." In reality the server owns a single `StdioTransport` and drives it
   from one `tokio::select!` loop (`server.rs`), reading and writing sequentially
   on one task — the `&mut self` methods reflect that. Reworded to a "Concurrency
   model" section describing the real single-task design (and noting `read_line`
   is cancellation-safe in `select!` because the server exits rather than
   resuming a partial read).
2. **Doc — missing "do not cap this" note.** `read_line` is unbounded, which
   looks like a DoS gap ("parses every byte from the client") — but it's
   *required*: `repo_push` carries its git bundle inline as base64 in a single
   JSON-RPC request, up to the ~1 GiB bundle-size limit. A per-line cap would
   break large pushes. Documented so a future "hardening" doesn't reintroduce the
   breakage.
3. **Coverage — read/write framing was integration-only.** stdin/stdout were
   hardcoded, so the framing logic had no unit coverage (only the Python
   integration suite exercised it, and it never tests CRLF / no-trailing-newline
   edges). Extracted the logic into a pure `strip_trailing_newline` helper and
   generic `read_message_line` / `write_message_line` helpers (over any
   `AsyncBufRead` / `AsyncWrite`); `read_line` and `write_raw` delegate to them.
   Added unit tests for LF / CRLF / EOF / no-trailing-newline / empty-line reads
   and newline-terminated writes.

## Related Issue

N/A — proactive audit, no tracking issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (concurrency model + unbounded-read rationale)
- [x] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

## Security Checklist ⚠️

Since this is a credential-handling project:

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`)
- [x] Error messages don't leak sensitive information

This module moves no credentials; it frames JSON-RPC bytes. No behaviour change.

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

`cargo test --all-features --workspace` green (701 lib tests). `transport.rs`
unit line coverage 40.86 % → ~78 %. Every executable line in this diff (the new
helpers and the new tests) is unit-covered, so `codecov/patch` is satisfied; the
file's remaining uncovered lines are the unchanged thin stdin/stdout glue
methods (`write_response`/`write_error`/`write_notification`/`write_json`),
which the integration suite exercises in CI.

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] Documentation is updated if needed (this PR *is* the doc fix)
- [x] CHANGELOG.md is updated for user-facing changes

## Commit Map

1. `refactor(transport): make line framing unit-testable; fix concurrency docs` — the refactor (helpers + delegation), both doc corrections, and the unit tests.
2. `docs(changelog): record transport testability refactor and doc fixes`.

## Findings That Are NOT in This PR

- **No read-length cap was added.** As above, inline base64 bundles make large
  incoming lines legitimate; capping would break `repo_push`. The unbounded read
  is now *documented* rather than "fixed".
- **The transport was not made fully generic.** Only the framing logic was
  extracted to generic helpers. Making the whole `StdioTransport` generic over
  reader/writer would let the thin `write_*` glue methods be unit-tested too, but
  they are trivial (serialise → delegate) and already integration-covered;
  the extra public-API surface wasn't worth it.
- **Invalid-UTF-8 input is fatal (unchanged).** `read_line` propagates the
  `AsyncBufReadExt::read_line` UTF-8 error, which terminates the server, whereas
  a valid-UTF-8 but malformed-JSON line is answered with a JSON-RPC error and the
  loop continues. For a single-client stdio server a non-UTF-8 byte stream
  signals a broken peer, so terminating is defensible; changing it is a
  behaviour change left out of this no-behaviour-change PR.

## Additional Notes

This completes the per-file audit sweep (`config`, all of `git2_ops`,
`streaming/tar`, `security/guards`, `security/rate_limit`, and now
`mcp/transport`).
