### PR TITLE
test(progress,protocol): reach 100% line coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`mcp::progress` and `mcp::protocol` coverage top-ups.** Added a test that
+  poisons `ProgressSender`'s `last_sent` mutex (via `catch_unwind`) and confirms
+  `send` recovers rather than panicking, taking `progress.rs` to 100 % line
+  coverage. Reworked three `protocol::parse_message` tests and two `progress`
+  send tests from `let-else { panic! }` / `match { _ => panic! }` shapes — whose
+  unreachable panic arms showed as uncovered — into single `assert!(matches!(…))`
+  forms, taking `protocol.rs` to 100 % line coverage. No production change.
+  (`config/mod.rs`'s only remaining gap is the `default_config_path()` →
+  `None` arm, reachable solely when `dirs::home_dir()` returns `None`, which is
+  not portably forceable in a test.)
 - **`git2_ops::auth` and `security::audit` coverage top-ups.** Added direct
   unit tests for `auth::credentials_callback`'s `DEFAULT` branch (deterministic)
   and its ssh-agent branch (no-panic exercise, since the outcome depends on

--- a/src/mcp/progress.rs
+++ b/src/mcp/progress.rs
@@ -754,22 +754,23 @@ mod tests {
         let (tx, rx) = ProgressSender::new("t".to_string());
         tx.send_transfer(100, 200, 5, 10, 5);
         let received = rx.recv().unwrap();
-        match received {
-            ProgressUpdate::Transfer {
-                received_bytes,
-                total_bytes,
-                received_objects,
-                total_objects,
-                indexed_objects,
-            } => {
-                assert_eq!(received_bytes, 100);
-                assert_eq!(total_bytes, 200);
-                assert_eq!(received_objects, 5);
-                assert_eq!(total_objects, 10);
-                assert_eq!(indexed_objects, 5);
-            }
-            other => panic!("expected Transfer, got {other:?}"),
-        }
+        assert!(
+            matches!(
+                received,
+                ProgressUpdate::Transfer {
+                    received_bytes,
+                    total_bytes,
+                    received_objects,
+                    total_objects,
+                    indexed_objects,
+                } if received_bytes == 100
+                    && total_bytes == 200
+                    && received_objects == 5
+                    && total_objects == 10
+                    && indexed_objects == 5
+            ),
+            "expected Transfer with the sent fields, got {received:?}"
+        );
     }
 
     #[test]
@@ -777,18 +778,41 @@ mod tests {
         let (tx, rx) = ProgressSender::new("t".to_string());
         tx.send_file_progress(1, 5, Some("a.txt"));
         let received = rx.recv().unwrap();
-        match received {
-            ProgressUpdate::FileProcessing {
-                processed,
-                total,
-                current_file,
-            } => {
-                assert_eq!(processed, 1);
-                assert_eq!(total, 5);
-                assert_eq!(current_file, Some("a.txt".to_string()));
-            }
-            other => panic!("expected FileProcessing, got {other:?}"),
-        }
+        assert!(
+            matches!(
+                received,
+                ProgressUpdate::FileProcessing {
+                    processed: 1,
+                    total: 5,
+                    current_file: Some(ref f),
+                } if f == "a.txt"
+            ),
+            "expected FileProcessing with the sent fields, got {received:?}"
+        );
+    }
+
+    #[test]
+    fn send_recovers_from_poisoned_last_sent_mutex() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        let (tx, _rx) = ProgressSender::new("t".to_string());
+
+        // Poison the `last_sent` mutex by panicking while holding the lock.
+        let poison_outcome = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = tx.last_sent.lock().unwrap();
+            panic!("intentional poison");
+        }));
+        assert!(poison_outcome.is_err());
+
+        // A non-Complete update takes the rate-limit path, which locks
+        // `last_sent`. It must recover from the poison rather than panicking.
+        let _ = tx.send(ProgressUpdate::Transfer {
+            received_bytes: 1,
+            total_bytes: 2,
+            received_objects: 1,
+            total_objects: 2,
+            indexed_objects: 1,
+        });
     }
 
     #[test]

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -439,11 +439,11 @@ mod tests {
         let json = r#"{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}"#;
         let msg = parse_message(json).unwrap();
 
-        let IncomingMessage::Request(req) = msg else {
-            panic!("Expected Request, got Notification");
-        };
-        assert_eq!(req.id, RequestId::Number(1));
-        assert_eq!(req.method, "initialize");
+        assert!(
+            matches!(&msg, IncomingMessage::Request(req)
+                if req.id == RequestId::Number(1) && req.method == "initialize"),
+            "expected Request(id=1, method=initialize)"
+        );
     }
 
     #[test]
@@ -451,10 +451,11 @@ mod tests {
         let json = r#"{"jsonrpc": "2.0", "method": "notifications/initialized"}"#;
         let msg = parse_message(json).unwrap();
 
-        let IncomingMessage::Notification(notif) = msg else {
-            panic!("Expected Notification, got Request");
-        };
-        assert_eq!(notif.method, "notifications/initialized");
+        assert!(
+            matches!(&msg, IncomingMessage::Notification(notif)
+                if notif.method == "notifications/initialized"),
+            "expected notifications/initialized notification"
+        );
     }
 
     #[test]
@@ -462,10 +463,11 @@ mod tests {
         let json = r#"{"jsonrpc": "2.0", "id": "abc-123", "method": "test"}"#;
         let msg = parse_message(json).unwrap();
 
-        let IncomingMessage::Request(req) = msg else {
-            panic!("Expected Request, got Notification");
-        };
-        assert_eq!(req.id, RequestId::String("abc-123".to_string()));
+        assert!(
+            matches!(&msg, IncomingMessage::Request(req)
+                if req.id == RequestId::String("abc-123".to_string())),
+            "expected Request with string id abc-123"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Stage 6 of the coverage-to-100% + bug-hunt sweep. Small top-ups on
`mcp/progress.rs`, `mcp/protocol.rs`, and `config/mod.rs` (all already
96–99%). **Tests only — no production change.**

### Bug hunt

No bug found. These modules were already high-coverage and previously audited;
this stage closes the last reachable gaps.

### Coverage

`mcp/progress.rs` → **100% lines**:
- New test poisons `ProgressSender`'s `last_sent` mutex (panic while holding the
  lock, contained with `catch_unwind`) and confirms `send` recovers via
  `into_inner()` instead of panicking — covering the poison-recovery arm.
- The Transfer/FileProcessing send tests moved from `match { _ => panic! }` to
  `assert!(matches!(..) )` with field guards, removing the unreachable panic
  arms that were showing as uncovered.

`mcp/protocol.rs` → **100% lines**:
- Three `parse_message` tests moved from `let-else { panic! }` to
  `assert!(matches!(.. if ..))`, removing the unreachable panic arms.

`config/mod.rs` is **untouched**: its only remaining uncovered lines are the
`default_config_path()` → `None` arm, reachable solely when `dirs::home_dir()`
returns `None`, which is not portably forceable in a unit test.

## Related Issue

N/A — proactive coverage + bug-hunt sweep (follows #193–#197).

## Type of Change

- [x] Refactoring (no functional changes) — test additions/rewrites only

## Security Checklist

- [x] No credentials in code, comments, or tests
- [x] No credentials in logs or error messages
- [x] No credentials in MCP responses
- [x] Credentials scoped to their operation
- [x] Error messages don't leak sensitive information

## Testing

- [x] Tested locally
- [x] `cargo test --all-features --workspace` — 768 lib tests pass

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS=-Dwarnings`
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Added)

## Commit Map

- `test(progress,protocol): reach 100% line coverage` — the poison-recovery test, the `matches!` rewrites, and the CHANGELOG entry.

## Findings That Are NOT in This PR

- `config/mod.rs`'s `dirs::home_dir() == None` arm — inherent (not portably forceable).
- A few sub-line *region* gaps remain in `progress.rs` (e.g. `matches!` non-match arms in other tests); line coverage is 100%.
