### PR TITLE
test(streaming): tar/chunked coverage + drop dead get_session_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`streaming::tar` and `streaming::chunked` coverage top-ups.** For `tar.rs`,
+  a test drives the LFS-resolution path with an unreachable LFS server
+  (`127.0.0.1:1`, `retry_max_attempts: 0`) so the pointer is parsed, a fetch is
+  attempted and fails fast, `lfs_failed` is counted, and the pointer is archived
+  verbatim — plus the LFS progress-report path. For `chunked.rs`, tests cover
+  `StreamingSession::age`, `progress()` on a zero-chunk (empty-archive) session,
+  and the `StreamingError` `Display` arms (`SessionExpired` / `InvalidChunkIndex`
+  / `LockPoisoned` / `IoError`) and `From<io::Error>` conversion; a literal-field
+  `matches!` was reworked to bind-and-guard to drop its phantom non-match arm.
+  `tar.rs` 92.82 % -> 97.46 %, `chunked.rs` 91.33 % -> 99.24 % line coverage.
+  Verified that `chunked::create_session` does **not** share the
+  overwrite-at-capacity bug fixed in `session.rs`: it assigns a fresh unique
+  `generate_id()` per call, so every create is a genuine new insert (no
+  in-place-overwrite case exists).
 - **`mcp::progress` and `mcp::protocol` coverage top-ups.** Added a test that
   poisons `ProgressSender`'s `last_sent` mutex (via `catch_unwind`) and confirms
   `send` recovers rather than panicking, taking `progress.rs` to 100 % line
@@ -1236,6 +1250,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **`StreamingSessionManager::get_session_info` deleted.** It was `pub` but had
+  zero callers outside its own (absent) tests — a dead duplicate of the live
+  `get_session_status`, which the `repo_clone_status` tool actually uses. Same
+  dead-`pub`-API cleanup as `fetch_batch` / `parse_bundle_info`. ~30 lines
+  removed; no behaviour change.
 - **`LfsClient::fetch_batch` and the `LfsBatchResult` struct deleted.**
   Both were `pub` but had zero callers outside `lfs.rs`'s own tests
   (the only LFS consumer, `streaming/tar.rs`, calls `fetch_content` per

--- a/src/streaming/chunked.rs
+++ b/src/streaming/chunked.rs
@@ -547,40 +547,6 @@ impl StreamingSessionManager {
         Ok((chunk, next_missing))
     }
 
-    /// Get session info without retrieving a chunk.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the session doesn't exist.
-    #[allow(clippy::significant_drop_tightening)]
-    pub fn get_session_info(
-        &self,
-        session_id: &str,
-    ) -> Result<StreamingSessionInfo, StreamingError> {
-        let sessions = self
-            .sessions
-            .read()
-            .map_err(|_| StreamingError::LockPoisoned)?;
-
-        let session = sessions
-            .get(session_id)
-            .ok_or_else(|| StreamingError::SessionNotFound(session_id.to_string()))?;
-
-        let delivered = session.retrieved_chunks.iter().filter(|&&r| r).count();
-
-        Ok(StreamingSessionInfo {
-            session_id: session.id.clone(),
-            total_chunks: session.total_chunks(),
-            total_size: session.total_size(),
-            chunk_size: session.chunk_size,
-            commit: session.commit.clone(),
-            branch: session.branch.clone(),
-            delivered_chunks: delivered,
-            next_missing_chunk: session.next_missing_chunk(),
-            progress_percent: session.progress(),
-        })
-    }
-
     /// Cancel a session explicitly.
     ///
     /// # Errors
@@ -979,13 +945,7 @@ mod tests {
             .get_chunk(&info.session_id, 99)
             .expect_err("must reject out-of-range chunk index");
         assert!(
-            matches!(
-                err,
-                StreamingError::InvalidChunkIndex {
-                    index: 99,
-                    total: 2,
-                }
-            ),
+            matches!(err, StreamingError::InvalidChunkIndex { index, total } if index == 99 && total == 2),
             "expected InvalidChunkIndex, got {err:?}"
         );
     }
@@ -1360,5 +1320,65 @@ mod tests {
         assert_eq!(info.delivered_chunks, 0);
         assert_eq!(info.next_missing_chunk, Some(0));
         assert!((info.progress_percent - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn streaming_session_age_advances() {
+        // Coverage: `StreamingSession::age()` had no caller.
+        let session = StreamingSession::new(
+            "id".to_string(),
+            "url".to_string(),
+            "main".to_string(),
+            "abc".to_string(),
+            vec![0u8; 100],
+            1024,
+        )
+        .unwrap();
+        let first = session.age();
+        std::thread::sleep(Duration::from_millis(5));
+        let second = session.age();
+        assert!(second >= first);
+        assert!(second >= Duration::from_millis(5));
+    }
+
+    #[test]
+    fn progress_is_complete_for_zero_chunk_session() {
+        // An empty archive yields a zero-chunk session; `progress()` must take
+        // the empty-`retrieved_chunks` branch and report 100%.
+        let session = StreamingSession::new(
+            "id".to_string(),
+            "url".to_string(),
+            "main".to_string(),
+            "abc".to_string(),
+            Vec::new(),
+            1024,
+        )
+        .unwrap();
+        assert_eq!(session.total_chunks(), 0);
+        assert!((session.progress() - 100.0).abs() < f64::EPSILON);
+        assert!(session.is_complete());
+    }
+
+    #[test]
+    fn streaming_error_display_and_from_io() {
+        // Coverage: the Display arms for SessionExpired / InvalidChunkIndex /
+        // LockPoisoned / IoError, and the From<io::Error> conversion.
+        assert!(StreamingError::SessionExpired("s1".to_string())
+            .to_string()
+            .contains("expired"));
+        let idx = StreamingError::InvalidChunkIndex { index: 3, total: 2 }.to_string();
+        assert!(
+            idx.contains("invalid chunk index 3") && idx.contains("total chunks: 2"),
+            "got: {idx}"
+        );
+        assert!(StreamingError::LockPoisoned
+            .to_string()
+            .contains("poisoned"));
+        assert!(StreamingError::IoError("disk gone".to_string())
+            .to_string()
+            .contains("disk gone"));
+
+        let from_io: StreamingError = std::io::Error::other("boom").into();
+        assert!(matches!(from_io, StreamingError::IoError(ref m) if m.contains("boom")));
     }
 }

--- a/src/streaming/tar.rs
+++ b/src/streaming/tar.rs
@@ -1308,6 +1308,50 @@ mod tests {
     }
 
     #[test]
+    fn create_tar_counts_lfs_failure_when_server_unreachable() {
+        // resolve_lfs = true with a valid-but-unreachable repo_url: the LFS
+        // client IS created, the pointer is parsed and a fetch is attempted,
+        // which fails fast (connection refused on 127.0.0.1:1). The failure is
+        // counted in `lfs_failed` and the pointer is archived verbatim.
+        // `retry_max_attempts: 0` makes the fetch a single attempt (no backoff).
+        let temp = tempfile::TempDir::new().unwrap();
+        let pointer = b"version https://git-lfs.github.com/spec/v1\n\
+                        oid sha256:1111111111111111111111111111111111111111111111111111111111111111\n\
+                        size 12\n";
+        let commit_oid = {
+            let repo = Repository::init_bare(temp.path()).unwrap();
+            let blob = repo.blob(pointer).unwrap();
+            let mut tb = repo.treebuilder(None).unwrap();
+            tb.insert("big.bin", blob, 0o100_644).unwrap();
+            let tree = repo.find_tree(tb.write().unwrap()).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "lfs pointer", &tree, &[])
+                .unwrap()
+        };
+        let repo = open_test_repo(&temp);
+        // A progress sender so the pre-fetch LFS progress report is exercised
+        // too; the receiver is kept alive so sends don't fail.
+        let (sender, _receiver) = crate::mcp::progress::ProgressSender::new("t".to_string());
+        let opts = TarOptions {
+            resolve_lfs: Some(true),
+            repo_url: Some("https://127.0.0.1:1/repo.git".to_string()),
+            lfs_config: Some(crate::config::LfsConfig {
+                retry_max_attempts: 0,
+                ..Default::default()
+            }),
+            progress: Some(sender),
+            ..Default::default()
+        };
+        let result = create_tar_from_tree_with_options(&repo, commit_oid, Some(opts)).unwrap();
+        assert_eq!(result.lfs_resolved, 0);
+        assert_eq!(result.lfs_failed, 1);
+        assert_eq!(
+            result.file_count, 1,
+            "pointer file is archived verbatim on fetch failure"
+        );
+    }
+
+    #[test]
     fn create_tar_handles_resolve_lfs_with_unsupported_repo_url() {
         // resolve_lfs = true with a repo_url whose scheme derive_lfs_url
         // rejects (ftp://): LfsClient::new errors, the "failed to create LFS


### PR DESCRIPTION
## Description

Stage 7 of the coverage-to-100% + bug-hunt sweep. Targets `streaming/tar.rs`
and `streaming/chunked.rs` (both previously deep-audited — #186, #157). Includes
the bug-class check I flagged back in Stage 2.

### Bug hunt — flagged item resolved (no bug)

In Stage 2 I noted that `chunked::StreamingSessionManager::create_session`
*might* share the overwrite-at-capacity bug I fixed in `session.rs` (#193).
**It does not.** The two managers differ fundamentally:

- `session.rs` used a **deterministic** ID (`{sanitised_url}@{branch}`), so
  re-cloning the same repo+branch produced the same key → an in-place overwrite
  that the capacity check wrongly rejected.
- `chunked.rs` assigns a fresh **unique** `generate_id()` (a `stream_*` id)
  **after** the capacity check, so every `create_session` is a genuine new
  insert. There is no overwrite case, and rejecting at capacity is correct.

No other bug found in either file.

### Dead-code removal

`StreamingSessionManager::get_session_info` was `pub` with **zero callers** — a
dead duplicate of the live `get_session_status` (which `repo_clone_status`
actually uses). Removed (~30 lines), matching the `fetch_batch` /
`parse_bundle_info` YAGNI cleanups.

### Coverage

`streaming/chunked.rs` (91.33% → **99.24%**):
- Tests for `StreamingSession::age`, `progress()` on a zero-chunk (empty-archive)
  session, and the `StreamingError` `Display` arms (`SessionExpired` /
  `InvalidChunkIndex` / `LockPoisoned` / `IoError`) + `From<io::Error>`.
- Reworked a literal-field `matches!` into bind-and-guard to drop its phantom
  non-match arm.

`streaming/tar.rs` (92.82% → **97.46%**):
- A test drives the LFS-resolution path with an unreachable LFS server
  (`127.0.0.1:1`, `retry_max_attempts: 0`, plus a progress sender): the pointer
  is parsed, a fetch is attempted and fails fast (connection refused),
  `lfs_failed` is counted, and the pointer is archived verbatim.

## Related Issue

N/A — proactive coverage + bug-hunt sweep (follows #193–#198).

## Type of Change

- [x] Refactoring (no functional changes) — dead-code removal + tests

## Security Checklist

- [x] No credentials in code, comments, or tests
- [x] No credentials in logs or error messages
- [x] No credentials in MCP responses
- [x] Credentials scoped to their operation
- [x] Error messages don't leak sensitive information

## Testing

- [x] Tested locally
- [x] `cargo test --all-features --workspace` — 772 lib tests pass

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS=-Dwarnings`
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Added + Removed)

## Commit Map

- `test(streaming): close tar/chunked gaps; drop dead get_session_info` — the removal, the new tests, and the CHANGELOG entries.

## Findings That Are NOT in This PR

- `tar.rs`'s LFS-**success** path (needs a mock/real LFS server), submodule-walk edge cases (corrupt tree, non-UTF-8 entry names, nested dirs), and `find_blob` error arms stay integration-covered or inherent.
- `chunked.rs`'s disk-backed I/O error arms (`read_chunk` past-end, `ChunkReadError::Io` mapping, temp-file init failure in `create_session`) require forcing OS-level I/O failures — inherent.
