### PR TITLE
test(integration): end-to-end repo allow/blocklist enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **End-to-end repo allow/blocklist enforcement tests.** New
+  `test_repo_filter_enforcement` in the Python integration suite spins up
+  servers configured with (1) a `repo_blocklist` host pattern — which refuses
+  the fixture clone before any network access; (2) a `repo_allowlist` that does
+  not match the fixture — refused (deny by default); and (3) an allowlist that
+  does match — permitted, and the clone succeeds. This exercises the server's
+  filter wiring (`RepoFilter` in the clone dispatch) end to end, which was
+  previously covered only at the unit level despite that wiring being exactly
+  where the earlier `repo_diff`-bypass bug lived. The harness's `McpTestClient`
+  now takes an optional per-client `log_path` so these auxiliary servers do not
+  clobber the shared server log. No production change.
 - **Unit-coverage top-ups for the JSON-RPC dispatch loop and three
   archive/submodule edge cases** (no production change). Added tests for
   previously-unit-uncovered paths that need neither real network access nor

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -88,9 +88,14 @@ TEST_CONFIG = {
 class McpTestClient:
     """Manages an MCP server subprocess and sends JSON-RPC requests."""
 
-    def __init__(self, binary, config_path):
+    def __init__(self, binary, config_path, log_path=SERVER_LOG_PATH):
         self.binary = binary
         self.config_path = config_path
+        # Each client logs to its own file. The shared client uses the default
+        # SERVER_LOG_PATH; auxiliary servers (e.g. the repo-filter enforcement
+        # checks, which need a differently-configured server) pass a distinct
+        # path so they do not truncate or interleave with the shared log.
+        self.log_path = log_path
         self.process = None
         self.log_file = None
         self.request_id = 0
@@ -98,7 +103,7 @@ class McpTestClient:
     def start(self):
         """Start the MCP server subprocess."""
         os.makedirs(LOG_DIR, exist_ok=True)
-        self.log_file = open(SERVER_LOG_PATH, "w", encoding="utf-8")
+        self.log_file = open(self.log_path, "w", encoding="utf-8")
         try:
             self.process = subprocess.Popen(
                 [self.binary, "--config", self.config_path],
@@ -114,7 +119,7 @@ class McpTestClient:
 
         if self.process.poll() is not None:
             self.log_file.close()
-            with open(SERVER_LOG_PATH, encoding="utf-8") as f:
+            with open(self.log_path, encoding="utf-8") as f:
                 log_content = f.read()
             raise RuntimeError(f"Server failed to start:\n{log_content}")
 
@@ -1781,6 +1786,90 @@ def test_clone_without_lfs_keeps_pointer(client, runner):
     )
 
 
+def _clone_with_security(security_overrides, tag):
+    """Spawn a fresh server with the shared `TEST_CONFIG` plus the given
+    `security` overrides, complete the handshake, and attempt to clone the
+    fixture.
+
+    Returns the parsed `repo_clone` result: a dict on success, or the
+    ``{"_error": ..., "_isError": True}`` shape on a tool error. Used to
+    exercise repo allow/blocklist enforcement, which needs a server configured
+    differently from the shared one.
+    """
+    cfg = dict(TEST_CONFIG)
+    cfg["security"] = {**TEST_CONFIG["security"], **security_overrides}
+    cfg_path = os.path.join(LOG_DIR, f"config-{tag}.json")
+    with open(cfg_path, "w", newline="\n", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=4)
+
+    client = McpTestClient(
+        BINARY, cfg_path, log_path=os.path.join(LOG_DIR, f"server-{tag}.log")
+    )
+    try:
+        client.start()
+        client.send(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "integration-test", "version": "1.0.0"},
+            },
+        )
+        client.notify("notifications/initialized")
+        time.sleep(0.5)
+        return client.call_tool(
+            "repo_clone", {"url": REPO_URL, "branch": "main", "depth": 1}
+        )
+    finally:
+        client.stop()
+
+
+def test_repo_filter_enforcement(runner):
+    """Repo allow/blocklist enforcement, end to end.
+
+    The shared server runs with both lists null (no filtering). These checks
+    spin up servers configured with a blocklist or an allowlist and confirm the
+    policy is enforced at the tool boundary — a path the unit tests cannot
+    reach, because it depends on the server wiring the filter into the clone
+    dispatch (the same wiring that once let `repo_diff` slip past the filter).
+    """
+    print()
+    print("=== Test: repo allow/blocklist enforcement ===")
+
+    host = urlsplit(REPO_URL).hostname
+
+    # Blocklist mode: a pattern matching the fixture's host refuses the clone
+    # before any network access.
+    blocked = _clone_with_security({"repo_blocklist": [f"{host}/*"]}, "blocklist")
+    runner.check(
+        blocked.get("_isError") is True
+        and "is not allowed by policy" in blocked.get("_error", ""),
+        "blocklisted repo is refused",
+        actual=blocked.get("_error", blocked),
+    )
+
+    # Allowlist mode with a non-matching pattern: the fixture is not on the
+    # allowlist, so it is refused (deny by default).
+    denied = _clone_with_security(
+        {"repo_allowlist": ["example.invalid/*"]}, "allowlist-deny"
+    )
+    runner.check(
+        denied.get("_isError") is True
+        and "is not allowed by policy" in denied.get("_error", ""),
+        "repo absent from allowlist is refused",
+        actual=denied.get("_error", denied),
+    )
+
+    # Allowlist mode with a matching pattern: the fixture is permitted and the
+    # clone actually succeeds.
+    allowed = _clone_with_security({"repo_allowlist": [f"{host}/*"]}, "allowlist-permit")
+    runner.check(
+        not allowed.get("_isError", False) and "commit" in allowed,
+        "allowlisted repo is permitted and clones",
+        actual=allowed.get("_error", allowed.get("commit")),
+    )
+
+
 def main():
     """Run all integration tests against the MCP server."""
     if not REPO_URL:
@@ -1820,6 +1909,10 @@ def main():
         # Push tests.
         test_repo_push(client, runner, refs_content)
         test_push_protected_branch(client, runner, refs_content)
+
+        # Security-policy tests (each spins up its own differently-configured
+        # server, so they take only `runner`).
+        test_repo_filter_enforcement(runner)
 
         # Advanced feature tests.
         test_multi_chunk_streaming(client, runner)


### PR DESCRIPTION
## Description

Stage 2 of the coverage-improvement plan: add **end-to-end** coverage for repo allow/blocklist enforcement. The filter was previously verified only by unit tests, but the path that actually matters — the server wiring that applies `RepoFilter` in the tool dispatch — had no integration coverage. That wiring is exactly where the historical `repo_diff`-bypass bug lived (a tool reached the network without consulting the filter), so an end-to-end guard is worth having.

`test_repo_filter_enforcement` spins up purpose-configured servers and asserts:

| Config | Expectation |
|--------|-------------|
| `repo_blocklist: ["<host>/*"]` | fixture clone **refused** before any network access (`...is not allowed by policy`) |
| `repo_allowlist: ["example.invalid/*"]` | fixture **refused** — deny by default (not on the allowlist) |
| `repo_allowlist: ["<host>/*"]` | fixture **permitted**, the clone succeeds |

The host pattern is derived from `TEST_REPO_URL` so nothing repo-specific is hard-coded. `McpTestClient` gains an optional per-client `log_path` so these auxiliary servers write to their own logs instead of truncating/interleaving the shared `server.log`.

## Related Issue

N/A — Stage 2 of a 3-stage coverage initiative (Stage 1 = #203, merged).

## Type of Change

- [x] Refactoring (no functional changes) — test-only additions (+ a backward-compatible harness parameter)

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets are included in code, comments, or tests
- [x] No credentials appear in log messages or error messages
- [x] No credentials are exposed in MCP responses
- [x] Credentials are scoped to their operation, not cached or persisted
- [x] Error messages don't leak sensitive information

## Testing

- [x] `py -3 -m py_compile tests/integration/test_mcp_tools.py` passes
- [x] `markdownlint-cli2 "**/*.md"` clean
- [ ] **Integration suite runs on CI only** — it needs the private fixture repo + credentials + a Linux runner (the harness uses `select.select` on pipes, which does not work on Windows), so it cannot be executed on the author's machine. CI's `coverage` job is the validating run for this PR.

## Code Quality

- [x] Python follows `STYLE.md` (4-space indent, double quotes, explicit `encoding="utf-8"`, docstrings, stdlib only)
- [x] Documentation is updated if needed (CHANGELOG `[Unreleased]`)
- [x] CHANGELOG.md is updated

## Additional Notes

This is the first integration test that runs a server with a non-default config, hence the `log_path` parameter. The blocklist/allowlist-deny cases fail at the policy stage (no network); only the allowlist-permit case performs a real fixture clone.

### Findings That Are NOT in This PR

- **Stage 3 (integration + fixture):** submodule `include`/`exclude`/`depth` filtering and the nested child-recursion arm (`submodule.rs` 558–573), which needs a second-level submodule added to `rebuild_fixture.py`.
- **Deferred from Stage 2 (lower value):** Tier 2 `repo_clone_start` with `resolve_lfs`/`sparse`/`exclude_binary`, and a `repo_clone_chunk` out-of-range-index test. Can fold into a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)