### PR TITLE
test(transport): move JSON-RPC dispatch tests off real stdout (Windows flakiness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **JSON-RPC dispatch unit tests no longer write to the real stdout** (no
+  production change). The four `handle_transport_result` `#[tokio::test]`s added
+  in v1.2.0 drove the server's write path through `tokio::io::stdout()`, which
+  both polluted the test runner's captured output and relied on Tokio's stdout
+  blocking-thread teardown — a plausible cause of an intermittent `cargo test`
+  process termination (exit 143) observed once on the Windows CI leg. The
+  `StdioTransport` now has a test-only `capture_output()` seam (a `#[cfg(test)]`
+  in-memory sink; the production write path is unchanged and compiles without
+  it), and the dispatch tests redirect to it and additionally assert on the
+  exact JSON-RPC response/error bytes written (a stronger check than before).
+
 ## [1.2.0] - 2026-05-29
 
 ### Added

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2645,9 +2645,16 @@ mod tests {
         assert_eq!(server.state(), ServerState::AwaitingInit);
     }
 
+    /// Reads the captured transport output as a UTF-8 string.
+    fn captured(sink: &std::sync::Arc<std::sync::Mutex<Vec<u8>>>) -> String {
+        String::from_utf8(sink.lock().unwrap().clone()).unwrap()
+    }
+
     #[tokio::test]
     async fn handle_transport_result_dispatches_request_and_continues() {
         let mut server = create_test_server();
+        // Capture writes in memory rather than the process's real stdout.
+        let sink = server.transport.capture_output();
         // A non-empty line carrying a valid `ping` request routes through
         // handle_line -> handle_message -> handle_request -> the ping dispatch
         // arm, and a response is written. `ping` needs no prior initialise, so
@@ -2659,11 +2666,15 @@ mod tests {
             .unwrap();
         assert!(outcome.is_none());
         assert_eq!(server.state(), ServerState::AwaitingInit);
+        // A successful result response was written for the request's id.
+        let written = captured(&sink);
+        assert!(written.contains("\"result\"") && written.contains("\"id\":1"));
     }
 
     #[tokio::test]
     async fn handle_transport_result_writes_error_for_unknown_method() {
         let mut server = create_test_server();
+        let sink = server.transport.capture_output();
         // A well-formed request for an unknown method parses successfully but
         // hits the method-not-found dispatch arm, which writes a JSON-RPC error
         // rather than a response.
@@ -2674,11 +2685,15 @@ mod tests {
             .unwrap();
         assert!(outcome.is_none());
         assert_eq!(server.state(), ServerState::AwaitingInit);
+        // Method-not-found is JSON-RPC error -32601.
+        let written = captured(&sink);
+        assert!(written.contains("\"error\"") && written.contains("-32601"));
     }
 
     #[tokio::test]
     async fn handle_transport_result_writes_error_for_malformed_json() {
         let mut server = create_test_server();
+        let sink = server.transport.capture_output();
         // A non-empty line that is not valid JSON makes parse_message return
         // Err, which handle_line writes back as a JSON-RPC parse error.
         let line = "{ this is not valid json".to_string();
@@ -2688,14 +2703,18 @@ mod tests {
             .unwrap();
         assert!(outcome.is_none());
         assert_eq!(server.state(), ServerState::AwaitingInit);
+        // Malformed JSON is JSON-RPC parse error -32700.
+        let written = captured(&sink);
+        assert!(written.contains("\"error\"") && written.contains("-32700"));
     }
 
     #[tokio::test]
     async fn handle_transport_result_processes_notification() {
         let mut server = create_test_server();
+        let sink = server.transport.capture_output();
         // A message with no `id` is a notification, routing through the
         // Notification arm of handle_message. An unknown notification is
-        // ignored without changing state and without writing a response.
+        // ignored without changing state and without writing any response.
         let line = r#"{"jsonrpc":"2.0","method":"some/notification"}"#.to_string();
         let outcome = server
             .handle_transport_result(Ok(Some(line)))
@@ -2703,5 +2722,7 @@ mod tests {
             .unwrap();
         assert!(outcome.is_none());
         assert_eq!(server.state(), ServerState::AwaitingInit);
+        // Notifications produce no wire response.
+        assert!(sink.lock().unwrap().is_empty());
     }
 }

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -35,6 +35,14 @@ pub struct StdioTransport {
     reader: BufReader<tokio::io::Stdin>,
     /// Handle for stdout.
     writer: tokio::io::Stdout,
+    /// Test-only capture sink. When set, [`StdioTransport::write_raw`] appends
+    /// framed messages here instead of writing to the real stdout, so unit
+    /// tests can drive and assert on the write path without touching the
+    /// process's stdout (which both pollutes the test runner output and relies
+    /// on `tokio::io::stdout()`'s blocking-thread teardown — an intermittent
+    /// source of hangs on Windows CI). Compiled out of non-test builds.
+    #[cfg(test)]
+    test_sink: Option<std::sync::Arc<std::sync::Mutex<Vec<u8>>>>,
 }
 
 impl StdioTransport {
@@ -44,7 +52,22 @@ impl StdioTransport {
         Self {
             reader: BufReader::new(tokio::io::stdin()),
             writer: tokio::io::stdout(),
+            #[cfg(test)]
+            test_sink: None,
         }
+    }
+
+    /// Redirects all subsequent writes to an in-memory buffer instead of the
+    /// real stdout, returning a shared handle to inspect what was written.
+    ///
+    /// Test-only: lets unit tests that exercise the write path (e.g. the
+    /// JSON-RPC dispatch tests) assert on the bytes written without going
+    /// through `tokio::io::stdout()`.
+    #[cfg(test)]
+    pub(crate) fn capture_output(&mut self) -> std::sync::Arc<std::sync::Mutex<Vec<u8>>> {
+        let sink = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        self.test_sink = Some(std::sync::Arc::clone(&sink));
+        sink
     }
 
     /// Reads the next message line from stdin.
@@ -115,6 +138,24 @@ impl StdioTransport {
     ///
     /// Returns an error if writing fails.
     async fn write_raw(&mut self, json: &str) -> io::Result<()> {
+        #[cfg(test)]
+        if let Some(sink) = &self.test_sink {
+            // In-memory capture: append the framed message synchronously. The
+            // framing matches `write_message_line` (message + '\n'), and there
+            // is no real I/O, so the lock is never held across an await. The
+            // guard is scoped tightly so it is released before returning.
+            debug_assert!(
+                !json.contains('\n'),
+                "JSON message must not contain embedded newlines"
+            );
+            {
+                let mut buf = sink.lock().expect("test_sink mutex poisoned");
+                buf.extend_from_slice(json.as_bytes());
+                buf.push(b'\n');
+            }
+            return Ok(());
+        }
+
         write_message_line(&mut self.writer, json).await
     }
 
@@ -317,5 +358,24 @@ mod tests {
         write_message_line(&mut buf, "a").await.unwrap();
         write_message_line(&mut buf, "b").await.unwrap();
         assert_eq!(String::from_utf8(buf).unwrap(), "a\nb\n");
+    }
+
+    #[tokio::test]
+    async fn capture_output_records_framed_writes_in_memory() {
+        // With capture enabled, write_response/write_error go to the in-memory
+        // sink (newline-framed) instead of the real stdout.
+        let mut transport = StdioTransport::new();
+        let sink = transport.capture_output();
+
+        let response = JsonRpcResponse::success(RequestId::Number(1), serde_json::json!({}));
+        transport.write_response(&response).await.unwrap();
+        let error = JsonRpcError::method_not_found(RequestId::Number(2), "no/such");
+        transport.write_error(&error).await.unwrap();
+
+        let written = String::from_utf8(sink.lock().unwrap().clone()).unwrap();
+        // Two newline-framed messages.
+        assert_eq!(written.matches('\n').count(), 2);
+        assert!(written.contains("\"result\"") && written.contains("\"id\":1"));
+        assert!(written.contains("\"error\"") && written.contains("-32601"));
     }
 }


### PR DESCRIPTION
## Description

Addresses the intermittent **Windows CI test-process termination** seen on PR #206 (exit code **143**, mid-run, no assertion failure), and resolves the stdout-pollution follow-up I flagged when adding these tests in #203.

### Diagnosis (what the evidence shows)

- The failure was a **genuine step failure**, not a CI cancellation: attempt #1's Windows job shows `Run tests: failure` with a normal job lifecycle afterward (`Complete job: success`); the matrix is `fail-fast: false`, and there was no superseding event. A concurrency cancellation would report `cancelled` and skip post-steps.
- Exit **143** = abnormal/external termination of the test *process* (not an assertion failure, not a crash code). It happened **once across 6+ green Windows runs** of the identical suite (#203/#204/#205, the #206 re-run, and the release build), so it's rare and was not reproducible locally.
- The single most plausible **code-level** cause: the four `handle_transport_result` `#[tokio::test]`s drove the server's write path through **`tokio::io::stdout()`**, whose blocking-thread teardown under per-test current-thread runtimes is a known intermittent-hang footgun on Windows.

### Fix

A test-only `StdioTransport::capture_output()` seam — a `#[cfg(test)]` in-memory sink that `write_raw` appends to (newline-framed) instead of writing to real stdout. The dispatch tests redirect to it and now **assert on the exact JSON-RPC bytes written** (a `"result"`/`"id":1` for ping, `-32601` for unknown method, `-32700` for malformed JSON, and *nothing* for a notification) — stronger than the prior outcome-only checks.

Benefits, independent of whether this was *the* cause:
- Removes the leading code-level flakiness suspect.
- Eliminates the `{"jsonrpc":...}` stdout noise these tests injected into the test runner output.
- Strengthens the assertions.

**Production write path is unchanged** — the `test_sink` field and the capture branch in `write_raw` are both `#[cfg(test)]`, so the shipped binary compiles exactly as before (verified: `cargo clippy --all-targets` and the full suite both green).

### Honest caveat

Because the failure is rare and not locally reproducible, I can't *prove* this eliminates it — but it removes the most plausible code-level cause and is a worthwhile cleanup regardless. If a 143 ever recurs, the next suspect is the `git credential fill` subprocess test (`get_credentials_for_url_returns_none_for_unconfigured_host`), which I'd harden with `GCM_INTERACTIVE=Never` / `GIT_CONFIG_NOSYSTEM`. The PR's Windows leg validates this directly (unlike the integration suite, the Windows build+test runs in `ci_pr.yml`).

## Type of Change

- [x] Refactoring (no functional changes) — test-only

## Security Checklist ⚠️

- [x] No credentials/secrets in code, comments, or tests
- [x] No credentials in logs, errors, or MCP responses
- [x] Error messages don't leak sensitive information

## Testing

- [x] `cargo test --all-features --workspace` (795 + integration crates) green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` green (fixed a `significant_drop_tightening` lint by scoping the sink lock)
- [x] `cargo fmt --all --check`, `cargo doc -Dwarnings`, `markdownlint-cli2`, toolchain-pin all green
- [x] New `capture_output_records_framed_writes_in_memory` transport test covers the seam

## Code Quality

- [x] Compiles without warnings; clippy/fmt/markdownlint/toolchain clean
- [x] CHANGELOG.md `[Unreleased]` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)