### PR TITLE
refactor(tools): unit-testable push/pull/diff/refs handlers, 86-92% → 99% coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`repo_push` / `repo_pull` / `repo_diff` / `repo_refs` handlers refactored
+  for unit-testability** (no behaviour change). Each had its success path — the
+  completion `info!` and result-struct assembly — reachable only through a real
+  network operation, so it was exercised only by the Python integration suite.
+  That logic is now a private `build_push_result` / `build_pull_result` /
+  `build_diff_result` / `build_refs_result` helper that unit tests drive by
+  constructing the underlying `git2_ops` result type directly (`PushResult`,
+  `PullResult`, `DiffResult`, `RefsResult` — all already had public fields).
+  `repo_pull`'s up-to-date-vs-changed branch is now covered for both arms, and
+  a minimal valid-header bundle lets a unit test drive `repo_push` through to
+  the `push_bundle` invocation. The `run_with_debug_logs` test helper that
+  forces `tracing` field evaluation (previously copy-pasted into three
+  clone-handler test modules) is consolidated into one `#[cfg(test)]` function
+  in `mcp::tools`. Coverage: `repo_push.rs` 85.92 % -> 99.43 %, `repo_pull.rs`
+  89.29 % -> 99.49 %, `repo_diff.rs` 92.08 % -> 99.27 %, `repo_refs.rs`
+  89.25 % -> 99.22 %; the single residual line in each is the success-path
+  delegation call, reachable only after a successful network operation.
 - **Clone-tool handlers refactored for unit-testability and de-duplicated**
   (no behaviour change). `handle_repo_clone` and `handle_repo_clone_start` each
   had their entire post-fetch body — LFS credential retrieval, submodule-config

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -55,3 +55,19 @@ pub use repo_diff::{handle_repo_diff, RepoDiffArgs, RepoDiffResult};
 pub use repo_pull::{handle_repo_pull, RepoPullArgs, RepoPullResult};
 pub use repo_push::{handle_repo_push, RepoPushArgs, RepoPushResult};
 pub use repo_refs::{handle_repo_refs, RepoRefsArgs, RepoRefsResult};
+
+/// Run a closure with a DEBUG-level `tracing` subscriber active (output
+/// discarded), so the `debug!`/`info!` field expressions in the tool handlers
+/// are actually evaluated and counted as covered. Without an active subscriber
+/// `tracing` skips evaluating the field values entirely, leaving them as
+/// phantom-uncovered lines under coverage instrumentation.
+///
+/// Shared by the tool handlers' unit tests.
+#[cfg(test)]
+pub(crate) fn run_with_debug_logs<T>(f: impl FnOnce() -> T) -> T {
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_writer(std::io::sink)
+        .finish();
+    tracing::subscriber::with_default(subscriber, f)
+}

--- a/src/mcp/tools/repo_clone.rs
+++ b/src/mcp/tools/repo_clone.rs
@@ -383,6 +383,7 @@ fn build_clone_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::run_with_debug_logs;
 
     #[test]
     fn repo_clone_args_defaults() {
@@ -638,18 +639,6 @@ mod tests {
         assert!(is_zero(&0));
         assert!(!is_zero(&1));
         assert!(!is_zero(&100));
-    }
-
-    /// Run a closure with a DEBUG-level `tracing` subscriber active (output
-    /// discarded), so the `debug!`/`info!` field expressions in the handlers
-    /// are actually evaluated and counted as covered. Without an active
-    /// subscriber, `tracing` skips evaluating the field values entirely.
-    fn run_with_debug_logs<T>(f: impl FnOnce() -> T) -> T {
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .with_writer(std::io::sink)
-            .finish();
-        tracing::subscriber::with_default(subscriber, f)
     }
 
     /// Build a `FetchResult` around a locally-created bare repo (no network)

--- a/src/mcp/tools/repo_clone_chunk.rs
+++ b/src/mcp/tools/repo_clone_chunk.rs
@@ -242,6 +242,7 @@ pub fn handle_repo_clone_cancel(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::run_with_debug_logs;
 
     #[test]
     fn repo_clone_chunk_args_deserialize() {
@@ -350,17 +351,6 @@ mod tests {
         let converted: RepoCloneChunkError =
             StreamingError::SessionNotFound("xyz".to_string()).into();
         assert!(converted.message.contains("xyz"));
-    }
-
-    /// Run a closure with a DEBUG-level `tracing` subscriber active (output
-    /// discarded), so the `debug!`/`info!` field expressions in the handlers
-    /// are actually evaluated and counted as covered.
-    fn run_with_debug_logs<T>(f: impl FnOnce() -> T) -> T {
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .with_writer(std::io::sink)
-            .finish();
-        tracing::subscriber::with_default(subscriber, f)
     }
 
     /// Create an in-memory streaming session and return the manager, its

--- a/src/mcp/tools/repo_clone_start.rs
+++ b/src/mcp/tools/repo_clone_start.rs
@@ -408,6 +408,7 @@ fn build_clone_start_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::run_with_debug_logs;
 
     #[test]
     fn repo_clone_start_args_defaults() {
@@ -604,17 +605,6 @@ mod tests {
         assert_eq!(resolve_chunk_size(Some(MAX_CHUNK_SIZE)), MAX_CHUNK_SIZE);
         assert_eq!(resolve_chunk_size(Some(MAX_CHUNK_SIZE + 1)), MAX_CHUNK_SIZE);
         assert_eq!(resolve_chunk_size(Some(usize::MAX)), MAX_CHUNK_SIZE);
-    }
-
-    /// Run a closure with a DEBUG-level `tracing` subscriber active (output
-    /// discarded), so the `debug!`/`info!` field expressions in the handlers
-    /// are actually evaluated and counted as covered.
-    fn run_with_debug_logs<T>(f: impl FnOnce() -> T) -> T {
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .with_writer(std::io::sink)
-            .finish();
-        tracing::subscriber::with_default(subscriber, f)
     }
 
     /// Build a `FetchResult` around a locally-created bare repo (no network)

--- a/src/mcp/tools/repo_diff.rs
+++ b/src/mcp/tools/repo_diff.rs
@@ -25,7 +25,7 @@ use tracing::info;
 
 use crate::config::ProxyConfig;
 use crate::git2_ops::auth::sanitize_url_for_logging;
-use crate::git2_ops::diff::{generate_diff, DiffStats};
+use crate::git2_ops::diff::{generate_diff, DiffResult, DiffStats};
 use crate::git2_ops::error::Git2Error;
 
 /// Arguments for the `repo_diff` tool.
@@ -127,6 +127,14 @@ pub fn handle_repo_diff(
         proxy_config.url.as_deref(),
     )?;
 
+    Ok(build_diff_result(diff_result))
+}
+
+/// Assemble the [`RepoDiffResult`] from a completed diff.
+///
+/// Split out from [`handle_repo_diff`] so the success-path logging and result
+/// shaping can be unit-tested without a real network fetch.
+fn build_diff_result(diff_result: DiffResult) -> RepoDiffResult {
     info!(
         files = diff_result.stats.files_changed,
         insertions = diff_result.stats.insertions,
@@ -134,17 +142,18 @@ pub fn handle_repo_diff(
         "repo_diff complete"
     );
 
-    Ok(RepoDiffResult {
+    RepoDiffResult {
         diff: diff_result.diff,
         stats: diff_result.stats,
         base_commit: diff_result.base_commit,
         head_commit: diff_result.head_commit,
-    })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::run_with_debug_logs;
 
     #[test]
     fn repo_diff_args_parses() {
@@ -235,5 +244,41 @@ mod tests {
         };
         let proxy = ProxyConfig::default();
         assert!(handle_repo_diff(args, &proxy).is_err());
+    }
+
+    #[test]
+    fn build_diff_result_maps_fields() {
+        let diff_result = DiffResult {
+            diff: "a unified diff".to_string(),
+            stats: DiffStats {
+                files_changed: 2,
+                insertions: 5,
+                deletions: 3,
+            },
+            base_commit: "abc123".to_string(),
+            head_commit: "def456".to_string(),
+        };
+        let result = run_with_debug_logs(|| build_diff_result(diff_result));
+        assert_eq!(result.diff, "a unified diff");
+        assert_eq!(result.stats.files_changed, 2);
+        assert_eq!(result.stats.insertions, 5);
+        assert_eq!(result.stats.deletions, 3);
+        assert_eq!(result.base_commit, "abc123");
+        assert_eq!(result.head_commit, "def456");
+    }
+
+    #[test]
+    fn handle_repo_diff_emits_entry_log_then_fails_on_invalid_url() {
+        let result = run_with_debug_logs(|| {
+            handle_repo_diff(
+                RepoDiffArgs {
+                    url: "not-a-url".to_string(),
+                    base_commit: "a".to_string(),
+                    head_commit: "b".to_string(),
+                },
+                &ProxyConfig::default(),
+            )
+        });
+        assert!(result.is_err());
     }
 }

--- a/src/mcp/tools/repo_pull.rs
+++ b/src/mcp/tools/repo_pull.rs
@@ -34,7 +34,7 @@ use tracing::info;
 use crate::config::ProxyConfig;
 use crate::git2_ops::auth::sanitize_url_for_logging;
 use crate::git2_ops::error::Git2Error;
-use crate::git2_ops::pull::{pull_changes, ChangedFile, PullStats};
+use crate::git2_ops::pull::{pull_changes, ChangedFile, PullResult, PullStats};
 
 /// Arguments for the `repo_pull` tool.
 #[derive(Debug, Clone, Deserialize)]
@@ -150,6 +150,14 @@ pub fn handle_repo_pull(
         proxy_config.url.as_deref(),
     )?;
 
+    Ok(build_pull_result(pull_result))
+}
+
+/// Assemble the [`RepoPullResult`] from a completed pull.
+///
+/// Split out from [`handle_repo_pull`] so the up-to-date/changed branch
+/// logging and result shaping can be unit-tested without a real network fetch.
+fn build_pull_result(pull_result: PullResult) -> RepoPullResult {
     if pull_result.up_to_date {
         info!("repo_pull: already up to date");
     } else {
@@ -163,7 +171,7 @@ pub fn handle_repo_pull(
         );
     }
 
-    Ok(RepoPullResult {
+    RepoPullResult {
         diff: pull_result.diff,
         files_archive: pull_result.files_archive,
         changed_files: pull_result.changed_files,
@@ -173,12 +181,13 @@ pub fn handle_repo_pull(
         stats: pull_result.stats,
         up_to_date: pull_result.up_to_date,
         hint: "Use helper_script tool to get git_proxy_helper.py, then: python git_proxy_helper.py extract <result.json> <output_dir>".to_string(),
-    })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::run_with_debug_logs;
 
     #[test]
     fn repo_pull_args_parses() {
@@ -307,5 +316,64 @@ mod tests {
         let json = serde_json::to_value(&cf).unwrap();
         assert_eq!(json["path"], "file.rs");
         assert!(json.get("old_path").is_none() || json["old_path"].is_null());
+    }
+
+    #[test]
+    fn build_pull_result_up_to_date_branch() {
+        let pull_result = PullResult {
+            diff: String::new(),
+            files_archive: String::new(),
+            changed_files: vec![],
+            deleted_files: vec![],
+            base_commit: "abc123".to_string(),
+            new_commit: "abc123".to_string(),
+            stats: PullStats::default(),
+            up_to_date: true,
+        };
+        let result = run_with_debug_logs(|| build_pull_result(pull_result));
+        assert!(result.up_to_date);
+        assert_eq!(result.base_commit, "abc123");
+        assert!(result.changed_files.is_empty());
+        assert!(result.hint.contains("extract"));
+    }
+
+    #[test]
+    fn build_pull_result_with_changes_branch() {
+        let pull_result = PullResult {
+            diff: "a diff".to_string(),
+            files_archive: "an archive".to_string(),
+            changed_files: vec![ChangedFile {
+                path: "file.rs".to_string(),
+                change_type: "modified".to_string(),
+                old_path: None,
+            }],
+            deleted_files: vec!["gone.rs".to_string()],
+            base_commit: "abc123".to_string(),
+            new_commit: "def456".to_string(),
+            stats: PullStats::default(),
+            up_to_date: false,
+        };
+        let result = run_with_debug_logs(|| build_pull_result(pull_result));
+        assert!(!result.up_to_date);
+        assert_eq!(result.new_commit, "def456");
+        assert_eq!(result.changed_files.len(), 1);
+        assert_eq!(result.deleted_files, vec!["gone.rs".to_string()]);
+        assert_eq!(result.diff, "a diff");
+        assert_eq!(result.files_archive, "an archive");
+    }
+
+    #[test]
+    fn handle_repo_pull_emits_entry_log_then_fails_on_invalid_url() {
+        let result = run_with_debug_logs(|| {
+            handle_repo_pull(
+                RepoPullArgs {
+                    url: "not-a-url".to_string(),
+                    branch: "main".to_string(),
+                    since_commit: "abc123".to_string(),
+                },
+                &ProxyConfig::default(),
+            )
+        });
+        assert!(result.is_err());
     }
 }

--- a/src/mcp/tools/repo_push.rs
+++ b/src/mcp/tools/repo_push.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info};
 use crate::config::ProxyConfig;
 use crate::git2_ops::auth::sanitize_url_for_logging;
 use crate::git2_ops::error::Git2Error;
-use crate::git2_ops::push::{push_bundle, PushOptions2};
+use crate::git2_ops::push::{push_bundle, PushOptions2, PushResult};
 use crate::streaming::bundle::{decode_bundle, validate_bundle};
 
 /// Arguments for the `repo_push` tool.
@@ -163,24 +163,34 @@ pub fn handle_repo_push(
         proxy_config.url.as_deref(),
     )?;
 
+    Ok(build_push_result(result, args.force, &args.url))
+}
+
+/// Assemble the [`RepoPushResult`] from a completed push.
+///
+/// Split out from [`handle_repo_push`] so the success-path logging and result
+/// shaping can be unit-tested without a real network push.
+fn build_push_result(result: PushResult, force: bool, url: &str) -> RepoPushResult {
     info!(
         commit = %result.commit,
         branch = %result.branch,
         "repo_push complete"
     );
 
-    Ok(RepoPushResult {
+    RepoPushResult {
         branch: result.branch,
         commit: result.commit,
-        force: args.force,
-        remote_url: sanitize_url_for_logging(&args.url),
+        force,
+        remote_url: sanitize_url_for_logging(url),
         hint: "To create a bundle: use helper_script tool, then: python git_proxy_helper.py bundle <repo_dir> <since_commit>".to_string(),
-    })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::run_with_debug_logs;
+    use crate::streaming::tar::encode_base64;
 
     #[test]
     fn repo_push_args_defaults() {
@@ -300,5 +310,43 @@ mod tests {
         };
         let proxy = ProxyConfig::default();
         assert!(handle_repo_push(args, &proxy).is_err());
+    }
+
+    #[test]
+    fn handle_repo_push_reaches_push_with_valid_header_bundle() {
+        // A minimal valid-header bundle passes `validate_bundle`, so the handler
+        // proceeds to build the push options and call `push_bundle`, which then
+        // rejects the invalid URL. This exercises the push-options construction
+        // and the push invocation (the success path beyond is integration-only).
+        let args = RepoPushArgs {
+            bundle: encode_base64(b"# v2 bundle\nnot-a-real-bundle"),
+            url: "not-a-url".to_string(),
+            branch: "main".to_string(),
+            force: false,
+        };
+        let result = run_with_debug_logs(|| handle_repo_push(args, &ProxyConfig::default()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_push_result_maps_fields_and_sanitises_url() {
+        let pushed = PushResult {
+            branch: "feature".to_string(),
+            commit: "abc123".to_string(),
+            remote_url: "https://github.com/owner/repo.git".to_string(),
+        };
+        let result = run_with_debug_logs(|| {
+            build_push_result(
+                pushed,
+                true,
+                "https://user:s3cr3t@github.com/owner/repo.git",
+            )
+        });
+        assert_eq!(result.branch, "feature");
+        assert_eq!(result.commit, "abc123");
+        assert!(result.force);
+        assert!(!result.remote_url.contains("s3cr3t"), "URL not sanitised");
+        assert!(result.remote_url.contains("github.com"));
+        assert!(result.hint.contains("bundle"));
     }
 }

--- a/src/mcp/tools/repo_refs.rs
+++ b/src/mcp/tools/repo_refs.rs
@@ -24,7 +24,7 @@ use tracing::info;
 use crate::config::ProxyConfig;
 use crate::git2_ops::auth::sanitize_url_for_logging;
 use crate::git2_ops::error::Git2Error;
-use crate::git2_ops::refs::{list_remote_refs, RefInfo};
+use crate::git2_ops::refs::{list_remote_refs, RefInfo, RefsResult};
 
 /// Arguments for the `repo_refs` tool.
 #[derive(Debug, Clone, Deserialize)]
@@ -109,6 +109,14 @@ pub fn handle_repo_refs(
 
     let refs_result = list_remote_refs(&args.url, proxy_config.url.as_deref())?;
 
+    Ok(build_refs_result(refs_result))
+}
+
+/// Assemble the [`RepoRefsResult`] from listed remote refs.
+///
+/// Split out from [`handle_repo_refs`] so the success-path logging and result
+/// shaping can be unit-tested without a real network connection.
+fn build_refs_result(refs_result: RefsResult) -> RepoRefsResult {
     info!(
         branches = refs_result.branches.len(),
         tags = refs_result.tags.len(),
@@ -116,17 +124,18 @@ pub fn handle_repo_refs(
         "repo_refs complete"
     );
 
-    Ok(RepoRefsResult {
+    RepoRefsResult {
         branches: refs_result.branches,
         tags: refs_result.tags,
         default_branch: refs_result.default_branch,
         total_refs: refs_result.total_refs,
-    })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::run_with_debug_logs;
 
     #[test]
     fn repo_refs_args_parses() {
@@ -211,6 +220,42 @@ mod tests {
         };
         let proxy = ProxyConfig::default();
         let result = handle_repo_refs(args, &proxy);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_refs_result_maps_fields() {
+        let refs_result = RefsResult {
+            branches: vec![RefInfo {
+                name: "refs/heads/main".to_string(),
+                short_name: "main".to_string(),
+                commit: "abc123".to_string(),
+            }],
+            tags: vec![RefInfo {
+                name: "refs/tags/v1.0.0".to_string(),
+                short_name: "v1.0.0".to_string(),
+                commit: "def456".to_string(),
+            }],
+            default_branch: "main".to_string(),
+            total_refs: 2,
+        };
+        let result = run_with_debug_logs(|| build_refs_result(refs_result));
+        assert_eq!(result.branches.len(), 1);
+        assert_eq!(result.tags.len(), 1);
+        assert_eq!(result.default_branch, "main");
+        assert_eq!(result.total_refs, 2);
+    }
+
+    #[test]
+    fn handle_repo_refs_emits_entry_log_then_fails_on_invalid_url() {
+        let result = run_with_debug_logs(|| {
+            handle_repo_refs(
+                RepoRefsArgs {
+                    url: "not-a-url".to_string(),
+                },
+                &ProxyConfig::default(),
+            )
+        });
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Description

Stage 3 of the coverage-to-100% + bug-hunt sweep. Targets the remaining four
tool handlers (`repo_push`, `repo_pull`, `repo_diff`, `repo_refs`), the last
of the un-individually-audited handlers. Behaviour-neutral testability refactor
plus the tests it enables.

### Bug hunt

No functional bug found in these four handlers — they are thin wrappers around
the (already unit-tested) `git2_ops` functions. One minor redundancy noted but
left as-is: `repo_push` re-derives `remote_url` via
`sanitize_url_for_logging(&args.url)` rather than using the already-sanitised
`PushResult.remote_url`; both yield the same value, so it is not a bug.

### Refactor + coverage

Each handler's success path (the completion `info!` + result-struct assembly)
was reachable only through a real network op — integration-covered only. It is
now a private `build_*_result` helper that unit tests drive by constructing the
underlying `git2_ops` result type directly (`PushResult` / `PullResult` /
`DiffResult` / `RefsResult` — all already have public fields). Notable:

- `repo_pull`'s up-to-date-vs-changed branch is covered for **both** arms.
- A minimal valid-header bundle (`# v2 bundle\n…`) passes `validate_bundle`, so
  a unit test drives `repo_push` through `push_bundle` (which then rejects the
  invalid URL) — covering the push-options construction and push invocation.
- The `run_with_debug_logs` helper (forces `tracing` field evaluation so
  logging lines aren't phantom-uncovered) is consolidated from three copies in
  the clone-handler test modules into one `#[cfg(test)]` fn in `mcp::tools`.

| File | Before | After |
|------|-------:|------:|
| `repo_push.rs` | 85.92% | 99.43% |
| `repo_pull.rs` | 89.29% | 99.49% |
| `repo_diff.rs` | 92.08% | 99.27% |
| `repo_refs.rs` | 89.25% | 99.22% |

## Related Issue

N/A — proactive coverage + bug-hunt sweep (follows #193, #194).

## Type of Change

- [x] Refactoring (no functional changes)

## Security Checklist ⚠️

- [x] No credentials in code, comments, or tests
- [x] No credentials in logs or error messages (a `build_push_result` test asserts the embedded credential is stripped from `remote_url`)
- [x] No credentials in MCP responses
- [x] Credentials scoped to their operation
- [x] Error messages don't leak sensitive information

## Testing

- [x] Tested locally
- [x] Added tests for each `build_*_result`, the `repo_push` push-invocation path, and entry-log evaluation
- [x] `cargo test --all-features --workspace` — 741 lib tests pass

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Changed)

## Commit Map

- `refactor(tools): make remaining tool handlers unit-testable` — the four `build_*_result` extractions, the `run_with_debug_logs` consolidation, all new tests, and the CHANGELOG entry.

## Findings That Are NOT in This PR

- The single residual uncovered line in each of the four files is the `Ok(build_*_result(...))` delegation call in the outer handler, reachable only after a successful network operation (integration-covered).