### PR TITLE
test: close unit-coverage gaps in dispatch loop and archive/submodule edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Unit-coverage top-ups for the JSON-RPC dispatch loop and three
+  archive/submodule edge cases** (no production change). Added tests for
+  previously-unit-uncovered paths that need neither real network access nor
+  OS-failure injection:
+    - `mcp::server` — four `#[tokio::test]`s drive `handle_transport_result`
+      with a non-empty line carrying a `ping` request, an unknown-method
+      request, malformed JSON, and a notification. Together they cover the
+      `handle_line` / `handle_message` / `handle_request` dispatch plumbing
+      (request-versus-notification routing, the `ping` and method-not-found
+      arms, and both the response and error write paths) that was previously
+      exercised only by the Python integration suite. `server.rs` line
+      coverage rose from 91.27 % to 93.42 %.
+    - `git2_ops::pull` — `create_files_archive_includes_nested_file` archives a
+      file inside a subdirectory, covering the non-blob (subtree) skip and the
+      nested-path `format!("{dir}{name}")` branch that the top-level-only tests
+      miss.
+    - `streaming::tar` — `create_tar_keeps_unparseable_lfs_pointer_verbatim` (a
+      blob whose first line is the v1 version line but which has no `oid`/`size`,
+      so `is_lfs_pointer` is true yet `parse_lfs_pointer` is None — the blob is
+      archived verbatim with no Batch API call) and
+      `create_tar_skips_blob_with_missing_object` (a hand-written tree whose
+      blob entry points at a missing OID, so `find_blob` fails and the blob is
+      logged-and-skipped while the archive still finishes). `tar.rs` 97.46 % ->
+      97.83 %.
+    - `git2_ops::submodule` — `fetch_all_submodules_skips_duplicate_url_cycle`
+      gives two submodules at different paths the same URL, so the second hits
+      the visited-URL cycle-detection warn-and-skip arm in the recursive
+      fetcher (the existing test only exercised the pure `normalise_url_for_cycle_detection`
+      helper). `submodule.rs` 94.19 % -> 94.63 %.
+  Total local unit line coverage rose from 95.92 % to 96.36 %.
 - **`security::guards` coverage top-ups.** Added unit tests for the
   previously-untested pure-logic paths in the (security-critical) guards:
   `BranchGuard::unprotect` and `Default`; the `SecurityGuard::check` CLI-arg

--- a/src/git2_ops/pull.rs
+++ b/src/git2_ops/pull.rs
@@ -688,13 +688,27 @@ mod tests {
         let tree = repo.find_tree(tree_oid).unwrap();
         let files = vec!["sub/nested.txt".to_string()];
         let archive = create_files_archive(&repo, &tree, &files).unwrap();
-        // The nested file matched and was archived, so the result is a real
-        // (non-trivial) tar.gz, larger than the empty envelope.
-        assert!(
-            archive.len() >= 100,
-            "expected a non-empty archive with the nested file, got {} bytes",
-            archive.len()
-        );
+
+        // Decode the archive and confirm the nested file is present with its
+        // content. This proves the walk descended into the subtree and joined
+        // the nested path (rather than relying on a brittle compressed-size
+        // threshold).
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&archive)
+            .unwrap();
+        let mut tar = tar::Archive::new(flate2::read::GzDecoder::new(&bytes[..]));
+        let mut found = false;
+        for entry in tar.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            if path == "sub/nested.txt" {
+                found = true;
+                let mut content = String::new();
+                std::io::Read::read_to_string(&mut entry, &mut content).unwrap();
+                assert_eq!(content, "nested content\n");
+            }
+        }
+        assert!(found, "the nested file should be present in the archive");
     }
 
     /// Builds a `file://` URL for a local path (Windows-friendly).

--- a/src/git2_ops/pull.rs
+++ b/src/git2_ops/pull.rs
@@ -665,6 +665,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn create_files_archive_includes_nested_file() {
+        // A file inside a subdirectory exercises the two branches the
+        // top-level-only tests miss: the non-blob (subtree) entry is skipped,
+        // and the matching blob's path is built via the `format!("{dir}{name}")`
+        // nested-path branch rather than the bare-name branch.
+        let temp = tempfile::TempDir::new().unwrap();
+        let tree_oid = {
+            let repo = Repository::init_bare(temp.path()).unwrap();
+            let blob = repo.blob(b"nested content\n").unwrap();
+            let sub_tree = {
+                let mut sub = repo.treebuilder(None).unwrap();
+                sub.insert("nested.txt", blob, 0o100_644).unwrap();
+                sub.write().unwrap()
+            };
+            let mut root = repo.treebuilder(None).unwrap();
+            root.insert("sub", sub_tree, 0o040_000).unwrap();
+            root.write().unwrap()
+        };
+        let repo = Repository::open_bare(temp.path()).unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let files = vec!["sub/nested.txt".to_string()];
+        let archive = create_files_archive(&repo, &tree, &files).unwrap();
+        // The nested file matched and was archived, so the result is a real
+        // (non-trivial) tar.gz, larger than the empty envelope.
+        assert!(
+            archive.len() >= 100,
+            "expected a non-empty archive with the nested file, got {} bytes",
+            archive.len()
+        );
+    }
+
     /// Builds a `file://` URL for a local path (Windows-friendly).
     fn local_file_url(path: &std::path::Path) -> String {
         let raw = path.display().to_string();

--- a/src/git2_ops/submodule.rs
+++ b/src/git2_ops/submodule.rs
@@ -1271,4 +1271,48 @@ mod tests {
         let result = fetch_all_submodules(&repo, commit, None, 1, 3, 4, &filter).unwrap();
         assert!(result.is_empty());
     }
+
+    #[test]
+    fn fetch_all_submodules_skips_duplicate_url_cycle() {
+        // Two submodules at different paths share one URL. In the filter phase
+        // the first inserts its URL into the visited set and becomes eligible
+        // (then fails fast against 127.0.0.1:1); the second's insert returns
+        // false, so it hits the cycle-detection warn-and-skip arm before any
+        // fetch is attempted. Net result: nothing fetched.
+        let temp = tempfile::TempDir::new().unwrap();
+        let url = "https://127.0.0.1:1/shared.git";
+        let commit = {
+            let repo = Repository::init_bare(temp.path()).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+
+            // A commit to serve as the gitlink target for both submodules.
+            let blob = repo.blob(b"x\n").unwrap();
+            let mut leaf = repo.treebuilder(None).unwrap();
+            leaf.insert("f.txt", blob, 0o100_644).unwrap();
+            let leaf_tree = repo.find_tree(leaf.write().unwrap()).unwrap();
+            let target = repo
+                .commit(None, &sig, &sig, "sub commit", &leaf_tree, &[])
+                .unwrap();
+
+            let gm = format!(
+                "[submodule \"a\"]\n\tpath = a\n\turl = {url}\n\
+                 [submodule \"b\"]\n\tpath = b\n\turl = {url}\n"
+            );
+            let gm_blob = repo.blob(gm.as_bytes()).unwrap();
+
+            let mut root = repo.treebuilder(None).unwrap();
+            root.insert("a", target, SUBMODULE_MODE).unwrap();
+            root.insert("b", target, SUBMODULE_MODE).unwrap();
+            root.insert(".gitmodules", gm_blob, 0o100_644).unwrap();
+            let root_tree = repo.find_tree(root.write().unwrap()).unwrap();
+            repo.commit(None, &sig, &sig, "root", &root_tree, &[])
+                .unwrap()
+        };
+        let repo = Repository::open_bare(temp.path()).unwrap();
+        let filter = SubmoduleFilter::new(None, None);
+        // max_failures high enough that the one failed fetch doesn't abort the
+        // run before the second (duplicate) entry is considered.
+        let result = fetch_all_submodules(&repo, commit, None, 1, 3, 4, &filter).unwrap();
+        assert!(result.is_empty());
+    }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2644,4 +2644,64 @@ mod tests {
         // A blank line does not advance the lifecycle.
         assert_eq!(server.state(), ServerState::AwaitingInit);
     }
+
+    #[tokio::test]
+    async fn handle_transport_result_dispatches_request_and_continues() {
+        let mut server = create_test_server();
+        // A non-empty line carrying a valid `ping` request routes through
+        // handle_line -> handle_message -> handle_request -> the ping dispatch
+        // arm, and a response is written. `ping` needs no prior initialise, so
+        // the post-dispatch state check sees AwaitingInit and continues.
+        let line = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#.to_string();
+        let outcome = server
+            .handle_transport_result(Ok(Some(line)))
+            .await
+            .unwrap();
+        assert!(outcome.is_none());
+        assert_eq!(server.state(), ServerState::AwaitingInit);
+    }
+
+    #[tokio::test]
+    async fn handle_transport_result_writes_error_for_unknown_method() {
+        let mut server = create_test_server();
+        // A well-formed request for an unknown method parses successfully but
+        // hits the method-not-found dispatch arm, which writes a JSON-RPC error
+        // rather than a response.
+        let line = r#"{"jsonrpc":"2.0","id":2,"method":"no/such/method"}"#.to_string();
+        let outcome = server
+            .handle_transport_result(Ok(Some(line)))
+            .await
+            .unwrap();
+        assert!(outcome.is_none());
+        assert_eq!(server.state(), ServerState::AwaitingInit);
+    }
+
+    #[tokio::test]
+    async fn handle_transport_result_writes_error_for_malformed_json() {
+        let mut server = create_test_server();
+        // A non-empty line that is not valid JSON makes parse_message return
+        // Err, which handle_line writes back as a JSON-RPC parse error.
+        let line = "{ this is not valid json".to_string();
+        let outcome = server
+            .handle_transport_result(Ok(Some(line)))
+            .await
+            .unwrap();
+        assert!(outcome.is_none());
+        assert_eq!(server.state(), ServerState::AwaitingInit);
+    }
+
+    #[tokio::test]
+    async fn handle_transport_result_processes_notification() {
+        let mut server = create_test_server();
+        // A message with no `id` is a notification, routing through the
+        // Notification arm of handle_message. An unknown notification is
+        // ignored without changing state and without writing a response.
+        let line = r#"{"jsonrpc":"2.0","method":"some/notification"}"#.to_string();
+        let outcome = server
+            .handle_transport_result(Ok(Some(line)))
+            .await
+            .unwrap();
+        assert!(outcome.is_none());
+        assert_eq!(server.state(), ServerState::AwaitingInit);
+    }
 }

--- a/src/streaming/tar.rs
+++ b/src/streaming/tar.rs
@@ -1391,6 +1391,68 @@ mod tests {
     }
 
     #[test]
+    fn create_tar_keeps_unparseable_lfs_pointer_verbatim() {
+        // A blob whose first line is exactly the v1 version line (so
+        // `is_lfs_pointer` is true) but which lacks the `oid`/`size` fields (so
+        // `parse_lfs_pointer` returns None). With an LFS client created (valid
+        // https repo_url), the Batch API is never called — the malformed pointer
+        // is archived verbatim. Exercises the is-pointer-but-unparseable arm.
+        let temp = tempfile::TempDir::new().unwrap();
+        let commit_oid = {
+            let repo = Repository::init_bare(temp.path()).unwrap();
+            let blob = repo
+                .blob(b"version https://git-lfs.github.com/spec/v1\n")
+                .unwrap();
+            let mut tb = repo.treebuilder(None).unwrap();
+            tb.insert("not-a-real-pointer.bin", blob, 0o100_644)
+                .unwrap();
+            let tree = repo.find_tree(tb.write().unwrap()).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "bad pointer", &tree, &[])
+                .unwrap()
+        };
+        let repo = open_test_repo(&temp);
+        let opts = TarOptions {
+            resolve_lfs: Some(true),
+            repo_url: Some("https://github.com/owner/repo.git".to_string()),
+            ..Default::default()
+        };
+        let result = create_tar_from_tree_with_options(&repo, commit_oid, Some(opts)).unwrap();
+        assert_eq!(result.lfs_resolved, 0);
+        assert_eq!(
+            result.lfs_failed, 0,
+            "unparseable pointer is not a fetch failure"
+        );
+        assert_eq!(result.file_count, 1, "the file is archived verbatim");
+    }
+
+    #[test]
+    fn create_tar_skips_blob_with_missing_object() {
+        // Hand-write a tree with a blob entry pointing at a missing (all-zero)
+        // OID, bypassing treebuilder's existence validation. The walk visits the
+        // entry (a top-level blob needs no subtree descent), but `find_blob`
+        // then fails — exercising the Err arm that logs and skips the blob while
+        // the archive still finishes.
+        let temp = tempfile::TempDir::new().unwrap();
+        let commit_oid = {
+            let repo = Repository::init_bare(temp.path()).unwrap();
+            let odb = repo.odb().unwrap();
+            let mut tree_bytes = Vec::new();
+            tree_bytes.extend_from_slice(b"100644 missing.txt\0");
+            tree_bytes.extend_from_slice(&[0u8; 20]);
+            let tree_oid = odb.write(git2::ObjectType::Tree, &tree_bytes).unwrap();
+            let tree = repo.find_tree(tree_oid).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "missing blob", &tree, &[])
+                .unwrap()
+        };
+        let repo = open_test_repo(&temp);
+        let result = create_tar_from_tree(&repo, commit_oid).unwrap();
+        assert_eq!(result.file_count, 0, "the unreadable blob is skipped");
+        assert!(!result.data.is_empty(), "the archive still finishes");
+    }
+
+    #[test]
     fn tar_mode_for_filemode_maps_correctly() {
         // Regular files keep their permission bits; a symlink (0o120000) has
         // none and must fall back to a readable 0o644 rather than 0o000.


### PR DESCRIPTION
## Description

Stage 1 of the coverage-improvement plan: small, fully-local unit top-ups for paths that `cargo llvm-cov` (unit-only) reported as uncovered but which need neither real network access nor OS-failure injection. All five additions are test-only — **no production code changes** (228 insertions, 0 deletions).

The most valuable addition exercises the **JSON-RPC dispatch loop** (`handle_line` → `handle_message` → `handle_request`), the heart of the server, which until now was driven only by the Python end-to-end suite and so showed as unit-uncovered.

| Module | New test(s) | Closes |
|--------|-------------|--------|
| `mcp::server` | `handle_transport_result_{dispatches_request_and_continues, writes_error_for_unknown_method, writes_error_for_malformed_json, processes_notification}` | request/notification routing + ping + method-not-found + response/error write paths (91.27% → 93.42% lines) |
| `git2_ops::pull` | `create_files_archive_includes_nested_file` | non-blob (subtree) skip + nested-path `format!("{dir}{name}")` branch |
| `streaming::tar` | `create_tar_keeps_unparseable_lfs_pointer_verbatim`, `create_tar_skips_blob_with_missing_object` | is-pointer-but-unparseable arm + `find_blob` failure arm (97.46% → 97.83%) |
| `git2_ops::submodule` | `fetch_all_submodules_skips_duplicate_url_cycle` | visited-URL cycle-detection warn-and-skip arm in the recursive fetcher (94.19% → 94.63%) |

Total local unit line coverage: **95.92% → 96.36%**.

## Related Issue

N/A — proactive coverage improvement (Stage 1 of a 3-stage plan).

## Type of Change

- [x] Refactoring (no functional changes) — test-only additions

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted
- [x] Error messages don't leak sensitive information

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove the covered paths behave as documented
- [x] New and existing tests pass (`cargo test --all-features --workspace`: 794 lib + all integration crates green)

## Code Quality

- [x] Code compiles without warnings
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all --check`)
- [x] Markdown is lint-clean (`markdownlint-cli2 "**/*.md"`)
- [x] Toolchain pin is consistent (`bash .github/scripts/check-toolchain-pin.sh`)
- [x] Documentation is updated if needed (CHANGELOG `[Unreleased]`)
- [x] CHANGELOG.md is updated

## Additional Notes

**One known tradeoff:** the four `mcp::server` `#[tokio::test]`s drive the real `StdioTransport`, which writes responses/errors to fd 1 (`tokio::io::stdout()`). libtest's capture only intercepts `print!`-family macros, not direct fd-1 writes, so a normal `cargo test` run emits a few short `{"jsonrpc":...}` lines into the captured test output. It is purely cosmetic (tiny payloads, no blocking, no failure) and is the only way to cover the `write_response`/`write_error` lines without adding a transport-injection seam to `McpServer`. If preferred, a follow-up could add such a seam to silence it.

### Findings That Are NOT in This PR

- **Stage 2 (integration):** repo allow/blocklist enforcement E2E, Tier 2 `repo_clone_start` with `resolve_lfs`/`sparse`/`exclude_binary`, and a `repo_clone_chunk` out-of-range-index test.
- **Stage 3 (integration + fixture):** submodule `include`/`exclude`/`depth` filtering and the nested child-recursion arm (`submodule.rs` 558–573), which needs a second-level submodule added to `rebuild_fixture.py`.
- **Deliberately left uncovered** (inherent): credential-helper / ssh-agent / `git credential fill` subprocess branches, OS-level I/O failure arms, defensive `remote_anonymous`/unreachable fallbacks, `tracing` macro field-expansion artifacts, and the signal/stdin async run-loop — all integration-covered or not portably forceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)