### PR TITLE
security(auth): never log the URL username (can be a PAT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1299,6 +1299,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The credential callback logged the URL username verbatim, which can be a
+  token.** `credentials_callback` logged `username = ?username_from_url` in its
+  entry `debug!`. For HTTPS, a Personal Access Token is commonly supplied *as*
+  the username (e.g. `https://<PAT>@github.com/…`), so git2 hands the callback
+  `username_from_url = Some("<PAT>")` — and the debug line would print the token,
+  violating the "never log credentials" rule. It only fired at `debug` level (the
+  default is `warn`) and the URL itself was already sanitised, so the exposure
+  was limited, but it was a real latent leak. The callback now logs only
+  `username_present = <bool>` — enough to diagnose auth problems, never the
+  value. Regression-tested by `credentials_callback_never_logs_a_token_username`,
+  which runs the callback under a live DEBUG subscriber and asserts the token
+  never appears in the captured output, plus `sanitize_url_strips_token_used_as_username`
+  for the URL-sanitiser equivalent. (Audit scope: every credential-adjacent
+  logging site was reviewed — the password parser, the `git credential fill`
+  error arms, and the `from_fetch`/`from_push` error redaction are all clean;
+  this username log was the only leak.)
 - **Force pushes to protected branches were not blocked when force push was
   globally enabled.** `repo_push` called `BranchGuard::check("push", &[branch])`,
   but that CLI-arg form expects a full `git push` argument vector: given only a

--- a/src/git2_ops/auth.rs
+++ b/src/git2_ops/auth.rs
@@ -133,9 +133,13 @@ fn credentials_callback(
     username_from_url: Option<&str>,
     allowed_types: CredentialType,
 ) -> Result<Cred, git2::Error> {
+    // Log only whether a username was present, never its value. For HTTPS a
+    // token is commonly supplied as the username (e.g. `https://<PAT>@host`),
+    // so `username_from_url` can itself be a secret — logging it verbatim would
+    // leak the credential at debug level. The URL is sanitised the same way.
     debug!(
         url = %sanitize_url_for_logging(url),
-        username = ?username_from_url,
+        username_present = username_from_url.is_some(),
         allowed_types = ?allowed_types,
         "credential callback invoked"
     );
@@ -931,5 +935,76 @@ mod tests {
         let sanitized = sanitize_url_for_logging(url);
         assert!(!sanitized.contains("tok"));
         assert!(sanitized.contains("***@gitlab.example.com:8443/group/project.git"));
+    }
+
+    #[test]
+    fn sanitize_url_strips_token_used_as_username() {
+        // A GitHub PAT supplied as the username (no password) — a common
+        // pattern (`https://<PAT>@github.com/...`). The whole userinfo, token
+        // included, must be replaced with `***`.
+        let url = "https://ghp_REALLOOKINGSECRET1234567890@github.com/owner/repo.git";
+        let sanitized = sanitize_url_for_logging(url);
+        assert!(!sanitized.contains("ghp_REALLOOKINGSECRET1234567890"));
+        assert!(!sanitized.contains("REALLOOKINGSECRET"));
+        assert_eq!(sanitized, "https://***@github.com/owner/repo.git");
+    }
+
+    /// Minimal [`std::io::Write`] that appends to a shared buffer so a test can
+    /// capture `tracing` output and assert credentials never appear in it.
+    #[derive(Clone)]
+    struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn credentials_callback_never_logs_a_token_username() {
+        // Defence-in-depth regression: with a DEBUG subscriber active, the
+        // credential callback's entry log must NOT contain a token supplied as
+        // the URL username. `CredentialType::empty()` is used so no real
+        // credential method is attempted (no ssh-agent / credential-helper /
+        // network), isolating the test to the logging path.
+        let token = "ghp_REALLOOKINGSECRET1234567890";
+        let url = format!("https://{token}@github.com/owner/repo.git");
+
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = buffer.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(move || CaptureWriter(sink.clone()))
+            .finish();
+
+        let result = tracing::subscriber::with_default(subscriber, || {
+            credentials_callback(&url, Some(token), CredentialType::empty())
+        });
+        // No credential method was allowed, so the callback reports failure.
+        assert!(result.is_err());
+
+        let logged = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+        assert!(
+            logged.contains("credential callback invoked"),
+            "entry log should have been emitted; got: {logged}"
+        );
+        assert!(
+            !logged.contains(token) && !logged.contains("REALLOOKINGSECRET"),
+            "token leaked into the credential-callback log: {logged}"
+        );
+        // The sanitised host is still logged for diagnostics.
+        assert!(logged.contains("github.com"));
+
+        // The fmt layer is line-buffered and may never call the writer's
+        // `flush`, so exercise it directly to confirm it is a clean no-op.
+        std::io::Write::flush(&mut CaptureWriter(buffer)).unwrap();
     }
 }


### PR DESCRIPTION
## Description

Credential-leak hardening of the most safety-sensitive path. Re-audited every
credential-adjacent logging / error / response site for a leak bug, **found and
fixed one**, and added adversarial regression tests proving credentials never
escape into logs.

### The leak (fixed)

`git2_ops::auth::credentials_callback` logged `username = ?username_from_url` in
its entry `debug!`. For HTTPS, a Personal Access Token is commonly supplied **as
the username** (`https://<PAT>@github.com/…`), so git2 hands the callback
`username_from_url = Some("<PAT>")` — and that debug line would print the token,
violating the project's "never log credentials" rule.

- **Scope of exposure:** limited — it only fired at `debug` level (the default is
  `warn`), and the URL itself was already passed through `sanitize_url_for_logging`.
  But it was a genuine latent leak of a credential into a log.
- **Fix:** log only `username_present = <bool>`. That still lets an operator
  diagnose "did the URL carry a username?" without ever recording the value.

### Audit result (the rest is clean)

I read every place a credential could reach a log, error, or MCP response:

- `get_credentials_for_url` / `parse_credential_output` — parse the password but
  **never log it**; the `git credential fill` error arms log exit codes / UTF-8
  errors, never stdout.
- `sanitize_url_for_logging` — authority-scoped `rfind('@')`, strips the whole
  userinfo (incl. token-as-username); preserved by tests.
- `Git2Error::from_fetch` / `from_push` / `sanitize_error_message` — redact
  `scheme://user:secret@host` userinfo from git2 error messages.
- No `Cred` object is ever logged or serialised.

This username log was the **only** leak.

### Tests

- `credentials_callback_never_logs_a_token_username` — runs the callback under a
  live DEBUG subscriber (capturing output to a buffer) and asserts the token
  never appears, while the sanitised host still does. Also covers the entry-log
  line.
- `sanitize_url_strips_token_used_as_username` — the URL-sanitiser equivalent
  (`https://<PAT>@github.com/…` → `https://***@github.com/…`).

## Related Issue

N/A — proactive credential-safety hardening.

## Type of Change

- [x] Security improvement
- [x] Bug fix (non-breaking) — stops a debug-level credential leak

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests (the test token is a fake `ghp_REALLOOKINGSECRET…` literal)
- [x] No credentials appear in log messages or error messages — **this PR fixes the one place that did**, and adds a test that fails if it regresses
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted
- [x] Error messages don't leak sensitive information

## Testing

- [x] Tested locally
- [x] Added a regression test that captures DEBUG logs and asserts no token leaks
- [x] `cargo test --all-features --workspace` — 786 lib tests pass

## Code Quality

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS=-Dwarnings`
- [x] `markdownlint-cli2 "**/*.md"` (0 errors)
- [x] `bash .github/scripts/check-toolchain-pin.sh`
- [x] CHANGELOG.md updated (Security)

## Commit Map

- `security(auth): never log the URL username (can be a token)` — the one-line fix, the audit note, and the two regression tests.

## Findings That Are NOT in This PR

- The credential **retrieval/selection** branches in `credentials_callback` (ssh-agent, credential-helper) and the `git credential fill` subprocess error arms remain unit-uncovered: they need a real agent / OS credential helper / failing subprocess, and the credential-helper path is deliberately not unit-tested so the suite never triggers an interactive OS credential prompt. They are credential-**retrieval** paths (they hand a `Cred` to git2 or return `None`) and carry **no leak risk** — none of them log the credential. A follow-up could make the *selection* logic 100%-testable via provider injection (a behaviour-preserving refactor of the callback); flagged for a separate review since it touches the credential code.
