### PR TITLE
chore(release): prepare v1.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,7 +42,7 @@ Paste any error messages here (remember to redact credentials!)
 ## Environment
 
 - **OS:** [e.g., Windows 11, macOS 14.2, Ubuntu 24.04]
-- **git-proxy-mcp version:** [output of `git-proxy-mcp --version`, e.g., 1.1.0]
+- **git-proxy-mcp version:** [output of `git-proxy-mcp --version`, e.g., 1.2.0]
 - **Rust version:** [output of `rustc --version`]
 - **MCP client:** [e.g., Claude Desktop, VS Code + Continue.dev, Cursor]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-29
+
 ### Added
 
 - **End-to-end submodule include/exclude/depth filtering test.** New
@@ -1253,7 +1255,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`.github/ISSUE_TEMPLATE/bug_report.md` example version was a
   pre-1.0 placeholder.** The `git-proxy-mcp version: [e.g., 0.1.0]` hint
   predated the project's 1.0 release. Replaced with a pointer to
-  `git-proxy-mcp --version` and a current-tier example (1.1.0).
+  `git-proxy-mcp --version` and a current-tier example (1.2.0).
 - **`CONTRIBUTING.md` British-spelling reference table was a partial
   list.** It had 7 American/British pairs, missing the ones that came
   up repeatedly during this audit (`sanitize`, `authorize`, `finalize`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-proxy-mcp"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -48,7 +48,7 @@ commits from human commits.
 {
   "protocolVersion": "2024-11-05",
   "capabilities": { "tools": {} },
-  "serverInfo": { "name": "git-proxy-mcp", "version": "1.1.0" },
+  "serverInfo": { "name": "git-proxy-mcp", "version": "1.2.0" },
   "gitIdentity": {
     "name": "Claude AI",
     "email": "ai-assistant@example.com"

--- a/src/mcp/tools/helper_script.rs
+++ b/src/mcp/tools/helper_script.rs
@@ -64,7 +64,7 @@ Examples:
     # Show info about a result without extracting
     python git_proxy_helper.py info clone_result.json
 
-Version: 1.1.0
+Version: 1.2.0
 """
 
 import json
@@ -335,7 +335,7 @@ pub fn handle_helper_script() -> HelperScriptResult {
             python git_proxy_helper.py bundle <repo_dir> <since_commit>     # Create push bundle\n  \
             python git_proxy_helper.py info <result.json>                   # Show result info"
             .to_string(),
-        version: "1.1.0".to_string(),
+        version: "1.2.0".to_string(),
     }
 }
 
@@ -349,7 +349,7 @@ mod tests {
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"script\":"));
         assert!(json.contains("\"filename\":\"git_proxy_helper.py\""));
-        assert!(json.contains("\"version\":\"1.1.0\""));
+        assert!(json.contains("\"version\":\"1.2.0\""));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Release preparation for **v1.2.0**. Version bump + CHANGELOG finalisation only — no functional code changes.

### What changed (5 files, +9/-7)

| File | Change |
|------|--------|
| `Cargo.toml` | `version` 1.1.0 → **1.2.0** |
| `CHANGELOG.md` | `[Unreleased]` → `## [1.2.0] - 2026-05-29`, fresh empty `[Unreleased]` kept on top; one entry's `bug_report.md` example aligned to 1.2.0 |
| `src/mcp/tools/helper_script.rs` | embedded Python helper version 1.1.0 → 1.2.0 (script text, returned struct, test assertion) |
| `docs/AI_WORKFLOW.md` | `serverInfo` example version → 1.2.0 |
| `.github/ISSUE_TEMPLATE/bug_report.md` | illustrative `--version` example → 1.2.0 |

`serverInfo.version`, the `--version` CLI output, and the LFS `USER_AGENT` all derive from `CARGO_PKG_VERSION`, so they follow the `Cargo.toml` bump automatically — only the genuinely hardcoded strings were edited.

### Pedantic verification done

- **Exhaustive version sweep** (`grep -rn '1\.1\.0'`): every reference accounted for. Remaining `1.1.0` mentions are all legitimate — the Keep-a-Changelog spec URL (`en/1.1.0/`), the historical `## [1.1.0]` section, and narrative back-references inside `[1.2.0]` entries (e.g. "the `[1.1.0]` CHANGELOG entry…", "drifted from the actual crate version (now 1.1.0)" — historical rationale, intentionally preserved).
- **Release-notes extraction simulated** with `release.yml`'s exact awk for `## [1.2.0]`: cleanly captures the full section (`### Added` → `### Security`, all 5 subsections), excludes the empty `[Unreleased]` above and the `[1.1.0]` below. No version header leaks into the release body.
- **Full local gate green:** `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --workspace` (794 lib + all integration crates), `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`, `markdownlint-cli2 "**/*.md"`, `check-toolchain-pin.sh`.
- **`server_info_has_correct_name_and_version`** and the helper-script `"version":"1.2.0"` assertion both pass against the bumped version.

### SemVer note

MINOR bump (1.1.0 → **1.2.0**): the cycle is backward-compatible feature additions + fixes (proxy/LFS-timeout config fields, config validation, security hardening, coverage). The one borderline item is the removal of the no-op `lfs.max_total_size` config key (documented under **Removed**); since it had no effect and the project is pre-2.0, a minor bump is appropriate and matches the existing framing.

## Type of Change

- [x] CI/CD changes — release preparation (version + changelog)

## Security Checklist ⚠️

- [x] No credentials/secrets in code, comments, or tests
- [x] No credentials in logs, errors, or MCP responses
- [x] Error messages don't leak sensitive information

## Testing

- [x] Full local gate passes (see above)

## Code Quality

- [x] Compiles without warnings; clippy/fmt/markdownlint/toolchain-pin clean
- [x] CHANGELOG.md finalised for the release

## Release steps AFTER this merges (NOT done in this PR)

The `release.yml` workflow is triggered by pushing a version tag. Once this PR is merged to `main`:

1. `git checkout main && git pull`
2. `git tag v1.2.0` — **lightweight tag** (matches the existing `v1.0.0`/`v1.1.0` style; `cat-file -t` → `commit`)
3. `git push origin v1.2.0`

That triggers `release.yml` → builds the 3-platform binaries, verifies `Cargo.toml` version == tag, extracts the `[1.2.0]` CHANGELOG section as release notes, and publishes the GitHub release with SLSA provenance.

**I have NOT created or pushed any tag** — holding for your explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)