### PR TITLE
refactor(tools): unit-testable clone handlers + de-dup, 73-81% → 98-100% coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Clone-tool handlers refactored for unit-testability and de-duplicated**
+  (no behaviour change). `handle_repo_clone` and `handle_repo_clone_start` each
+  had their entire post-fetch body — LFS credential retrieval, submodule-config
+  merge, in-memory tar creation, result assembly — reachable only through a
+  real network fetch, so it was exercised only by the Python integration suite.
+  That logic is now a private `build_clone_result` / `build_clone_start_result`
+  helper that unit tests drive against a locally-created bare repo (via the
+  existing test-only `FetchResult::from_parts_for_test`);
+  `handle_repo_clone_start`'s chunk-size clamping is a testable
+  `resolve_chunk_size` helper; and the per-request submodule include/exclude
+  merge — previously copy-pasted identically into both handlers — is now a
+  shared `SubmoduleConfig::with_request_overrides` method so the two cannot
+  drift. As part of the de-duplication, `repo_clone` now populates
+  `TarOptions.repo_url` only when `resolve_lfs` is enabled, matching
+  `repo_clone_start` (`repo_url` is consumed only on the LFS path, so this is
+  behaviour-neutral). `repo_clone.rs` 80.61 % -> 98.48 %, `repo_clone_chunk.rs`
+  72.73 % -> 100 %, `repo_clone_start.rs` 72.98 % -> 98.44 % line coverage; the
+  residual lines are the outer handlers' one-statement delegation calls,
+  reachable only after a successful network fetch (integration-covered).
 - **Credential-setup docs consolidated to a single source.** The
   `git config --global credential.helper …` (osxkeychain / manager / libsecret)
   and ssh-agent setup commands were duplicated verbatim in three places: the

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -663,6 +663,32 @@ impl Default for SubmoduleConfig {
     }
 }
 
+impl SubmoduleConfig {
+    /// Build an effective config by layering per-request include/exclude glob
+    /// overrides on top of these server defaults.
+    ///
+    /// A per-request override, when present, fully replaces the corresponding
+    /// server-configured pattern list; when absent (`None`) the server default
+    /// is used. The `max_concurrent` and `max_failures` limits always come from
+    /// the server config — they are not per-request overridable.
+    ///
+    /// This is shared by the `repo_clone` and `repo_clone_start` tool handlers
+    /// so the two cannot drift apart.
+    #[must_use]
+    pub fn with_request_overrides(
+        &self,
+        include: Option<Vec<String>>,
+        exclude: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            max_concurrent: self.max_concurrent,
+            max_failures: self.max_failures,
+            include_patterns: include.or_else(|| self.include_patterns.clone()),
+            exclude_patterns: exclude.or_else(|| self.exclude_patterns.clone()),
+        }
+    }
+}
+
 /// Proxy configuration for network connections.
 ///
 /// When configured, all git fetch/push/connect operations and LFS HTTP
@@ -1130,6 +1156,60 @@ mod tests {
         assert_eq!(config.submodules.max_failures, 3);
         assert!(config.submodules.include_patterns.is_none());
         assert!(config.submodules.exclude_patterns.is_none());
+    }
+
+    #[test]
+    fn submodule_with_request_overrides_layers_correctly() {
+        let server = SubmoduleConfig {
+            max_concurrent: 8,
+            max_failures: 5,
+            include_patterns: Some(vec!["server-include/*".to_string()]),
+            exclude_patterns: Some(vec!["server-exclude/*".to_string()]),
+        };
+
+        // Request overrides replace the server lists entirely; the limits are
+        // always preserved from the server config.
+        let overridden = server.with_request_overrides(
+            Some(vec!["req-include/*".to_string()]),
+            Some(vec!["req-exclude/*".to_string()]),
+        );
+        assert_eq!(overridden.max_concurrent, 8);
+        assert_eq!(overridden.max_failures, 5);
+        assert_eq!(
+            overridden.include_patterns,
+            Some(vec!["req-include/*".to_string()])
+        );
+        assert_eq!(
+            overridden.exclude_patterns,
+            Some(vec!["req-exclude/*".to_string()])
+        );
+
+        // Absent request overrides fall back to the server defaults.
+        let fallback = server.with_request_overrides(None, None);
+        assert_eq!(
+            fallback.include_patterns,
+            Some(vec!["server-include/*".to_string()])
+        );
+        assert_eq!(
+            fallback.exclude_patterns,
+            Some(vec!["server-exclude/*".to_string()])
+        );
+
+        // A mix: include overridden, exclude falls back.
+        let mixed = server.with_request_overrides(Some(vec!["only-include/*".to_string()]), None);
+        assert_eq!(
+            mixed.include_patterns,
+            Some(vec!["only-include/*".to_string()])
+        );
+        assert_eq!(
+            mixed.exclude_patterns,
+            Some(vec!["server-exclude/*".to_string()])
+        );
+
+        // With no server defaults and no overrides, both stay None.
+        let empty = SubmoduleConfig::default().with_request_overrides(None, None);
+        assert!(empty.include_patterns.is_none());
+        assert!(empty.exclude_patterns.is_none());
     }
 
     #[test]

--- a/src/mcp/tools/repo_clone.rs
+++ b/src/mcp/tools/repo_clone.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info};
 
 use crate::config::{LfsConfig, ProxyConfig, SubmoduleConfig};
 use crate::git2_ops::auth::{get_credentials_for_url, sanitize_url_for_logging};
-use crate::git2_ops::clone::{fetch_bare, FetchOptions2};
+use crate::git2_ops::clone::{fetch_bare, FetchOptions2, FetchResult};
 use crate::git2_ops::error::Git2Error;
 use crate::mcp::ProgressSender;
 use crate::streaming::tar::{create_tar_from_tree_with_options, encode_base64, TarOptions};
@@ -226,7 +226,6 @@ pub fn handle_repo_clone(
 /// - URL validation fails
 /// - Fetch operation fails (auth, network, etc.)
 /// - Tar creation fails
-#[allow(clippy::too_many_lines)] // Complex setup with many optional features
 pub fn handle_repo_clone_with_progress(
     args: RepoCloneArgs,
     proxy_config: &ProxyConfig,
@@ -238,6 +237,46 @@ pub fn handle_repo_clone_with_progress(
         url = %sanitize_url_for_logging(&args.url),
         branch = ?args.branch,
         "repo_clone tool called"
+    );
+
+    // Fetch into bare repository
+    let fetch_opts = FetchOptions2 {
+        branch: args.branch.clone(),
+        depth: args.depth,
+        progress: progress.clone(),
+        proxy_url: proxy_config.url.clone(),
+    };
+
+    let fetch_result = fetch_bare(&args.url, Some(fetch_opts))?;
+
+    build_clone_result(
+        &fetch_result,
+        args,
+        proxy_config,
+        lfs_config,
+        submodule_config,
+        progress,
+    )
+}
+
+/// Build the [`RepoCloneResult`] from an already-fetched bare repository.
+///
+/// Split out from [`handle_repo_clone_with_progress`] so the post-fetch path
+/// (LFS credential retrieval, submodule-config merge, in-memory tar creation,
+/// base64 encoding and result assembly) can be exercised by unit tests against
+/// a locally-created bare repo, without a real network fetch.
+fn build_clone_result(
+    fetch_result: &FetchResult,
+    args: RepoCloneArgs,
+    proxy_config: &ProxyConfig,
+    lfs_config: &LfsConfig,
+    submodule_config: &SubmoduleConfig,
+    progress: Option<ProgressSender>,
+) -> Result<RepoCloneResult, RepoCloneError> {
+    debug!(
+        commit = %fetch_result.head_commit,
+        branch = %fetch_result.branch,
+        "fetch complete, creating tar"
     );
 
     // Log info about optional features
@@ -253,58 +292,34 @@ pub fn handle_repo_clone_with_progress(
     if let Some(max_size) = args.max_file_size {
         debug!(max_size = max_size, "max file size limit set");
     }
-    if args.resolve_lfs == Some(true) {
-        debug!("LFS resolution enabled");
-    }
     if args.include_submodules == Some(true) {
         debug!("submodule inclusion enabled");
     }
 
-    // Fetch into bare repository
-    let fetch_opts = FetchOptions2 {
-        branch: args.branch.clone(),
-        depth: args.depth,
-        progress: progress.clone(),
-        proxy_url: proxy_config.url.clone(),
-    };
-
-    let fetch_result = fetch_bare(&args.url, Some(fetch_opts))?;
-
-    debug!(
-        commit = %fetch_result.head_commit,
-        branch = %fetch_result.branch,
-        "fetch complete, creating tar"
-    );
-
     // Get LFS credentials from git credential helper if LFS resolution is enabled
     // Credentials are retrieved on-demand from OS credential stores (macOS Keychain,
     // Windows Credential Manager, etc.) and NEVER sent to AI - they stay on user's PC.
-    let lfs_credentials = if args.resolve_lfs == Some(true) {
+    let resolve_lfs = args.resolve_lfs == Some(true);
+    let lfs_credentials = if resolve_lfs {
         debug!("LFS enabled, retrieving credentials from OS credential store");
         get_credentials_for_url(&args.url)
     } else {
         None
     };
 
-    // Build effective submodule config: merge per-request overrides with server defaults
-    let effective_sub_config = SubmoduleConfig {
-        max_concurrent: submodule_config.max_concurrent,
-        max_failures: submodule_config.max_failures,
-        include_patterns: args
-            .submodule_include
-            .or_else(|| submodule_config.include_patterns.clone()),
-        exclude_patterns: args
-            .submodule_exclude
-            .or_else(|| submodule_config.exclude_patterns.clone()),
-    };
+    // Build effective submodule config: merge per-request overrides with server defaults.
+    let effective_sub_config =
+        submodule_config.with_request_overrides(args.submodule_include, args.submodule_exclude);
 
-    // Create tar.gz from tree (in memory), with optional filtering
+    // Create tar.gz from tree (in memory), with optional filtering.
+    // `repo_url` is only consumed when LFS resolution is enabled, so only set
+    // it then (matching `repo_clone_start`).
     let tar_opts = TarOptions {
         sparse_patterns: args.sparse,
         exclude_binary: args.exclude_binary,
         max_file_size: args.max_file_size,
         resolve_lfs: args.resolve_lfs,
-        repo_url: Some(args.url),
+        repo_url: if resolve_lfs { Some(args.url) } else { None },
         lfs_credentials, // From OS credential store, NEVER sent to AI
         include_submodules: args.include_submodules,
         proxy_url: proxy_config.url.clone(),
@@ -350,7 +365,7 @@ pub fn handle_repo_clone_with_progress(
     Ok(RepoCloneResult {
         archive: archive_base64,
         commit: fetch_result.head_commit.to_string(),
-        branch: fetch_result.branch,
+        branch: fetch_result.branch.clone(),
         file_count: tar_result.file_count,
         archive_size: tar_result.data.len(),
         skipped_by_filter: tar_result.skipped_by_filter,
@@ -623,5 +638,183 @@ mod tests {
         assert!(is_zero(&0));
         assert!(!is_zero(&1));
         assert!(!is_zero(&100));
+    }
+
+    /// Run a closure with a DEBUG-level `tracing` subscriber active (output
+    /// discarded), so the `debug!`/`info!` field expressions in the handlers
+    /// are actually evaluated and counted as covered. Without an active
+    /// subscriber, `tracing` skips evaluating the field values entirely.
+    fn run_with_debug_logs<T>(f: impl FnOnce() -> T) -> T {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(std::io::sink)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f)
+    }
+
+    /// Build a `FetchResult` around a locally-created bare repo (no network)
+    /// so the post-fetch `build_clone_result` path can be exercised directly.
+    /// The repo has two files: `README.md` and `src/main.rs`.
+    fn local_fetch_result() -> FetchResult {
+        use git2::Repository;
+        let temp = tempfile::TempDir::new().unwrap();
+        let commit = {
+            let repo = Repository::init_bare(temp.path()).unwrap();
+            let readme = repo.blob(b"# Test Repo\n").unwrap();
+            let main_rs = repo.blob(b"fn main() {}\n").unwrap();
+            let mut tb = repo.treebuilder(None).unwrap();
+            tb.insert("README.md", readme, 0o100_644).unwrap();
+            let src = {
+                let mut sb = repo.treebuilder(None).unwrap();
+                sb.insert("main.rs", main_rs, 0o100_644).unwrap();
+                sb.write().unwrap()
+            };
+            tb.insert("src", src, 0o040_000).unwrap();
+            let tree_oid = tb.write().unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            let tree = repo.find_tree(tree_oid).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "test", &tree, &[])
+                .unwrap()
+        };
+        let repo = Repository::open_bare(temp.path()).unwrap();
+        FetchResult::from_parts_for_test(repo, commit, "main".to_string(), temp)
+    }
+
+    fn clone_args(url: &str) -> RepoCloneArgs {
+        RepoCloneArgs {
+            url: url.to_string(),
+            branch: None,
+            depth: None,
+            sparse: None,
+            exclude_binary: None,
+            max_file_size: None,
+            resolve_lfs: None,
+            include_submodules: None,
+            submodule_depth: None,
+            submodule_include: None,
+            submodule_exclude: None,
+        }
+    }
+
+    #[test]
+    fn build_clone_result_archives_local_repo() {
+        let fetch = local_fetch_result();
+        let expected_commit = fetch.head_commit.to_string();
+        let result = build_clone_result(
+            &fetch,
+            clone_args("https://github.com/owner/repo.git"),
+            &ProxyConfig::default(),
+            &LfsConfig::default(),
+            &SubmoduleConfig::default(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(result.commit, expected_commit);
+        assert_eq!(result.branch, "main");
+        assert_eq!(result.file_count, 2); // README.md + src/main.rs
+        assert!(!result.archive.is_empty());
+        assert!(result.archive_size > 0);
+        assert_eq!(result.skipped_by_filter, 0);
+    }
+
+    #[test]
+    fn build_clone_result_applies_sparse_and_logs_options() {
+        // Exercises the optional-feature debug branches (depth, sparse,
+        // exclude_binary, max_file_size, include_submodules) and the sparse
+        // filter: only `src/main.rs` matches `**/*.rs`, so `README.md` is
+        // counted as skipped.
+        let fetch = local_fetch_result();
+        let mut args = clone_args("https://github.com/owner/repo.git");
+        args.depth = Some(1);
+        args.sparse = Some(vec!["**/*.rs".to_string()]);
+        args.exclude_binary = Some(true);
+        args.max_file_size = Some(1_048_576);
+        args.include_submodules = Some(true);
+        args.submodule_include = Some(vec!["lib/*".to_string()]);
+
+        // Run under a live subscriber so the per-feature `debug!` lines and the
+        // completion `info!` are evaluated.
+        let result = run_with_debug_logs(|| {
+            build_clone_result(
+                &fetch,
+                args,
+                &ProxyConfig::default(),
+                &LfsConfig::default(),
+                &SubmoduleConfig::default(),
+                None,
+            )
+        })
+        .unwrap();
+
+        assert_eq!(result.file_count, 1);
+        assert_eq!(result.skipped_by_filter, 1);
+        assert_eq!(result.submodules_included, 0); // repo has no submodules
+    }
+
+    #[test]
+    fn handle_repo_clone_emits_entry_log_then_fails_on_invalid_url() {
+        // Drives the outer handler under a live subscriber so its entry
+        // `info!` (which formats the sanitised URL) is evaluated; the invalid
+        // URL then fails fast at the fetch with no network access.
+        let result = run_with_debug_logs(|| {
+            handle_repo_clone(
+                clone_args("not-a-url"),
+                &ProxyConfig::default(),
+                &LfsConfig::default(),
+                &SubmoduleConfig::default(),
+            )
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_clone_result_with_lfs_resolution_archives_non_pointer_files() {
+        // Exercises the `resolve_lfs == Some(true)` branch: credentials are
+        // retrieved (gracefully None when no helper is configured — and the
+        // call degrades cleanly if git is absent), `repo_url` is set, and an
+        // LFS client is created. The repo has no LFS pointers, so no network
+        // request is made and the files are archived verbatim.
+        let fetch = local_fetch_result();
+        let mut args = clone_args("https://github.com/owner/repo.git");
+        args.resolve_lfs = Some(true);
+
+        let result = build_clone_result(
+            &fetch,
+            args,
+            &ProxyConfig::default(),
+            &LfsConfig::default(),
+            &SubmoduleConfig::default(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(result.file_count, 2);
+        assert_eq!(result.lfs_resolved, 0);
+        assert_eq!(result.lfs_failed, 0);
+    }
+
+    #[test]
+    fn build_clone_result_propagates_tar_error_for_unknown_commit() {
+        // A `FetchResult` pointing at a commit that does not exist in the repo
+        // makes `create_tar_from_tree_with_options` fail; the error must
+        // propagate as a `RepoCloneError` (covers the `?` error path and the
+        // `Git2Error -> RepoCloneError` conversion).
+        use git2::Repository;
+        let temp = tempfile::TempDir::new().unwrap();
+        Repository::init_bare(temp.path()).unwrap();
+        let repo = Repository::open_bare(temp.path()).unwrap();
+        let bogus = git2::Oid::from_str("dead00000000000000000000000000000000beef").unwrap();
+        let fetch = FetchResult::from_parts_for_test(repo, bogus, "main".to_string(), temp);
+
+        let result = build_clone_result(
+            &fetch,
+            clone_args("https://github.com/owner/repo.git"),
+            &ProxyConfig::default(),
+            &LfsConfig::default(),
+            &SubmoduleConfig::default(),
+            None,
+        );
+        assert!(result.is_err());
     }
 }

--- a/src/mcp/tools/repo_clone_chunk.rs
+++ b/src/mcp/tools/repo_clone_chunk.rs
@@ -332,4 +332,164 @@ mod tests {
         assert!(json.contains("\"is_complete\":true"));
         assert!(json.contains("\"next_missing_chunk\":null"));
     }
+
+    #[test]
+    fn repo_clone_cancel_result_serializes() {
+        let json = serde_json::to_string(&RepoCloneCancelResult { cancelled: true }).unwrap();
+        assert!(json.contains("\"cancelled\":true"));
+    }
+
+    #[test]
+    fn repo_clone_chunk_error_displays_and_converts() {
+        let err = RepoCloneChunkError {
+            message: "boom".to_string(),
+        };
+        assert_eq!(format!("{err}"), "boom");
+
+        // From<StreamingError> is used by the `?` operator in the handlers.
+        let converted: RepoCloneChunkError =
+            StreamingError::SessionNotFound("xyz".to_string()).into();
+        assert!(converted.message.contains("xyz"));
+    }
+
+    /// Run a closure with a DEBUG-level `tracing` subscriber active (output
+    /// discarded), so the `debug!`/`info!` field expressions in the handlers
+    /// are actually evaluated and counted as covered.
+    fn run_with_debug_logs<T>(f: impl FnOnce() -> T) -> T {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(std::io::sink)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f)
+    }
+
+    /// Create an in-memory streaming session and return the manager, its
+    /// session ID, and its total chunk count.
+    fn manager_with_session(
+        data: Vec<u8>,
+        chunk_size: usize,
+    ) -> (StreamingSessionManager, String, usize) {
+        let manager = StreamingSessionManager::default();
+        let info = manager
+            .create_session(
+                "https://github.com/owner/repo.git",
+                "main",
+                "abc123",
+                data,
+                chunk_size,
+            )
+            .unwrap();
+        (manager, info.session_id, info.total_chunks)
+    }
+
+    #[test]
+    fn handle_chunk_returns_data_and_resume_hint() {
+        // Chunk size is clamped to a 1 KiB minimum by the session, so use a
+        // >1 KiB payload to get multiple chunks.
+        let data: Vec<u8> = (0u8..=255).cycle().take(3000).collect();
+        let (manager, id, total) = manager_with_session(data, 1024);
+        assert!(total >= 2);
+
+        // Run under a live subscriber so the completion `info!` field
+        // expressions (including `chunk.data.len()`) are evaluated.
+        let first = run_with_debug_logs(|| {
+            handle_repo_clone_chunk(
+                RepoCloneChunkArgs {
+                    session_id: id.clone(),
+                    chunk_index: 0,
+                },
+                &manager,
+            )
+        })
+        .unwrap();
+        assert_eq!(first.chunk_index, 0);
+        assert_eq!(first.chunk_size, 1024);
+        assert!(!first.is_last);
+        assert_eq!(first.next_missing_chunk, Some(1));
+        assert!(!first.data.is_empty());
+
+        // The final chunk reports is_last and no further missing chunk.
+        let last = handle_repo_clone_chunk(
+            RepoCloneChunkArgs {
+                session_id: id,
+                chunk_index: total - 1,
+            },
+            &manager,
+        )
+        .unwrap();
+        assert!(last.is_last);
+    }
+
+    #[test]
+    fn handle_chunk_errors_for_unknown_session() {
+        let manager = StreamingSessionManager::default();
+        let result = handle_repo_clone_chunk(
+            RepoCloneChunkArgs {
+                session_id: "does-not-exist".to_string(),
+                chunk_index: 0,
+            },
+            &manager,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn handle_status_reports_progress() {
+        let data: Vec<u8> = (0u8..=255).cycle().take(3000).collect();
+        let (manager, id, total) = manager_with_session(data, 1024);
+
+        // Retrieve one chunk so progress is non-zero but incomplete.
+        let _ = handle_repo_clone_chunk(
+            RepoCloneChunkArgs {
+                session_id: id.clone(),
+                chunk_index: 0,
+            },
+            &manager,
+        )
+        .unwrap();
+
+        let status = handle_repo_clone_status(
+            RepoCloneStatusArgs {
+                session_id: id.clone(),
+            },
+            &manager,
+        )
+        .unwrap();
+        assert_eq!(status.session_id, id);
+        assert_eq!(status.total_chunks, total);
+        assert_eq!(status.delivered_chunks, 1);
+        assert!(!status.is_complete);
+        assert!(status.progress_percent > 0.0);
+    }
+
+    #[test]
+    fn handle_status_errors_for_unknown_session() {
+        let manager = StreamingSessionManager::default();
+        let result = handle_repo_clone_status(
+            RepoCloneStatusArgs {
+                session_id: "does-not-exist".to_string(),
+            },
+            &manager,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn handle_cancel_removes_existing_then_reports_missing() {
+        let (manager, id, _) = manager_with_session(vec![1u8; 100], 64);
+
+        let cancelled = handle_repo_clone_cancel(
+            RepoCloneCancelArgs {
+                session_id: id.clone(),
+            },
+            &manager,
+        )
+        .unwrap();
+        assert!(cancelled.cancelled);
+
+        // A second cancel finds nothing — `cancelled` is false, not an error.
+        let again =
+            handle_repo_clone_cancel(RepoCloneCancelArgs { session_id: id }, &manager).unwrap();
+        assert!(!again.cancelled);
+    }
 }

--- a/src/mcp/tools/repo_clone_start.rs
+++ b/src/mcp/tools/repo_clone_start.rs
@@ -36,7 +36,7 @@ use tracing::{debug, info};
 
 use crate::config::{LfsConfig, ProxyConfig, SubmoduleConfig};
 use crate::git2_ops::auth::{get_credentials_for_url, sanitize_url_for_logging};
-use crate::git2_ops::clone::{fetch_bare, FetchOptions2};
+use crate::git2_ops::clone::{fetch_bare, FetchOptions2, FetchResult};
 use crate::git2_ops::error::Git2Error;
 use crate::streaming::chunked::{
     StreamingError, StreamingSessionManager, DEFAULT_CHUNK_SIZE, MAX_CHUNK_SIZE,
@@ -201,6 +201,15 @@ impl From<StreamingError> for RepoCloneStartError {
     }
 }
 
+/// Clamp a requested chunk size to the supported range.
+///
+/// `None` selects [`DEFAULT_CHUNK_SIZE`]; any larger request is capped at
+/// [`MAX_CHUNK_SIZE`]. The lower bound (1 KiB) is enforced later by the
+/// streaming session when the session is created.
+fn resolve_chunk_size(requested: Option<usize>) -> usize {
+    requested.map_or(DEFAULT_CHUNK_SIZE, |s| s.min(MAX_CHUNK_SIZE))
+}
+
 /// Handle the `repo_clone_start` tool call.
 ///
 /// This function:
@@ -226,7 +235,6 @@ impl From<StreamingError> for RepoCloneStartError {
 /// - Fetch operation fails (auth, network, etc.)
 /// - Tar creation fails
 /// - Session creation fails (too many active sessions)
-#[allow(clippy::too_many_lines)] // Complex setup with many optional features
 pub fn handle_repo_clone_start(
     args: RepoCloneStartArgs,
     proxy_config: &ProxyConfig,
@@ -234,14 +242,57 @@ pub fn handle_repo_clone_start(
     submodule_config: &SubmoduleConfig,
     session_manager: &StreamingSessionManager,
 ) -> Result<RepoCloneStartResult, RepoCloneStartError> {
-    let sanitized_url = sanitize_url_for_logging(&args.url);
-
     info!(
-        url = %sanitized_url,
+        url = %sanitize_url_for_logging(&args.url),
         branch = ?args.branch,
         chunk_size = ?args.chunk_size,
         "repo_clone_start tool called"
     );
+
+    // Fetch into bare repository
+    let fetch_opts = FetchOptions2 {
+        branch: args.branch.clone(),
+        depth: args.depth,
+        progress: None,
+        proxy_url: proxy_config.url.clone(),
+    };
+
+    let fetch_result = fetch_bare(&args.url, Some(fetch_opts))?;
+
+    build_clone_start_result(
+        &fetch_result,
+        args,
+        proxy_config,
+        lfs_config,
+        submodule_config,
+        session_manager,
+    )
+}
+
+/// Build the [`RepoCloneStartResult`] from an already-fetched bare repository.
+///
+/// Split out from [`handle_repo_clone_start`] so the post-fetch path (LFS
+/// credential retrieval, submodule-config merge, in-memory tar creation,
+/// streaming-session creation and result assembly) can be exercised by unit
+/// tests against a locally-created bare repo, without a real network fetch.
+fn build_clone_start_result(
+    fetch_result: &FetchResult,
+    args: RepoCloneStartArgs,
+    proxy_config: &ProxyConfig,
+    lfs_config: &LfsConfig,
+    submodule_config: &SubmoduleConfig,
+    session_manager: &StreamingSessionManager,
+) -> Result<RepoCloneStartResult, RepoCloneStartError> {
+    debug!(
+        commit = %fetch_result.head_commit,
+        branch = %fetch_result.branch,
+        "fetch complete, creating tar"
+    );
+
+    // Sanitise the URL now, before `args.url` may be moved into the tar
+    // options below. The streaming-session key uses this sanitised form so a
+    // credential embedded in the URL is never stored.
+    let sanitized_url = sanitize_url_for_logging(&args.url);
 
     // Log info about optional features
     if let Some(depth) = args.depth {
@@ -256,67 +307,35 @@ pub fn handle_repo_clone_start(
     if let Some(max_size) = args.max_file_size {
         debug!(max_size = max_size, "max file size limit set");
     }
-    if args.resolve_lfs == Some(true) {
-        debug!("LFS resolution enabled");
-    }
     if args.include_submodules == Some(true) {
         debug!("submodule inclusion enabled");
     }
 
-    // Determine chunk size
-    let chunk_size = args
-        .chunk_size
-        .map_or(DEFAULT_CHUNK_SIZE, |s| s.min(MAX_CHUNK_SIZE));
-
-    // Fetch into bare repository
-    let fetch_opts = FetchOptions2 {
-        branch: args.branch.clone(),
-        depth: args.depth,
-        progress: None,
-        proxy_url: proxy_config.url.clone(),
-    };
-
-    let fetch_result = fetch_bare(&args.url, Some(fetch_opts))?;
-
-    debug!(
-        commit = %fetch_result.head_commit,
-        branch = %fetch_result.branch,
-        "fetch complete, creating tar"
-    );
+    let chunk_size = resolve_chunk_size(args.chunk_size);
 
     // Get LFS credentials from git credential helper if LFS resolution is enabled
     // Credentials are retrieved on-demand from OS credential stores (macOS Keychain,
     // Windows Credential Manager, etc.) and NEVER sent to AI - they stay on user's PC.
-    let lfs_credentials = if args.resolve_lfs == Some(true) {
+    let resolve_lfs = args.resolve_lfs == Some(true);
+    let lfs_credentials = if resolve_lfs {
         debug!("LFS enabled, retrieving credentials from OS credential store");
         get_credentials_for_url(&args.url)
     } else {
         None
     };
 
-    // Build effective submodule config: merge per-request overrides with server defaults
-    let effective_sub_config = SubmoduleConfig {
-        max_concurrent: submodule_config.max_concurrent,
-        max_failures: submodule_config.max_failures,
-        include_patterns: args
-            .submodule_include
-            .or_else(|| submodule_config.include_patterns.clone()),
-        exclude_patterns: args
-            .submodule_exclude
-            .or_else(|| submodule_config.exclude_patterns.clone()),
-    };
+    // Build effective submodule config: merge per-request overrides with server defaults.
+    let effective_sub_config =
+        submodule_config.with_request_overrides(args.submodule_include, args.submodule_exclude);
 
-    // Create tar.gz from tree (in memory), with optional filtering
+    // Create tar.gz from tree (in memory), with optional filtering.
+    // `repo_url` is only consumed when LFS resolution is enabled.
     let tar_opts = TarOptions {
         sparse_patterns: args.sparse,
         exclude_binary: args.exclude_binary,
         max_file_size: args.max_file_size,
         resolve_lfs: args.resolve_lfs,
-        repo_url: if args.resolve_lfs == Some(true) {
-            Some(args.url.clone())
-        } else {
-            None
-        },
+        repo_url: if resolve_lfs { Some(args.url) } else { None },
         lfs_credentials, // From OS credential store, NEVER sent to AI
         include_submodules: args.include_submodules,
         proxy_url: proxy_config.url.clone(),
@@ -348,7 +367,7 @@ pub fn handle_repo_clone_start(
         "tar creation complete, creating streaming session"
     );
 
-    // Create streaming session
+    // Create streaming session.
     let session_info = session_manager.create_session(
         &sanitized_url,
         &fetch_result.branch,
@@ -576,5 +595,226 @@ mod tests {
         let submods = SubmoduleConfig::default();
         let manager = StreamingSessionManager::default();
         assert!(handle_repo_clone_start(args, &proxy, &lfs, &submods, &manager).is_err());
+    }
+
+    #[test]
+    fn resolve_chunk_size_clamps_and_defaults() {
+        assert_eq!(resolve_chunk_size(None), DEFAULT_CHUNK_SIZE);
+        assert_eq!(resolve_chunk_size(Some(1024)), 1024);
+        assert_eq!(resolve_chunk_size(Some(MAX_CHUNK_SIZE)), MAX_CHUNK_SIZE);
+        assert_eq!(resolve_chunk_size(Some(MAX_CHUNK_SIZE + 1)), MAX_CHUNK_SIZE);
+        assert_eq!(resolve_chunk_size(Some(usize::MAX)), MAX_CHUNK_SIZE);
+    }
+
+    /// Run a closure with a DEBUG-level `tracing` subscriber active (output
+    /// discarded), so the `debug!`/`info!` field expressions in the handlers
+    /// are actually evaluated and counted as covered.
+    fn run_with_debug_logs<T>(f: impl FnOnce() -> T) -> T {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(std::io::sink)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f)
+    }
+
+    /// Build a `FetchResult` around a locally-created bare repo (no network)
+    /// so the post-fetch `build_clone_start_result` path can be exercised
+    /// directly. The repo has two files: `README.md` and `src/main.rs`.
+    fn local_fetch_result() -> FetchResult {
+        use git2::Repository;
+        let temp = tempfile::TempDir::new().unwrap();
+        let commit = {
+            let repo = Repository::init_bare(temp.path()).unwrap();
+            let readme = repo.blob(b"# Test Repo\n").unwrap();
+            let main_rs = repo.blob(b"fn main() {}\n").unwrap();
+            let mut tb = repo.treebuilder(None).unwrap();
+            tb.insert("README.md", readme, 0o100_644).unwrap();
+            let src = {
+                let mut sb = repo.treebuilder(None).unwrap();
+                sb.insert("main.rs", main_rs, 0o100_644).unwrap();
+                sb.write().unwrap()
+            };
+            tb.insert("src", src, 0o040_000).unwrap();
+            let tree_oid = tb.write().unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            let tree = repo.find_tree(tree_oid).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "test", &tree, &[])
+                .unwrap()
+        };
+        let repo = Repository::open_bare(temp.path()).unwrap();
+        FetchResult::from_parts_for_test(repo, commit, "main".to_string(), temp)
+    }
+
+    fn start_args(url: &str) -> RepoCloneStartArgs {
+        RepoCloneStartArgs {
+            url: url.to_string(),
+            branch: None,
+            depth: None,
+            sparse: None,
+            chunk_size: None,
+            exclude_binary: None,
+            max_file_size: None,
+            resolve_lfs: None,
+            include_submodules: None,
+            submodule_depth: None,
+            submodule_include: None,
+            submodule_exclude: None,
+        }
+    }
+
+    #[test]
+    fn build_clone_start_result_creates_retrievable_session() {
+        let fetch = local_fetch_result();
+        let expected_commit = fetch.head_commit.to_string();
+        let manager = StreamingSessionManager::default();
+
+        let mut args = start_args("https://github.com/owner/repo.git");
+        // Below the 1 KiB minimum; the session clamps it up to 1024.
+        args.chunk_size = Some(64);
+
+        let result = build_clone_start_result(
+            &fetch,
+            args,
+            &ProxyConfig::default(),
+            &LfsConfig::default(),
+            &SubmoduleConfig::default(),
+            &manager,
+        )
+        .unwrap();
+
+        assert_eq!(result.commit, expected_commit);
+        assert_eq!(result.branch, "main");
+        assert_eq!(result.file_count, 2);
+        assert_eq!(result.chunk_size, 1024); // clamped up from 64
+        assert!(result.total_chunks >= 1);
+        assert!(!result.session_id.is_empty());
+
+        // The session is registered and its chunk count matches the result.
+        let status = manager.get_session_status(&result.session_id).unwrap();
+        assert_eq!(status.total_chunks, result.total_chunks);
+        assert!(!status.is_complete);
+    }
+
+    #[test]
+    fn build_clone_start_result_applies_sparse_and_logs_options() {
+        // Exercises the optional-feature debug branches and the sparse filter.
+        let fetch = local_fetch_result();
+        let manager = StreamingSessionManager::default();
+
+        let mut args = start_args("https://github.com/owner/repo.git");
+        args.depth = Some(1);
+        args.sparse = Some(vec!["**/*.rs".to_string()]);
+        args.exclude_binary = Some(true);
+        args.max_file_size = Some(1_048_576);
+        args.include_submodules = Some(true);
+
+        // Run under a live subscriber so the per-feature `debug!` lines and the
+        // completion `info!` are evaluated.
+        let result = run_with_debug_logs(|| {
+            build_clone_start_result(
+                &fetch,
+                args,
+                &ProxyConfig::default(),
+                &LfsConfig::default(),
+                &SubmoduleConfig::default(),
+                &manager,
+            )
+        })
+        .unwrap();
+
+        assert_eq!(result.file_count, 1);
+        assert_eq!(result.skipped_by_filter, 1);
+    }
+
+    #[test]
+    fn build_clone_start_result_with_lfs_resolution() {
+        // Exercises the `resolve_lfs == Some(true)` branch: credentials are
+        // retrieved (gracefully None without a helper / git), `repo_url` is set
+        // and an LFS client is created. The repo has no LFS pointers, so no
+        // network request is made.
+        let fetch = local_fetch_result();
+        let manager = StreamingSessionManager::default();
+        let mut args = start_args("https://github.com/owner/repo.git");
+        args.resolve_lfs = Some(true);
+
+        let result = build_clone_start_result(
+            &fetch,
+            args,
+            &ProxyConfig::default(),
+            &LfsConfig::default(),
+            &SubmoduleConfig::default(),
+            &manager,
+        )
+        .unwrap();
+
+        assert_eq!(result.file_count, 2);
+        assert_eq!(result.lfs_resolved, 0);
+    }
+
+    #[test]
+    fn handle_repo_clone_start_emits_entry_log_then_fails_on_invalid_url() {
+        // Drives the outer handler under a live subscriber so its entry
+        // `info!` is evaluated; the invalid URL fails fast at the fetch.
+        let manager = StreamingSessionManager::default();
+        let result = run_with_debug_logs(|| {
+            handle_repo_clone_start(
+                start_args("not-a-url"),
+                &ProxyConfig::default(),
+                &LfsConfig::default(),
+                &SubmoduleConfig::default(),
+                &manager,
+            )
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn repo_clone_start_error_from_streaming_error() {
+        // The `From<StreamingError>` conversion is used by `?` when session
+        // creation fails (e.g. too many sessions).
+        let err: RepoCloneStartError = StreamingError::TooManySessions { max: 3 }.into();
+        assert!(err.message.contains('3') || !err.message.is_empty());
+    }
+
+    #[test]
+    fn build_clone_start_result_propagates_tar_error_for_unknown_commit() {
+        // A commit that does not exist makes tar creation fail; the error must
+        // propagate (covers the `?` error path before session creation).
+        use git2::Repository;
+        let temp = tempfile::TempDir::new().unwrap();
+        Repository::init_bare(temp.path()).unwrap();
+        let repo = Repository::open_bare(temp.path()).unwrap();
+        let bogus = git2::Oid::from_str("dead00000000000000000000000000000000beef").unwrap();
+        let fetch = FetchResult::from_parts_for_test(repo, bogus, "main".to_string(), temp);
+        let manager = StreamingSessionManager::default();
+
+        let result = build_clone_start_result(
+            &fetch,
+            start_args("https://github.com/owner/repo.git"),
+            &ProxyConfig::default(),
+            &LfsConfig::default(),
+            &SubmoduleConfig::default(),
+            &manager,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_clone_start_result_propagates_session_error_when_full() {
+        // A session manager with zero capacity makes `create_session` fail
+        // after a successful tar build; the `StreamingError` must propagate as
+        // a `RepoCloneStartError` (covers the session-creation `?` path).
+        let fetch = local_fetch_result();
+        let manager = StreamingSessionManager::new(std::time::Duration::from_secs(3600), 0);
+
+        let result = build_clone_start_result(
+            &fetch,
+            start_args("https://github.com/owner/repo.git"),
+            &ProxyConfig::default(),
+            &LfsConfig::default(),
+            &SubmoduleConfig::default(),
+            &manager,
+        );
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Description

Stage 2 of the coverage-to-100% + bug-hunt sweep. Targets the three clone-family
tool handlers (`repo_clone`, `repo_clone_start`, `repo_clone_chunk`), which were
the lowest-covered handlers (72–81% lines) and had **not** been individually
audited. This is a behaviour-neutral testability refactor plus the tests it
enables.

### Bug hunt

No functional bug found, but one copy-paste divergence was confirmed and
removed: `repo_clone` always set `TarOptions.repo_url` while `repo_clone_start`
set it only when `resolve_lfs` was enabled. `repo_url` is consumed **only** on
the LFS path in `streaming::tar` (`if resolve_lfs { if let Some(url) = repo_url`),
so the divergence was behaviour-neutral — but it is exactly the copy-paste class
that has produced real bugs before, so the two are now unified and the shared
logic factored out so they cannot drift again.

### Refactor + coverage

- The post-fetch body of each fetch handler (LFS credential retrieval,
  submodule-config merge, in-memory tar creation, result assembly) was reachable
  only through a real network fetch — covered only by the Python integration
  suite, which doesn't run in the PR coverage job or locally on Windows. It is
  now a private `build_clone_result` / `build_clone_start_result` helper that
  unit tests drive against a locally-created bare repo via the existing test-only
  `FetchResult::from_parts_for_test`.
- Chunk-size clamping → testable `resolve_chunk_size`.
- The duplicated per-request submodule include/exclude merge →
  shared `SubmoduleConfig::with_request_overrides` method.
- The chunk/status/cancel handlers are now covered directly via an in-memory
  session manager (no network), including error paths and the
  `From<StreamingError>` conversions.

| File | Before | After |
|------|-------:|------:|
| `repo_clone.rs` | 80.61% | 98.48% |
| `repo_clone_chunk.rs` | 72.73% | **100%** |
| `repo_clone_start.rs` | 72.98% | 98.44% |
| `config/settings.rs` | 100% | 100% (new method + test) |

## Related Issue

N/A — proactive coverage + bug-hunt sweep (follows #193).

## Type of Change

- [x] Refactoring (no functional changes)

## Security Checklist ⚠️

- [x] No credentials in code, comments, or tests
- [x] No credentials in logs or error messages
- [x] No credentials in MCP responses
- [x] Credentials scoped to their operation (the `resolve_lfs` path still retrieves them on demand from the OS store)
- [x] Error messages don't leak sensitive information
- [x] The streaming-session key still uses the **sanitised** URL (preserved across the refactor)

## Testing

- [x] Tested locally
- [x] Added tests that drive the post-fetch path, filtering, LFS path, error propagation, and the chunk/status/cancel handlers
- [x] `cargo test --all-features --workspace` — 732 lib tests pass

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Changed)

## Commit Map

- `refactor(tools): make clone handlers unit-testable and de-duplicate config merge` — the extraction, the `repo_url` unification, the shared `with_request_overrides`/`resolve_chunk_size`, all new tests, and the CHANGELOG entry.

## Findings That Are NOT in This PR

- The residual ~7 uncovered lines in `repo_clone.rs` / `repo_clone_start.rs` are the outer handlers' single-statement delegation calls to the new `build_*` helpers, reachable only after a successful network fetch. They stay integration-covered.
- `streaming::chunked::StreamingSessionManager::create_session` may have the same "reject in-place overwrite at capacity" issue that #193 fixed in `session::SessionManager`. Deferred to the Stage 7 `chunked.rs` audit rather than widening this PR.