### PR TITLE
test(auth,audit): close reachable coverage gaps (92.4% / 97.4%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`git2_ops::auth` and `security::audit` coverage top-ups.** Added direct
+  unit tests for `auth::credentials_callback`'s `DEFAULT` branch (deterministic)
+  and its ssh-agent branch (no-panic exercise, since the outcome depends on
+  system state); and for `audit`'s leap-year date conversion (`days_to_ymd`),
+  the `AuditLogger::log_path` getter, and the two `AuditLogger::new` IoError
+  arms (parent-is-a-file → `create_dir_all` fails; path-is-a-directory → open
+  fails). `auth.rs` 89.47 % -> 92.43 %, `audit.rs` 93.79 % -> 97.37 % line
+  coverage. The remaining lines are the git2-invoked transfer-progress callback,
+  the credential-helper branch (deliberately not unit-tested so the suite never
+  triggers an interactive OS credential helper), the `git credential fill`
+  subprocess spawn/write/wait error arms, and the audit write/flush/serialise
+  I/O error arms — all inherent or integration-covered.
 - **`mcp::server` tool-dispatch coverage.** The `call_*_tool` methods (which
   run the rate-limit, repo-filter and branch/push-guard checks before invoking
   a handler) were exercised almost entirely by the Python integration suite.

--- a/src/git2_ops/auth.rs
+++ b/src/git2_ops/auth.rs
@@ -850,11 +850,37 @@ mod tests {
         let err = result
             .err()
             .expect("expected error when no credential type is allowed");
+        let msg = err.message();
         assert!(
-            err.message()
-                .contains("no suitable credential method available"),
-            "expected fallback message, got: {}",
-            err.message()
+            msg.contains("no suitable credential method available"),
+            "expected fallback message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn credentials_callback_returns_default_cred_for_default_type() {
+        // `Cred::default()` never fails, so when only the DEFAULT credential
+        // type is allowed the callback returns it directly — exercising the
+        // DEFAULT branch deterministically, without touching ssh-agent or any
+        // credential helper.
+        let result = credentials_callback(
+            "https://example.com/repo.git",
+            None,
+            CredentialType::DEFAULT,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn credentials_callback_attempts_ssh_agent_branch() {
+        // Exercises the SSH-agent branch. Whether it returns Ok (an agent with
+        // a usable key is present) or Err (none) depends on system state, so —
+        // unlike the existing fallback test — this only asserts the branch runs
+        // without panicking, never the outcome (keeping it non-flaky on CI).
+        let _ = credentials_callback(
+            "git@github.com:owner/repo.git",
+            Some("git"),
+            CredentialType::SSH_KEY,
         );
     }
 

--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -693,6 +693,43 @@ mod tests {
     }
 
     #[test]
+    fn days_to_ymd_resolves_leap_year_date() {
+        // 19782 days after the Unix epoch is 2024-02-29. 2024 is a leap year,
+        // so this drives the leap-year `days_in_months` arm (29-day February).
+        assert_eq!(days_to_ymd(19782), (2024, 2, 29));
+        // And the first day of that leap year (19723 = 2024-01-01).
+        assert_eq!(days_to_ymd(19723), (2024, 1, 1));
+    }
+
+    #[test]
+    fn audit_logger_exposes_log_path() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path().to_path_buf();
+        let logger = AuditLogger::new(&path).unwrap();
+        assert!(logger.is_enabled());
+        assert_eq!(logger.log_path(), path.as_path());
+    }
+
+    #[test]
+    fn audit_logger_new_fails_when_parent_is_a_file() {
+        // The log path's parent is an existing *file*, so `create_dir_all`
+        // cannot create the intermediate directory — surfaces as an IoError.
+        let temp_file = NamedTempFile::new().unwrap();
+        let bad_path = temp_file.path().join("subdir").join("audit.log");
+        let result = AuditLogger::new(&bad_path);
+        assert!(matches!(result, Err(AuditLoggerError::IoError { .. })));
+    }
+
+    #[test]
+    fn audit_logger_new_fails_when_path_is_a_directory() {
+        // Opening an existing directory as an append-mode file fails — surfaces
+        // as an IoError from the open step.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let result = AuditLogger::new(temp_dir.path());
+        assert!(matches!(result, Err(AuditLoggerError::IoError { .. })));
+    }
+
+    #[test]
     fn audit_event_server_stopped_with_reason() {
         let event = AuditEvent::server_stopped(ShutdownReason::SigInt);
 


### PR DESCRIPTION
## Description

Stage 5 of the coverage-to-100% + bug-hunt sweep. Targets `git2_ops/auth.rs`
and `security/audit.rs` — both previously deep-audited (#153, #154), so this is
coverage top-ups plus a fresh bug read. **Tests only — no production change.**

### Bug hunt

No functional bug found in either file. `credentials_callback`'s
method-selection order (SSH agent → credential helper → default → error) is
correct, and `audit`'s date/leap-year arithmetic and logger error mapping are
sound.

### Coverage

`git2_ops/auth.rs` (89.47% → 92.43%):
- `credentials_callback` `DEFAULT` branch (deterministic `Ok`) and its
  ssh-agent branch (no-panic exercise — the outcome depends on whether an agent
  is present, so it asserts only that the branch runs, keeping it non-flaky).
- Bound `err.message()` before the fallback-message assert so the call is not a
  phantom-uncovered line.

`security/audit.rs` (93.79% → 97.37%):
- `days_to_ymd` on a leap-year date (2024-02-29) — drives the leap-year
  `days_in_months` arm.
- `AuditLogger::log_path` getter.
- Both `AuditLogger::new` IoError arms: parent-is-a-file (so `create_dir_all`
  fails) and path-is-a-directory (so the open fails). Both deterministic and
  cross-platform.

## Related Issue

N/A — proactive coverage + bug-hunt sweep (follows #193–#196).

## Type of Change

- [x] Refactoring (no functional changes) — test additions only

## Security Checklist

- [x] No credentials in code, comments, or tests
- [x] No credentials in logs or error messages
- [x] No credentials in MCP responses
- [x] The credential-helper branch is deliberately NOT unit-tested, so the suite never triggers an interactive OS credential manager / GUI prompt
- [x] Error messages don't leak sensitive information

## Testing

- [x] Tested locally
- [x] Added unit tests for the reachable auth/audit gaps
- [x] `cargo test --all-features --workspace` — 767 lib tests pass

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS=-Dwarnings`
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Added)

## Commit Map

- `test(auth,audit): close reachable coverage gaps` — all new tests, the assert fix, and the CHANGELOG entry.

## Findings That Are NOT in This PR

- `auth.rs` `create_callbacks_with_progress`'s `transfer_progress` closure (git2 invokes it during a real fetch), the credential-helper branch (prompt risk), the env-dependent ssh-agent success/failure arm, and the `git credential fill` subprocess spawn/write/wait error arms stay integration-covered or inherent.
- `audit.rs` `log()` write/flush/serialise error arms require forcing an I/O or serialisation failure on a valid file/event — inherent.
