### PR TITLE
test(integration): self-calibrating submodule include/exclude/depth filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **End-to-end submodule include/exclude/depth filtering test.** New
+  `test_clone_submodule_filtering` in the Python integration suite clones the
+  fixture with `include_submodules: true` and asserts that a matching
+  `submodule_exclude`, a non-matching `submodule_include`, and
+  `submodule_depth: 0` each reduce the number of submodules attempted to zero.
+  Because bare-repo submodule detection is environment-dependent (the existing
+  `test_clone_with_submodules` already tolerates a zero-detected outcome), the
+  test self-calibrates: it first clones with no filter to learn whether the
+  fixture's submodule is attempted at all, and skips the filter assertions with
+  a NOTE (rather than asserting vacuously) when detection reports none. The
+  nested child-submodule recursion arm is intentionally not covered — it
+  requires a submodule whose own repository contains a submodule, which the
+  fixture's external, uncontrolled submodule target cannot provide. No
+  production change.
 - **End-to-end repo allow/blocklist enforcement tests.** New
   `test_repo_filter_enforcement` in the Python integration suite spins up
   servers configured with (1) a `repo_blocklist` host pattern — which refuses

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -999,6 +999,77 @@ def test_clone_without_submodules(client, runner):
     )
 
 
+def test_clone_submodule_filtering(client, runner):
+    """Submodule include/exclude/depth filtering, end to end.
+
+    Submodule detection in the bare-repo clone path is environment-dependent
+    (see test_clone_with_submodules — some git2/libgit2 builds report no
+    submodules at all). So this first clones with no filter to learn whether
+    the fixture's `vendor/mustache` submodule is attempted. If it is, each
+    filter must drive the attempt count back to zero; if detection finds none,
+    the filter checks are skipped with a NOTE rather than asserting vacuously.
+
+    The nested child-submodule recursion arm is intentionally not covered here:
+    it needs a submodule whose own repository contains a submodule, which the
+    fixture's external, uncontrolled submodule target cannot provide.
+    """
+    print()
+    print("=== Test: submodule include/exclude/depth filtering ===")
+
+    def attempted(**extra):
+        """Clone main with submodules enabled plus `extra` args; return the
+        number of submodules attempted (included + failed), or None on error."""
+        args = {
+            "url": REPO_URL,
+            "branch": "main",
+            "depth": 1,
+            "include_submodules": True,
+        }
+        args.update(extra)
+        content = client.call_tool("repo_clone", args)
+        if content.get("_isError"):
+            return None
+        return content.get("submodules_included", 0) + content.get(
+            "submodules_failed", 0
+        )
+
+    baseline = attempted()
+    if baseline is None:
+        runner.check(False, "baseline submodule clone succeeded", actual="error")
+        return
+    if baseline == 0:
+        print("  NOTE: no submodules detected in clone path — filter checks skipped")
+        runner.check(True, "submodule detection unavailable; filter checks skipped")
+        return
+
+    # Exclude the matching submodule -> nothing attempted.
+    excl = attempted(submodule_exclude=["vendor/mustache"])
+    runner.check(
+        excl == 0,
+        "submodule_exclude removes the matching submodule",
+        actual=excl,
+        expected=0,
+    )
+
+    # An allowlist that does not match the submodule path -> nothing attempted.
+    inc = attempted(submodule_include=["nonexistent/*"])
+    runner.check(
+        inc == 0,
+        "non-matching submodule_include removes the submodule",
+        actual=inc,
+        expected=0,
+    )
+
+    # submodule_depth=0 skips submodule processing entirely.
+    depth0 = attempted(submodule_depth=0)
+    runner.check(
+        depth0 == 0,
+        "submodule_depth=0 skips submodules",
+        actual=depth0,
+        expected=0,
+    )
+
+
 def test_force_push(client, runner, refs_content):
     """Test that force push is rejected when allow_force_push=false."""
     print()
@@ -1918,6 +1989,7 @@ def main():
         test_multi_chunk_streaming(client, runner)
         test_clone_with_submodules(client, runner)
         test_clone_without_submodules(client, runner)
+        test_clone_submodule_filtering(client, runner)
         test_force_push(client, runner, refs_content)
         test_clone_exclude_binary(client, runner)
         test_concurrent_sessions(client, runner)


### PR DESCRIPTION
## Description

Stage 3 of the coverage-improvement plan: end-to-end coverage for the **submodule filtering** tool arguments (`submodule_include` / `submodule_exclude` / `submodule_depth`), which were previously exercised only by `SubmoduleFilter` unit tests.

`test_clone_submodule_filtering` clones the fixture with `include_submodules: true` and asserts that each of the following drives the attempted-submodule count to zero:

| Filter | Effect |
|--------|--------|
| `submodule_exclude: ["vendor/mustache"]` | the matching submodule is excluded (before any fetch) |
| `submodule_include: ["nonexistent/*"]` | allowlist that doesn't match → submodule excluded |
| `submodule_depth: 0` | submodule processing skipped entirely |

### Two honest constraints (please read)

**1. The test is self-calibrating, not vacuous.** Bare-repo submodule *detection* is environment-dependent — the existing `test_clone_with_submodules` already tolerates an `included=0, failed=0` outcome ("submodule detection may not find `.gitmodules` in all git2/libgit2 configurations"), and the project's own notes record that detection can return 0 in bare repos. Since `repo_clone` always uses bare repos, a naive "excluded → 0" assertion could pass trivially. So the test **first clones with no filter** to see whether the submodule is attempted at all:
- if it **is** attempted (`baseline ≥ 1`), the three filter assertions are real (each must bring it back to 0);
- if detection finds **none** (`baseline == 0`), the filter checks are **skipped with a NOTE** rather than asserting vacuously.

This means the CI run also serves as a **definitive probe** of whether bare-repo submodule detection works in this environment — something the suite currently only handles defensively. I'll report what CI shows.

**2. The nested child-recursion arm (`submodule.rs` 558–573) is NOT covered, and can't be here.** It requires a submodule whose *own* repository contains a submodule. The fixture's submodule points at an external, uncontrolled public repo (`nickel-org/rust-mustache`), and the CI PAT is scoped to only the fixture repo — so a controlled nested chain isn't possible without provisioning additional writable repos, and depending on an external repo-with-submodule would make the suite non-deterministic. Documented here rather than faked.

## Related Issue

N/A — Stage 3 of a 3-stage coverage initiative (Stage 1 = #203, Stage 2 = #204, both merged).

## Type of Change

- [x] Refactoring (no functional changes) — test-only addition

## Security Checklist ⚠️

- [x] No credentials, tokens, or secrets in code, comments, or tests
- [x] No credentials in log/error messages or MCP responses
- [x] Credentials scoped to their operation, not cached or persisted
- [x] Error messages don't leak sensitive information

## Testing

- [x] `py -3 -m py_compile tests/integration/test_mcp_tools.py` passes
- [x] `markdownlint-cli2 "**/*.md"` clean
- [ ] **Integration suite runs on CI only** (private fixture + credentials + Linux runner; Windows `select.select` doesn't work on pipes). CI's `coverage` job is the validating run.

## Code Quality

- [x] Python follows `STYLE.md` (4-space indent, double quotes, docstrings, stdlib only)
- [x] Documentation is updated if needed (CHANGELOG `[Unreleased]`)
- [x] CHANGELOG.md is updated

## Additional Notes

No fixture (`rebuild_fixture.py`) change and no harness change — the test uses the shared client and the existing single submodule, so the blast radius is one new test function. If CI reveals that detection works reliably, a future PR could add the baseline-attempted assertion as a hard requirement; if it reveals detection is unavailable, we can decide whether to keep this as a forward-looking guard or drop it.

### Findings That Are NOT in This PR

- Nested submodule child-recursion (see constraint #2 above) — needs infrastructure not currently available.
- Tier 2 `repo_clone_start` with `resolve_lfs`/`sparse`/`exclude_binary`, and a `repo_clone_chunk` out-of-range-index test (deferred from Stage 2 as lower value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)