### PR TITLE
test(guards): cover pure-logic CLI paths, guards.rs 92% → 99%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`security::guards` coverage top-ups.** Added unit tests for the
+  previously-untested pure-logic paths in the (security-critical) guards:
+  `BranchGuard::unprotect` and `Default`; the `SecurityGuard::check` CLI-arg
+  paths for `BranchGuard` (non-modifying command, `local:remote` push refspec
+  parsing, push with no extractable branch), `PushGuard` (non-push command) and
+  `RepoFilter` (non-remote command, `remote add <name> <url>` URL extraction,
+  trailing-slash pattern normalisation, `new`/`default`); and
+  `extract_branch_from_args` across all its command shapes. `guards.rs` line
+  coverage rose from 92.00 % to 99.15 % (the remainder is a defensive
+  `_ => None` arm `revparse`/`check` never reaches). No production change.
 - **`git2_ops` coverage top-ups.** Reworked the `Git2Error` mapping tests
   (`error.rs`, taking it to 100 % line coverage) and the `push_bundle`
   ref-not-found test from `match { _ => panic! }` shapes — whose unreachable

--- a/src/security/guards.rs
+++ b/src/security/guards.rs
@@ -905,4 +905,144 @@ mod tests {
         // A genuinely different repo is unaffected.
         assert!(filter.is_allowed("https://github.com/public/repo.git"));
     }
+
+    #[test]
+    fn branch_guard_unprotect_removes_branch() {
+        let mut guard = BranchGuard::new(["main", "release"]);
+        assert!(guard.is_protected("release"));
+        guard.unprotect("release");
+        assert!(!guard.is_protected("release"));
+        assert!(guard.is_protected("main")); // others unaffected
+    }
+
+    #[test]
+    fn branch_guard_check_allows_non_modifying_command() {
+        // A command that cannot modify branches is allowed without inspection.
+        let guard = BranchGuard::with_defaults();
+        assert!(guard.check("status", &[]).is_allowed());
+        assert!(guard.check("log", &["--oneline".to_string()]).is_allowed());
+    }
+
+    #[test]
+    fn branch_guard_check_push_parses_refspec_target() {
+        // A `local:remote` refspec resolves to the remote-side ref; a force push
+        // to a protected target is blocked, a non-force push is allowed.
+        let guard = BranchGuard::with_defaults();
+        let blocked = guard.check(
+            "push",
+            &[
+                "--force".to_string(),
+                "origin".to_string(),
+                "local:main".to_string(),
+            ],
+        );
+        assert!(blocked.is_blocked());
+
+        let allowed = guard.check("push", &["origin".to_string(), "local:main".to_string()]);
+        assert!(allowed.is_allowed()); // not a force push
+    }
+
+    #[test]
+    fn extract_branch_from_args_handles_all_command_shapes() {
+        use BranchGuard as BG;
+        // push: plain `remote branch` takes the second non-flag arg.
+        assert_eq!(
+            BG::extract_branch_from_args("push", &["origin".to_string(), "main".to_string()]),
+            Some("main".to_string())
+        );
+        // push: a `local:remote` refspec resolves to the remote ref (with `+`).
+        assert_eq!(
+            BG::extract_branch_from_args("push", &["origin".to_string(), "+feat:main".to_string()]),
+            Some("main".to_string())
+        );
+        // branch / checkout: first non-flag arg.
+        assert_eq!(
+            BG::extract_branch_from_args("branch", &["-d".to_string(), "old".to_string()]),
+            Some("old".to_string())
+        );
+        assert_eq!(
+            BG::extract_branch_from_args("checkout", &["feature".to_string()]),
+            Some("feature".to_string())
+        );
+        // merge / rebase: first non-flag arg.
+        assert_eq!(
+            BG::extract_branch_from_args("merge", &["topic".to_string()]),
+            Some("topic".to_string())
+        );
+        assert_eq!(
+            BG::extract_branch_from_args("rebase", &["upstream".to_string()]),
+            Some("upstream".to_string())
+        );
+        // Unknown command: nothing to extract.
+        assert_eq!(
+            BG::extract_branch_from_args("status", &["x".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn push_guard_check_allows_non_push_command() {
+        let guard = PushGuard::block_force_push();
+        assert!(guard.check("clone", &["--force".to_string()]).is_allowed());
+    }
+
+    #[test]
+    fn repo_filter_new_starts_empty_blocklist_mode() {
+        // `new()` (distinct from the `*_mode` constructors) is blocklist mode
+        // with empty lists, so everything is allowed.
+        let filter = RepoFilter::new();
+        assert!(filter.is_allowed("https://github.com/any/repo.git"));
+        assert!(RepoFilter::default().is_allowed("https://github.com/any/repo.git"));
+    }
+
+    #[test]
+    fn repo_filter_check_allows_non_remote_command() {
+        let filter = RepoFilter::blocklist_mode();
+        assert!(filter.check("status", &[]).is_allowed());
+    }
+
+    #[test]
+    fn repo_filter_check_extracts_url_from_remote_add() {
+        let mut filter = RepoFilter::blocklist_mode();
+        filter.block("github.com/blocked/*");
+        // `remote add <name> <url>` — the URL is the third argument.
+        let blocked = filter.check(
+            "remote",
+            &[
+                "add".to_string(),
+                "origin".to_string(),
+                "https://github.com/blocked/repo.git".to_string(),
+            ],
+        );
+        assert!(blocked.is_blocked());
+        // A non-`add` remote subcommand exposes no URL and is allowed.
+        let allowed = filter.check("remote", &["remove".to_string(), "origin".to_string()]);
+        assert!(allowed.is_allowed());
+    }
+
+    #[test]
+    fn repo_filter_normalises_trailing_slash_in_pattern() {
+        // A blocklist pattern with a trailing slash is normalised (slash
+        // stripped) before matching, so a repo under it is still blocked.
+        let mut filter = RepoFilter::blocklist_mode();
+        filter.block("github.com/blocked/");
+        assert!(!filter.is_allowed("https://github.com/blocked/repo.git"));
+    }
+
+    #[test]
+    fn branch_guard_default_uses_built_in_protections() {
+        // `Default` delegates to `with_defaults`.
+        let guard = BranchGuard::default();
+        assert!(guard.is_protected("main"));
+        assert!(!guard.is_protected("feature/x"));
+    }
+
+    #[test]
+    fn branch_guard_check_push_without_a_branch_is_allowed() {
+        // A push with no extractable branch falls through to Allowed.
+        let guard = BranchGuard::with_defaults();
+        assert!(guard.check("push", &[]).is_allowed());
+        // A force push whose only arg is the flag also has no branch to check.
+        assert!(guard.check("push", &["--force".to_string()]).is_allowed());
+    }
 }


### PR DESCRIPTION
## Description

Final stage of the coverage-to-100% + bug-hunt sweep. Targets
`security/guards.rs` — the branch/push guards and repository filter. Unlike the
git2_ops network arms, this is **pure in-memory logic**, so its gaps were
genuinely reachable. **Tests only — no production change.**

### Bug hunt

No bug found (the guards were bug-audited in #187). This pass closes the
unit-coverage gaps in their CLI-arg `check` paths.

### Coverage (`guards.rs` 92.00% → 99.15% lines)

Added tests for the previously-untested pure-logic paths:

- **`BranchGuard`**: `unprotect`, `Default`, `check()` for a non-modifying
  command, the `local:remote` push-refspec parse, and a push with no
  extractable branch.
- **`extract_branch_from_args`** across all command shapes (push plain/refspec,
  branch, checkout, merge, rebase, unknown).
- **`PushGuard`**: `check()` for a non-push command.
- **`RepoFilter`**: `new`/`Default`, `check()` for a non-remote command,
  `remote add <name> <url>` URL extraction, and trailing-slash pattern
  normalisation.

The remaining ~5 lines are a defensive `_ => None` arm in `extract_repo_url`
(which `check` never reaches — it only calls it for recognised remote commands)
plus brace-attribution artifacts.

## Related Issue

N/A — proactive coverage + bug-hunt sweep (final stage; follows #193–#200).

## Type of Change

- [x] Refactoring (no functional changes) — test additions only

## Security Checklist

- [x] No credentials in code, comments, or tests
- [x] No credentials in logs or error messages
- [x] No credentials in MCP responses
- [x] These tests strengthen the protected-branch / force-push / repo-filter guards (the credential-relay's policy layer)
- [x] Error messages don't leak sensitive information

## Testing

- [x] Tested locally
- [x] `cargo test --all-features --workspace` — 784 lib tests pass

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS=-Dwarnings`
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Added)

## Commit Map

- `test(guards): cover the pure-logic CLI paths` — all new tests + the CHANGELOG entry.

## Findings That Are NOT in This PR

- `extract_repo_url`'s `_ => None` arm is unreachable through `check` (which only passes recognised remote commands) — left as defensive code.
