### PR TITLE
test(git2_ops): error.rs to 100% + commit-resolution coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`git2_ops` coverage top-ups.** Reworked the `Git2Error` mapping tests
+  (`error.rs`, taking it to 100 % line coverage) and the `push_bundle`
+  ref-not-found test from `match { _ => panic! }` shapes — whose unreachable
+  panic arms showed as uncovered — into `assert!(matches!(…))` forms. Added a
+  `resolve_commit` test for an **annotated** tag (a tag object that
+  `revparse_single` returns and `resolve_commit` peels to its commit), distinct
+  from the existing lightweight-tag test. The remaining `git2_ops` gaps are the
+  network success/error arms (covered end-to-end by the Python integration
+  suite via the `*_inner` helpers), defensive ref-resolution fallbacks that
+  `revparse_single` makes redundant, the submodule child-recursion path (needs a
+  working remote), and OS-level I/O failure arms — all integration-covered or
+  inherent.
 - **`streaming::tar` and `streaming::chunked` coverage top-ups.** For `tar.rs`,
   a test drives the LFS-resolution path with an unreachable LFS server
   (`127.0.0.1:1`, `retry_max_attempts: 0`) so the pointer is parsed, a fetch is

--- a/src/git2_ops/diff.rs
+++ b/src/git2_ops/diff.rs
@@ -383,10 +383,21 @@ mod tests {
                 )
                 .unwrap();
 
-            // Tag the second commit
+            // Tag the second commit (lightweight: a direct ref to the commit).
             repo.tag_lightweight(
                 "v1.0",
                 &repo.find_commit(commit2).unwrap().into_object(),
+                false,
+            )
+            .unwrap();
+
+            // Annotated tag (a tag *object*, not a direct ref) so
+            // `resolve_commit`'s peel-to-commit path can be exercised.
+            repo.tag(
+                "v2.0",
+                &repo.find_commit(commit2).unwrap().into_object(),
+                &signature,
+                "release 2.0",
                 false,
             )
             .unwrap();
@@ -421,6 +432,16 @@ mod tests {
         let (temp, _, oid2) = build_test_repo_with_two_commits();
         let repo = Repository::open_bare(temp.path()).unwrap();
         let resolved = resolve_commit(&repo, "v1.0").unwrap();
+        assert_eq!(resolved, oid2);
+    }
+
+    #[test]
+    fn resolve_commit_annotated_tag() {
+        // An annotated tag resolves via `revparse_single` to a Tag *object*,
+        // which `resolve_commit` then peels to the underlying commit.
+        let (temp, _, oid2) = build_test_repo_with_two_commits();
+        let repo = Repository::open_bare(temp.path()).unwrap();
+        let resolved = resolve_commit(&repo, "v2.0").unwrap();
         assert_eq!(resolved, oid2);
     }
 

--- a/src/git2_ops/error.rs
+++ b/src/git2_ops/error.rs
@@ -272,10 +272,10 @@ mod tests {
             "repository not found",
         );
         let mapped = Git2Error::from(raw_err);
-        match mapped {
-            Git2Error::Git2(msg) => assert!(msg.contains("repository not found")),
-            other => panic!("expected Git2 variant, got {other:?}"),
-        }
+        assert!(
+            matches!(&mapped, Git2Error::Git2(msg) if msg.contains("repository not found")),
+            "expected Git2 variant, got {mapped:?}"
+        );
     }
 
     #[test]
@@ -319,12 +319,10 @@ mod tests {
     fn from_io_error_maps_to_temp_dir_failed() {
         let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "denied");
         let mapped = Git2Error::from(io_err);
-        match mapped {
-            Git2Error::TempDirFailed(inner) => {
-                assert_eq!(inner.kind(), io::ErrorKind::PermissionDenied);
-            }
-            other => panic!("expected TempDirFailed, got {other:?}"),
-        }
+        assert!(
+            matches!(&mapped, Git2Error::TempDirFailed(inner) if inner.kind() == io::ErrorKind::PermissionDenied),
+            "expected TempDirFailed(PermissionDenied), got {mapped:?}"
+        );
     }
 
     #[test]
@@ -389,10 +387,11 @@ mod tests {
             git2::ErrorClass::Net,
             "connection refused",
         );
-        match Git2Error::from_fetch(&err) {
-            Git2Error::FetchFailed(msg) => assert!(msg.contains("connection refused")),
-            other => panic!("expected FetchFailed, got {other:?}"),
-        }
+        let mapped = Git2Error::from_fetch(&err);
+        assert!(
+            matches!(&mapped, Git2Error::FetchFailed(msg) if msg.contains("connection refused")),
+            "expected FetchFailed, got {mapped:?}"
+        );
     }
 
     #[test]
@@ -402,13 +401,11 @@ mod tests {
             git2::ErrorClass::Net,
             "failed to resolve https://u:ghp_x@github.com/o/r.git",
         );
-        match Git2Error::from_fetch(&err) {
-            Git2Error::FetchFailed(msg) => {
-                assert!(!msg.contains("ghp_x"));
-                assert!(msg.contains("***@github.com"));
-            }
-            other => panic!("expected FetchFailed, got {other:?}"),
-        }
+        let mapped = Git2Error::from_fetch(&err);
+        assert!(
+            matches!(&mapped, Git2Error::FetchFailed(msg) if !msg.contains("ghp_x") && msg.contains("***@github.com")),
+            "expected redacted FetchFailed, got {mapped:?}"
+        );
     }
 
     #[test]
@@ -418,10 +415,11 @@ mod tests {
             git2::ErrorClass::Net,
             "remote rejected",
         );
-        match Git2Error::from_push(&err) {
-            Git2Error::PushFailed(msg) => assert!(msg.contains("remote rejected")),
-            other => panic!("expected PushFailed, got {other:?}"),
-        }
+        let mapped = Git2Error::from_push(&err);
+        assert!(
+            matches!(&mapped, Git2Error::PushFailed(msg) if msg.contains("remote rejected")),
+            "expected PushFailed, got {mapped:?}"
+        );
     }
 
     #[test]

--- a/src/git2_ops/push.rs
+++ b/src/git2_ops/push.rs
@@ -425,12 +425,10 @@ mod tests {
             opts,
             None,
         );
-        match result {
-            Err(Git2Error::RefNotFound(name)) => {
-                assert_eq!(name, "feature/missing");
-            }
-            other => panic!("expected RefNotFound, got: {other:?}"),
-        }
+        assert!(
+            matches!(&result, Err(Git2Error::RefNotFound(name)) if name == "feature/missing"),
+            "expected RefNotFound(feature/missing), got: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Stage 8 of the coverage-to-100% + bug-hunt sweep. Coverage top-ups across the
`git2_ops` module (all files previously deep-audited — #159, #160, #180–185).
**Tests only — no production change.**

### Bug hunt

No bug found. A read of the remaining uncovered arms confirmed they are the hard
long-tail: network success/error paths, defensive ref-resolution fallbacks, the
submodule child-recursion path, and OS-level I/O failure arms.

### Coverage

- **`error.rs` → 100% lines.** The five `Git2Error` mapping tests used
  `match { Variant => assert, _ => panic! }`; the unreachable panic arms showed
  as uncovered. Rewritten to `assert!(matches!(.. if ..))`.
- **`push.rs`** — same rewrite for the `RefNotFound` push test.
- **`diff.rs` 91.19% → 92.54%** — added a `resolve_commit` test for an
  **annotated** tag. The existing tag test uses a *lightweight* tag (resolves
  straight to a commit); an annotated tag is returned by `revparse_single` as a
  Tag object that `resolve_commit` must peel to its commit, exercising that
  branch.

### Why this stage is deliberately small

The `git2_ops` files were already at 91–99% from their prior audits, where the
`*_inner` + local-`file://` pattern covered the main success and error paths.
The lines that remain are genuinely the hardest: the real network connect/fetch
arms (integration-covered), defensive fallbacks that `revparse_single` makes
redundant, the submodule child-recursion (needs a working remote), and
OS-failure arms (temp-file creation, disk I/O). Chasing them with unit tests
would mean elaborate git fixtures and OS-failure injection on already-audited
code — diminishing returns. They are left to integration coverage / documented
as inherent.

## Related Issue

N/A — proactive coverage + bug-hunt sweep (follows #193–#199).

## Type of Change

- [x] Refactoring (no functional changes) — test additions/rewrites only

## Security Checklist

- [x] No credentials in code, comments, or tests
- [x] No credentials in logs or error messages
- [x] No credentials in MCP responses
- [x] Error messages don't leak sensitive information (the `from_fetch` redaction test is preserved)

## Testing

- [x] Tested locally
- [x] `cargo test --all-features --workspace` — 773 lib tests pass

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS=-Dwarnings`
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Added)

## Commit Map

- `test(git2_ops): error.rs to 100%, annotated-tag resolve, panic-arm hygiene` — the rewrites, the annotated-tag test, and the CHANGELOG entry.

## Findings That Are NOT in This PR

- Network connect/fetch/push success and error arms in `clone.rs` / `diff.rs` / `pull.rs` / `push.rs` — integration-covered via the `*_inner` helpers.
- `resolve_commit`'s `find_reference`-by-branch / by-tag fallbacks — defensive, made redundant by `revparse_single`; effectively unreachable.
- `submodule.rs` child-recursion + successful-fetch arm — needs a working remote (integration).
- OS-level I/O failure arms (temp-file creation in `clone`/`chunked`, disk reads) and the `auth` credential-helper branch (deliberately untested to avoid triggering the OS credential manager).
