### PR TITLE
docs: documentation consistency audit across all MD files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,6 +75,7 @@ src/
 ├── main.rs             # CLI entry point
 ├── error.rs            # Top-level error types
 ├── session.rs          # Session tracking
+├── util.rs             # Shared helpers (sanitise_for_log)
 ├── config/             # Configuration
 │   ├── mod.rs          # Module exports
 │   └── settings.rs     # Config file parsing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Credential-setup docs consolidated to a single source.** The
+  `git config --global credential.helper …` (osxkeychain / manager / libsecret)
+  and ssh-agent setup commands were duplicated verbatim in three places: the
+  README "Git authentication" section, the SECURITY.md "Git Configuration"
+  best-practices subsection, and the `docs/errors.md` troubleshooting section.
+  Per `STYLE.md`'s Single Source of Truth rule, the README is now the canonical
+  home (and absorbs SECURITY.md's macOS Keychain passphrase tip); SECURITY.md
+  and `docs/errors.md` cross-reference it instead of repeating the commands. Each
+  keeps its unique content — SECURITY.md's credential recommendations and
+  `docs/errors.md`'s `git ls-remote` connectivity test.
 - **`mcp::transport` line framing refactored for unit-testability; concurrency
   docs corrected** (no behaviour change):
     1. The `\n` / `\r\n` stripping and the read/write framing were extracted into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -543,6 +543,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`limits.max_output_bytes` validation was undocumented.** `Config::validate`
+  rejects a zero `limits.max_output_bytes` (it sits in the same `nonzero_usize`
+  check as the session limits — see `src/config/settings.rs`), but the field was
+  missing from every narrative description of the validation rules: the
+  `validate` rustdoc, the README "Validation" prose, and the `docs/errors.md`
+  validation-rules table each listed the timeout, rate-limit, session, and
+  log-level checks but not this one. A user setting `max_output_bytes: 0` would
+  hit a `configuration validation failed` abort that none of the docs predicted.
+  Added it to all three.
+- **`docs/AI_WORKFLOW.md` workflow diagram showed a `repo_push` response shape
+  the server never returns.** The "Complete Workflow" ASCII diagram's PUSH step
+  said `Receives: { success: true, url: "…/commit/…" }`, but `RepoPushResult`
+  (see `src/mcp/tools/repo_push.rs`) has no `success` or `url` field — it returns
+  `branch`, `commit`, `force`, `remote_url`, and `hint`, exactly as the detailed
+  example later in the same document already shows. Updated the diagram to list
+  the real fields.
 - **`RateLimiter::time_until_available` could panic on a config-valid input.**
   It computed `Duration::from_secs_f64(1.0 / refill_rate)`, which panics when the
   result overflows `Duration`. A finite, positive but minuscule
@@ -956,7 +972,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`README.md` configuration table omitted defaults for half the
   options.** `git_identity.{name,email}`, `security.{protected_branches,
   repo_allowlist, repo_blocklist}`, `logging.{level, audit_log_path}`,
-  `proxy.{url, no_proxy}`, `lfs.{max_object_size, max_total_size}`, and
+  `proxy.{url, no_proxy}`, `lfs.max_object_size`, and
   `submodules.{include_patterns, exclude_patterns}` had no default
   documented. Added the actual defaults from `src/config/settings.rs`
   (mostly `null`/empty/`warn`) so users no longer have to guess what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -553,6 +553,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **README "Git CLI" prerequisite named the wrong git subcommand.** It said the
+  server invokes `git bundle unbundle` to apply a `repo_push` payload, but
+  `git2_ops::push::unbundle` actually shells out to
+  `git fetch --no-tags <bundle> refs/heads/*:refs/heads/*` (libgit2 cannot fetch
+  from bundle files reliably — see `src/git2_ops/push.rs`). Changed the prose to
+  "`git fetch` from a bundle file".
+- **`docs/SECURITY.md`'s `sanitize_url_for_logging` snippet had drifted from the
+  code.** The shown implementation found the first `@` anywhere in the URL; the
+  real function (`src/git2_ops/auth.rs`) scans only the authority component for
+  the userinfo `@` per RFC 3986 — the fix that stopped it mangling URLs with an
+  `@` in the path or query. Replaced the snippet and prose with the
+  authority-scoped logic. Also softened the adjacent "temp directory permissions
+  are 0700" claim: the code sets no explicit mode and relies on the `tempfile`
+  crate's owner-only default (0700 on Unix; the user's profile ACL on Windows).
+- **Source-tree diagrams omitted `src/util.rs`.** The shared `sanitize_for_log`
+  helper module was missing from the trees in both `docs/ARCHITECTURE.md` and
+  `.claude/CLAUDE.md`; added it. Also added a `CODE_OF_CONDUCT.md` row to
+  `CONTRIBUTING.md`'s "Types of Documentation" table, tightened
+  `docs/ARCHITECTURE.md`'s Tier 2 disk-threshold wording from "≥ 10 MiB" to
+  "larger than 10 MiB" (the code uses a strict `>`), and refreshed
+  `docs/errors.md`'s "Last updated" date.
 - **`limits.max_output_bytes` validation was undocumented.** `Config::validate`
   rejects a zero `limits.max_output_bytes` (it sits in the same `nonzero_usize`
   check as the session limits — see `src/config/settings.rs`), but the field was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -557,12 +557,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   section read "GNU General Public License v3.0" while `Cargo.toml`'s `license`
   field is `GPL-3.0-or-later`; the README now reads "v3.0 or later" so the two
   agree (the bundled `LICENCE` file is the GPLv3 text).
-- **README "Git CLI" prerequisite named the wrong git subcommand.** It said the
-  server invokes `git bundle unbundle` to apply a `repo_push` payload, but
-  `git2_ops::push::unbundle` actually shells out to
-  `git fetch --no-tags <bundle> refs/heads/*:refs/heads/*` (libgit2 cannot fetch
-  from bundle files reliably — see `src/git2_ops/push.rs`). Changed the prose to
-  "`git fetch` from a bundle file".
 - **`docs/SECURITY.md`'s `sanitize_url_for_logging` snippet had drifted from the
   code.** The shown implementation found the first `@` anywhere in the URL; the
   real function (`src/git2_ops/auth.rs`) scans only the authority component for
@@ -943,7 +937,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HTTP standard).
 - **`README.md` Prerequisites omitted the runtime Git CLI requirement.**
   The server shells out to `git credential fill` (in
-  `src/git2_ops/auth.rs`) and `git bundle unbundle` (in
+  `src/git2_ops/auth.rs`) and `git fetch` from a bundle file (in
   `src/git2_ops/push.rs`); a user installing only the prebuilt binary
   without git on `PATH` would have hit the credential helper failing to
   return anything and `repo_push` failing to apply the bundle. Added a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -553,6 +553,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **README licence statement now matches the SPDX expression.** The Licence
+  section read "GNU General Public License v3.0" while `Cargo.toml`'s `license`
+  field is `GPL-3.0-or-later`; the README now reads "v3.0 or later" so the two
+  agree (the bundled `LICENCE` file is the GPLv3 text).
 - **README "Git CLI" prerequisite named the wrong git subcommand.** It said the
   server invokes `git bundle unbundle` to apply a `repo_push` payload, but
   `git2_ops::push::unbundle` actually shells out to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,6 +325,7 @@ When adding or modifying code that handles credentials:
 |----------|--------|
 | `README.md` | User-facing overview and quick start |
 | `CONTRIBUTING.md` | This file — contributor guidelines |
+| `CODE_OF_CONDUCT.md` | Contributor Covenant code of conduct |
 | `STYLE.md` | Style conventions for Rust, YAML, JSON, TOML, Python, Markdown |
 | `SECURITY.md` | Security policy and vulnerability reporting (root) |
 | `docs/SECURITY.md` | Technical threat model and security controls |

--- a/README.md
+++ b/README.md
@@ -344,11 +344,14 @@ Get a Python helper script for processing results (decoding base64, extracting t
 
 #### Git CLI
 
-The server invokes `git` for two operations: `git credential fill` (to read your stored
-credentials via the OS credential helper — see `src/git2_ops/auth.rs`) and `git fetch` from a
-bundle file (to apply a `repo_push` payload before the authenticated push — see
-`src/git2_ops/push.rs`). Any reasonably modern git (2.x) on `PATH` works; bundles produced by
-git ≥ 2.53 (with the `# v3 git bundle` header) are also accepted.
+Most of the server's Git operations (clone, push, pull, diff, refs) authenticate in-process
+via libgit2's credential callbacks and never shell out to `git` (see `src/git2_ops/auth.rs`).
+The `git` CLI is required nonetheless, because the server invokes it for two narrower tasks:
+`git credential fill` (to read your stored credentials via the OS credential helper, used for
+Git LFS object downloads) and `git fetch` from a bundle file (to apply a `repo_push` payload
+before the authenticated push — see `src/git2_ops/push.rs`). Any reasonably modern git (2.x)
+on `PATH` works; bundles produced by git ≥ 2.53 (with the `# v3 git bundle` header) are also
+accepted.
 
 #### Git authentication
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ For SSH, ensure your key is in ssh-agent:
 ```bash
 eval "$(ssh-agent -s)"
 ssh-add ~/.ssh/id_ed25519
+
+# macOS: also cache the key's passphrase in the Keychain
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
 ```
 
 ### Usage with Claude Desktop

--- a/README.md
+++ b/README.md
@@ -481,8 +481,10 @@ The configuration is validated when it loads; an invalid value aborts startup
 with a `configuration validation failed: …` message naming the offending field.
 The checks reject only values that would render a subsystem unusable: a zero
 `timeouts.request_timeout_secs` or any of the `lfs.*_timeout_secs` (every request
-would time out immediately), `rate_limits.max_burst` of `0` (every operation
-blocked forever), a non-finite or negative `rate_limits.refill_rate_per_sec`
+would time out immediately), a zero `limits.max_output_bytes` (every command's
+output would be truncated to nothing), `rate_limits.max_burst` of `0` (every
+operation blocked forever), a non-finite or negative
+`rate_limits.refill_rate_per_sec`
 (`0.0` is allowed — it means "burst once, never refill"), a zero
 `sessions.timeout_secs` / `sessions.max_streaming_sessions` /
 `sessions.max_repo_sessions`, and a `logging.level` outside

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 Copyright (C) 2026 Matej Gomboc <https://github.com/MatejGomboc/git-proxy-mcp>.
 
-GNU General Public License v3.0 — see [LICENCE](LICENCE).
+GNU General Public License v3.0 or later — see [LICENCE](LICENCE).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -345,10 +345,10 @@ Get a Python helper script for processing results (decoding base64, extracting t
 #### Git CLI
 
 The server invokes `git` for two operations: `git credential fill` (to read your stored
-credentials via the OS credential helper — see `src/git2_ops/auth.rs`) and `git bundle unbundle`
-(to apply a `repo_push` payload before the authenticated push — see `src/git2_ops/push.rs`).
-Any reasonably modern git (2.x) on `PATH` works; bundles produced by git ≥ 2.53 (with the
-`# v3 git bundle` header) are also accepted.
+credentials via the OS credential helper — see `src/git2_ops/auth.rs`) and `git fetch` from a
+bundle file (to apply a `repo_push` payload before the authenticated push — see
+`src/git2_ops/push.rs`). Any reasonably modern git (2.x) on `PATH` works; bundles produced by
+git ≥ 2.53 (with the `# v3 git bundle` header) are also accepted.
 
 #### Git authentication
 

--- a/README.md
+++ b/README.md
@@ -482,8 +482,8 @@ with a `configuration validation failed: …` message naming the offending field
 The checks reject only values that would render a subsystem unusable: a zero
 `timeouts.request_timeout_secs` or any of the `lfs.*_timeout_secs` (every request
 would time out immediately), a zero `limits.max_output_bytes` (every command's
-output would be truncated to nothing), `rate_limits.max_burst` of `0` (every
-operation blocked forever), a non-finite or negative
+combined stdout+stderr would be truncated to nothing), `rate_limits.max_burst`
+of `0` (every operation blocked forever), a non-finite or negative
 `rate_limits.refill_rate_per_sec`
 (`0.0` is allowed — it means "burst once, never refill"), a zero
 `sessions.timeout_secs` / `sessions.max_streaming_sessions` /

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,30 +78,10 @@ Given our focus on credential security, we consider these especially critical:
 
 ### Git Configuration
 
-The MCP server uses your existing Git setup. Ensure your credentials are stored securely:
-
-**For HTTPS (PATs):**
-
-```bash
-# macOS - use Keychain
-git config --global credential.helper osxkeychain
-
-# Windows - use Credential Manager
-git config --global credential.helper manager
-
-# Linux - use libsecret or cache
-git config --global credential.helper libsecret
-```
-
-**For SSH:**
-
-```bash
-# Add key to ssh-agent (prompted for passphrase once)
-ssh-add ~/.ssh/id_ed25519
-
-# macOS: store passphrase in Keychain
-ssh-add --apple-use-keychain ~/.ssh/id_ed25519
-```
+The MCP server uses your existing Git setup, so your credentials must be stored
+securely — with an OS credential helper for HTTPS (PATs) or ssh-agent for SSH.
+The README's [Git authentication](README.md#git-authentication) section has the
+exact per-platform setup commands.
 
 ### Credential Recommendations
 

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -26,7 +26,7 @@ This document explains how an AI assistant uses git-proxy-mcp to work with priva
 │  3. PUSH                                                                    │
 │     AI creates: git bundle create changes.bundle main..HEAD               │
 │     AI calls: repo_push { url: "...", branch: "feature/fix-bug", bundle } │
-│     Receives: { success: true, url: "https://github.com/.../commit/..." } │
+│     Receives: { branch, commit, force, remote_url, hint }                 │
 │                                                                             │
 │  4. ITERATE (if needed)                                                     │
 │     Make more changes locally                                              │

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,7 +125,7 @@ repo.checkout_head(...)?;                  // Would write files!
 | Bundle file | Temp only | For unbundle operation |
 | Credentials | **NO** | System helpers only |
 | Tar archive (Tier 1) | **NO** | Built in memory |
-| Tar archive (Tier 2) | Temp only when ≥ 10 MiB | Disk-backed via `NamedTempFile`; deleted when session ends or expires |
+| Tar archive (Tier 2) | Temp only when larger than 10 MiB | Disk-backed via `NamedTempFile`; deleted when session ends or expires |
 
 ### Temp Directory Contents
 
@@ -232,6 +232,7 @@ src/
 ├── main.rs                      # CLI entry point
 ├── error.rs                     # Top-level error types
 ├── session.rs                   # Session tracking (no files!)
+├── util.rs                      # Shared helpers (sanitise_for_log)
 │
 ├── config/                      # Configuration
 │   ├── mod.rs                   # Module exports

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -94,7 +94,7 @@ fn clone_and_stream(url: &str) -> Result<Archive> {
 - Source files NEVER written to user's disk
 - Only git pack files in temp (compressed, deduplicated objects)
 - No risk of leftover files after disconnect
-- Temp directory permissions are 0700 (owner only)
+- Temp directories use the `tempfile` crate's owner-only default (0700 on Unix; the user's profile ACL on Windows)
 
 ### 3. Audit Trail Without Secrets
 
@@ -206,20 +206,26 @@ if !limiter.try_acquire() {
 
 The actual implementation lives at `src/git2_ops/auth.rs::sanitize_url_for_logging`
 and uses byte-safe `find` operations rather than a regex (the project has no
-regex dependency). The behaviour is: if the URL contains both `://` and `@`,
-everything between the scheme and the `@` is replaced with `***`.
+regex dependency). Per RFC 3986 it scans only the URL's authority component
+(between `://` and the first `/`, `?`, or `#`) for the userinfo `@`; if one is
+found, everything between the scheme and that `@` is replaced with `***`. An `@`
+in the path, query, or fragment is left untouched, and SSH-style URLs without
+`://` are returned unchanged.
 
 ```rust
-/// Remove credentials from URLs before logging.
+/// Remove credentials from URLs before logging. Only the authority
+/// (between `://` and the first `/`, `?`, or `#`) is scanned for `@`,
+/// so an `@` in the path or query is preserved (RFC 3986).
 pub fn sanitize_url_for_logging(url: &str) -> String {
-    if let Some(at_pos) = url.find('@') {
-        if let Some(scheme_end) = url.find("://") {
-            let scheme = &url[..scheme_end + 3];
-            let after_at = &url[at_pos + 1..];
-            return format!("{scheme}***@{after_at}");
-        }
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string(); // SSH-style / non-URL: nothing to strip
+    };
+    let after_scheme = &url[scheme_end + 3..];
+    let authority_end = after_scheme.find(['/', '?', '#']).unwrap_or(after_scheme.len());
+    match after_scheme[..authority_end].rfind('@') {
+        Some(at) => format!("{}***@{}", &url[..scheme_end + 3], &after_scheme[at + 1..]),
+        None => url.to_string(),
     }
-    url.to_string()
 }
 ```
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -248,4 +248,4 @@ per-platform setup commands.
 
 ---
 
-*Last updated: 2026-05-01*
+*Last updated: 2026-05-29*

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -98,6 +98,7 @@ accepted as-is.
 | Field(s) | Rule | Why |
 |----------|------|-----|
 | `timeouts.request_timeout_secs`, `lfs.request_timeout_secs`, `lfs.connect_timeout_secs`, `lfs.download_timeout_secs` | must be > 0 | a zero `Duration` makes every request time out immediately |
+| `limits.max_output_bytes` | must be > 0 | a zero limit would truncate every command's combined stdout+stderr to nothing |
 | `rate_limits.max_burst` | must be > 0 | the token bucket would never hand out a token, blocking every operation |
 | `rate_limits.refill_rate_per_sec` | finite and ≥ 0 | `NaN` panics in `time_until_available`; `±∞`/negatives break the token-bucket maths; `0.0` is allowed ("burst once, never refill") |
 | `sessions.timeout_secs`, `sessions.max_streaming_sessions`, `sessions.max_repo_sessions` | must be > 0 | sessions would expire instantly or never be creatable |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -241,34 +241,10 @@ git ls-remote https://github.com/your-private-repo.git
 git ls-remote git@github.com:your-private-repo.git
 ```
 
-If prompted for credentials, configure a credential helper or SSH agent.
-
-### Credential Helper Setup
-
-Configure a credential helper to store your credentials:
-
-```bash
-# macOS
-git config --global credential.helper osxkeychain
-
-# Windows
-git config --global credential.helper manager
-
-# Linux
-git config --global credential.helper libsecret
-```
-
-### SSH Agent Setup
-
-For SSH authentication, ensure your SSH agent is running and has your key loaded:
-
-```bash
-# Start the agent (if not running)
-eval "$(ssh-agent -s)"
-
-# Add your key
-ssh-add ~/.ssh/id_ed25519
-```
+If prompted for credentials, you need to configure an OS credential helper
+(HTTPS) or load your key into ssh-agent (SSH). See the README's
+[Git authentication](../README.md#git-authentication) section for the
+per-platform setup commands.
 
 ---
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -91,6 +91,8 @@ impl Config {
     /// - zero timeouts (`timeouts.request_timeout_secs` and the three
     ///   `lfs.*_timeout_secs`) — a `Duration` of zero makes every request fail
     ///   immediately;
+    /// - a zero `limits.max_output_bytes` — every command's combined
+    ///   stdout+stderr would then be truncated to nothing;
     /// - `rate_limits.max_burst` of zero — the token bucket can then never hand
     ///   out a token, blocking every operation forever;
     /// - a non-finite or negative `rate_limits.refill_rate_per_sec` — such a


### PR DESCRIPTION
## Description

A consistency audit of **every Markdown file** in the repo (and the rustdoc it references), cross-referenced against canonical sources — `src/config/settings.rs` for config, the tool structs in `src/mcp/tools/` for MCP tools, and the rest of `src/` for prose claims — per `STYLE.md`'s Single Source of Truth table. **Documentation only; no behaviour change.**

**Accuracy fixes (doc said X, code does Y)**

- **README "Git CLI" prerequisite was inaccurate.** It said the server runs `git bundle unbundle`; it actually runs `git fetch` from a bundle file (`git2_ops::push::unbundle`, `src/git2_ops/push.rs`). Corrected — and clarified that primary auth (clone/push/pull/diff/refs) is in-process via libgit2 credential callbacks; the `git` CLI is invoked only for LFS credential lookup and applying push bundles.
- **`docs/SECURITY.md`'s `sanitize_url_for_logging` snippet was stale.** It showed the old "first `@` anywhere" logic; the real function is authority-scoped per RFC 3986 (`src/git2_ops/auth.rs`). Snippet + prose updated. The adjacent "temp dir is 0700" claim was qualified — the code sets no explicit mode, relying on `tempfile`'s default (0700 on Unix; user-profile ACL on Windows).
- **`limits.max_output_bytes` validation was undocumented** in the `validate()` rustdoc, the README "Validation" prose, and the `docs/errors.md` table. All three now describe it, using the established term "combined stdout+stderr".
- **`docs/AI_WORKFLOW.md` workflow diagram showed a `repo_push` response the server never returns** (`{ success, url }`); replaced with the real `RepoPushResult` fields (`branch`, `commit`, `force`, `remote_url`, `hint`).

**Single Source of Truth**

- **Consolidated the duplicated credential-setup commands.** The `git config --global credential.helper …` / ssh-agent blocks were repeated in README, `SECURITY.md`, and `docs/errors.md`. README "Git authentication" is now canonical (and absorbs `SECURITY.md`'s macOS Keychain tip); the other two cross-reference it, each keeping its unique content. (The `docs/SECURITY.md` architecture-diagram mention of the OS helpers is a mechanism explanation, not setup, so it stays.)

**Structure & hygiene**

- Added the missing `src/util.rs` to the source-tree diagrams in `docs/ARCHITECTURE.md` and `.claude/CLAUDE.md`.
- Added a `CODE_OF_CONDUCT.md` row to `CONTRIBUTING.md`'s "Types of Documentation" table.
- Tightened `docs/ARCHITECTURE.md`'s Tier 2 disk-threshold wording ("≥ 10 MiB" → "larger than 10 MiB"; the code uses a strict `>`).
- Aligned the README licence statement with `Cargo.toml`'s SPDX (`GPL-3.0-or-later`): "v3.0" → "v3.0 or later".
- Dropped the removed `lfs.max_total_size` from an `[Unreleased]` CHANGELOG entry; reconciled the `[Unreleased]` "Git CLI" entry with the `git fetch` correction; refreshed `docs/errors.md`'s "Last updated" date.

**Verified consistent, no change needed:** all 27 config fields (presence/defaults/units/validation across `settings.rs` ↔ `config/example-config.json` ↔ README ↔ `errors.md`); all 10 MCP tools (names, count, arguments, response fields, hint strings); every quoted error-message string in `docs/errors.md`; CONTRIBUTING toolchain pins (1.95.0 / 1.75), CI commands, and codecov targets; `STYLE.md` ↔ `.editorconfig` values; the binary name, `LICENCE` file, and config paths.

## Related Issue

N/A — proactive documentation audit, no tracking issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

## Security Checklist ⚠️

Documentation-only change; no credential-handling code touched.

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted (see `src/git2_ops/auth.rs`)
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix/feature works — N/A, documentation-only (no doctests in the edited rustdoc)
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] Documentation is updated if needed
- [x] CHANGELOG.md is updated for user-facing changes

## Screenshots / Logs

N/A — documentation-only change.

## Additional Notes

Method: four read-only sub-agents cross-referenced the MD files against the source in parallel (config, MCP tools, error reference, architecture/security/process docs); every flagged item was verified against the code before editing. Self-reviewed afterwards, which caught a contradictory `[Unreleased]` CHANGELOG entry (now reconciled). All CI gates run locally and green: `markdownlint-cli2` (0 errors, 14 files), `cargo fmt --all --check`, clippy `-D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, the toolchain-pin check, and `cargo test` (incl. doctests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)