### PR TITLE
fix(session): only enforce max_sessions for new sessions + 100% coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`session` module coverage.** The session-tracking module's least-covered
+  paths had no unit tests: `RepoSession::age`, `SessionManager::default`, the
+  at-capacity eviction-then-`TooManySessions` path in `create_session`, the
+  expired-session removal in `get_session`, the public `cleanup_expired` method
+  (and the `retain` body of `cleanup_expired_internal`), and the `Display` impl
+  for every `SessionError` variant. Added unit tests covering each, plus a
+  `tracing`-capture test that asserts the `create_session` `info!` log uses the
+  *sanitised* URL and never emits an embedded credential. `session.rs` line
+  coverage rose from 78.44 % to 100 %.
 - **`mcp::transport` line-framing coverage.** The read/write paths were only
   exercised by the Python integration suite because stdin/stdout were hardcoded.
   Following the testability refactor, new unit tests cover LF / CRLF / EOF /
@@ -553,6 +562,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`SessionManager::create_session` wrongly rejected in-place updates at
+  capacity.** The `max_sessions` check (`sessions.len() >= self.max_sessions`)
+  ran before recognising that re-creating a session with the same URL and
+  branch is an *overwrite* that does not grow the map. So once the session
+  table was full, re-cloning a repository that already had a session returned
+  `TooManySessions` instead of refreshing it in place. The capacity limit (and
+  the expired-session eviction it triggers) is now applied only when the session
+  key is genuinely new; an overwrite always succeeds. Regression-tested by
+  `recreating_existing_session_at_capacity_succeeds`.
 - **README licence statement now matches the SPDX expression.** The Licence
   section read "GNU General Public License v3.0" while `Cargo.toml`'s `license`
   field is `GPL-3.0-or-later`; the README now reads "v3.0 or later" so the two

--- a/src/session.rs
+++ b/src/session.rs
@@ -123,9 +123,16 @@ impl SessionManager {
 
     /// Create or update a session after a clone operation.
     ///
+    /// Updating an existing session (same URL and branch) overwrites it in
+    /// place and is never rejected for capacity, because it does not grow the
+    /// session map. Only a genuinely new session is subject to the
+    /// `max_sessions` limit.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the session limit is reached and cleanup fails.
+    /// Returns [`SessionError::TooManySessions`] if a *new* session would
+    /// exceed `max_sessions` and no expired sessions could be evicted to make
+    /// room, or [`SessionError::LockPoisoned`] if the session lock is poisoned.
     #[allow(clippy::significant_drop_tightening)]
     pub fn create_session(
         &self,
@@ -140,8 +147,12 @@ impl SessionManager {
             .write()
             .map_err(|_| SessionError::LockPoisoned)?;
 
-        // Clean up expired sessions if we're at capacity
-        if sessions.len() >= self.max_sessions {
+        // Enforce the capacity limit only when inserting a *new* session.
+        // Re-creating a session that already exists (same URL + branch)
+        // overwrites it in place and does not grow the map, so it must not be
+        // rejected just because we are at capacity.
+        if !sessions.contains_key(&session_id) && sessions.len() >= self.max_sessions {
+            // Try to make room by evicting expired sessions first.
             self.cleanup_expired_internal(&mut sessions);
 
             // Still at capacity after cleanup?
@@ -420,5 +431,216 @@ mod tests {
 
         let result = manager.update_session_commit("nonexistent", "abc123");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn repo_session_age_advances() {
+        // Coverage gap fix: `RepoSession::age()` had no caller in any test.
+        let session = RepoSession::new(
+            "https://github.com/owner/repo.git".to_string(),
+            "main".to_string(),
+            "abc123".to_string(),
+        );
+
+        let first = session.age();
+        std::thread::sleep(Duration::from_millis(5));
+        let second = session.age();
+
+        // Age is measured from creation, so it only ever grows.
+        assert!(second >= first);
+        assert!(second >= Duration::from_millis(5));
+    }
+
+    #[test]
+    fn default_manager_is_empty_and_usable() {
+        // Coverage gap fix: `SessionManager::default()` was never constructed.
+        let manager = SessionManager::default();
+        assert_eq!(manager.session_count().unwrap(), 0);
+
+        // The default (1 hour / 100 sessions) manager still works.
+        let id = manager
+            .create_session("https://github.com/owner/repo.git", "main", "abc123")
+            .unwrap();
+        assert!(manager.get_session(&id).unwrap().is_some());
+    }
+
+    #[test]
+    fn create_session_evicts_expired_to_make_room() {
+        // At capacity, expired sessions are evicted so a new session fits.
+        let manager = SessionManager::new(Duration::from_millis(1), 1);
+        manager
+            .create_session("https://github.com/owner/a.git", "main", "abc123")
+            .unwrap();
+
+        std::thread::sleep(Duration::from_millis(10));
+
+        // Capacity is 1 and we hold 1 (now-expired) session; the new session
+        // must succeed because cleanup evicts the expired one first.
+        let id = manager
+            .create_session("https://github.com/owner/b.git", "main", "def456")
+            .unwrap();
+        assert!(manager.get_session(&id).unwrap().is_some());
+        assert_eq!(manager.session_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn create_session_rejects_when_full_of_live_sessions() {
+        // At capacity with only live sessions, a new session is rejected.
+        let manager = SessionManager::new(Duration::from_secs(3600), 1);
+        manager
+            .create_session("https://github.com/owner/a.git", "main", "abc123")
+            .unwrap();
+
+        let result = manager.create_session("https://github.com/owner/b.git", "main", "def456");
+        assert!(
+            matches!(result, Err(SessionError::TooManySessions { max }) if max == 1),
+            "expected TooManySessions {{ max: 1 }}, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn recreating_existing_session_at_capacity_succeeds() {
+        // Regression test: re-creating an *existing* session (same URL +
+        // branch) overwrites in place and must not be rejected for capacity,
+        // even when the manager is otherwise full. Previously the capacity
+        // check ran before the overwrite was recognised, so this returned
+        // `TooManySessions`.
+        let manager = SessionManager::new(Duration::from_secs(3600), 1);
+        let id = manager
+            .create_session("https://github.com/owner/a.git", "main", "abc123")
+            .unwrap();
+
+        // Same URL + branch -> same session ID -> in-place overwrite.
+        let id_again = manager
+            .create_session("https://github.com/owner/a.git", "main", "def456")
+            .expect("re-creating an existing session at capacity must succeed");
+
+        assert_eq!(id, id_again);
+        assert_eq!(manager.session_count().unwrap(), 1);
+        let session = manager.get_session(&id).unwrap().unwrap();
+        assert_eq!(session.last_commit, "def456");
+    }
+
+    #[test]
+    fn get_session_removes_and_returns_none_when_expired() {
+        // An expired session is dropped (and removed) on access.
+        let manager = SessionManager::new(Duration::from_millis(1), 100);
+        let id = manager
+            .create_session("https://github.com/owner/repo.git", "main", "abc123")
+            .unwrap();
+
+        std::thread::sleep(Duration::from_millis(10));
+
+        assert!(manager.get_session(&id).unwrap().is_none());
+        // The expired session was removed, not merely hidden.
+        assert_eq!(manager.session_count().unwrap(), 0);
+    }
+
+    #[test]
+    fn cleanup_expired_removes_expired_and_reports_count() {
+        // Coverage gap fix: the public `cleanup_expired` method and the
+        // `retain`/`info!` body of `cleanup_expired_internal` were untested.
+        let manager = SessionManager::new(Duration::from_millis(1), 100);
+        manager
+            .create_session("https://github.com/owner/a.git", "main", "abc123")
+            .unwrap();
+        manager
+            .create_session("https://github.com/owner/b.git", "main", "def456")
+            .unwrap();
+
+        std::thread::sleep(Duration::from_millis(10));
+
+        let removed = manager.cleanup_expired().unwrap();
+        assert_eq!(removed, 2);
+        assert_eq!(manager.session_count().unwrap(), 0);
+
+        // Idempotent: nothing left to remove.
+        assert_eq!(manager.cleanup_expired().unwrap(), 0);
+    }
+
+    #[test]
+    fn cleanup_expired_keeps_live_sessions() {
+        // The retain "keep" arm: a live session survives cleanup.
+        let manager = SessionManager::new(Duration::from_secs(3600), 100);
+        manager
+            .create_session("https://github.com/owner/repo.git", "main", "abc123")
+            .unwrap();
+
+        assert_eq!(manager.cleanup_expired().unwrap(), 0);
+        assert_eq!(manager.session_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn session_error_display_messages() {
+        // Coverage gap fix: the `Display` impl for every `SessionError`
+        // variant was uncovered.
+        assert_eq!(
+            SessionError::LockPoisoned.to_string(),
+            "session lock poisoned"
+        );
+        assert_eq!(
+            SessionError::NotFound("abc@main".to_string()).to_string(),
+            "session not found: abc@main"
+        );
+        assert_eq!(
+            SessionError::TooManySessions { max: 7 }.to_string(),
+            "too many active sessions (max 7), try again later"
+        );
+    }
+
+    /// Minimal [`std::io::Write`] that appends to a shared buffer so a test
+    /// can capture `tracing` output and assert on it.
+    #[derive(Clone)]
+    struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn create_session_log_uses_sanitised_url() {
+        // The `info!` in `create_session` formats the session's *sanitised*
+        // URL via `RepoSession::sanitized_url()`. That call is only evaluated
+        // when an INFO-level subscriber is active, so install a capturing
+        // subscriber and assert the embedded credential never reaches the log.
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = buffer.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(move || CaptureWriter(sink.clone()))
+            .finish();
+
+        let manager = SessionManager::new(Duration::from_secs(3600), 100);
+        tracing::subscriber::with_default(subscriber, || {
+            manager
+                .create_session(
+                    "https://user:s3cr3t@github.com/owner/repo.git",
+                    "main",
+                    "abc123",
+                )
+                .unwrap();
+        });
+
+        let logged = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+        assert!(logged.contains("session created"), "log was: {logged}");
+        assert!(
+            !logged.contains("s3cr3t"),
+            "credential leaked into log: {logged}"
+        );
+        assert!(logged.contains("github.com"));
+
+        // The fmt layer is line-buffered and may never call the writer's
+        // `flush`, so exercise it directly to confirm it is a clean no-op.
+        std::io::Write::flush(&mut CaptureWriter(buffer)).unwrap();
     }
 }


### PR DESCRIPTION
## Description

Stage 1 of the coverage-to-100% + bug-hunt sweep. Targets `src/session.rs`
(the repo-session tracker), which was the lowest-covered un-audited module at
**78.44% lines**. This PR fixes one real bug uncovered while reading the file
and closes every reachable unit-coverage gap.

### The bug

`SessionManager::create_session` checked `sessions.len() >= self.max_sessions`
*before* recognising that re-creating a session with the same URL and branch is
an in-place overwrite that does not grow the map. So once the session table was
full, re-cloning a repository that already had a session returned
`TooManySessions` instead of refreshing it. The capacity check (and the
expired-session eviction it triggers) is now gated on the session key being
genuinely new; an in-place overwrite always succeeds.

### Coverage

Added unit tests for the previously-untested paths: `RepoSession::age`,
`SessionManager::default`, the at-capacity eviction-then-`TooManySessions`
path, the expired-session removal in `get_session`, `cleanup_expired` (+ the
`retain` body of `cleanup_expired_internal`, both the kept and removed arms),
and the `Display` impl for all three `SessionError` variants. Plus a
`tracing`-capture test that installs an INFO subscriber and asserts the
`create_session` log uses the **sanitised** URL — i.e. an embedded credential
never reaches the log. `session.rs` line coverage **78.44% -> 100%**
(functions 100%; the 7 residual sub-line *regions* are `assert!`/`matches!`
false-arms that cannot fire while the tests pass).

## Related Issue

N/A — proactive coverage + bug-hunt sweep.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes) — test additions

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages (new test asserts this)
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test --all-features --workspace` — 711 lib tests pass)

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` (`RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`)
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Fixed + Added)

## Commit Map

- `fix(session): only enforce max_sessions limit for new sessions` — the capacity-vs-overwrite fix, its regression test, the full coverage test set, the `create_session` rustdoc clarification, and both CHANGELOG entries.

## Findings That Are NOT in This PR

- The 7 residual uncovered *regions* in `session.rs` are sub-line branches inside test-only `assert!`/`matches!` macros (the false arms), which only execute on test failure. Not worth forcing.
- `RepoSession::age` uses `created_at` while `is_expired`/`cleanup` use `last_accessed` (idle time). This is intentional (age vs. inactivity) and unchanged.