### PR TITLE
Run Dependabot weekly at 00:00 on Saturdays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ updates:
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
-        interval: "daily"
+        interval: weekly
+        day: saturday
         time: "00:00"
+        timezone: "Europe/Ljubljana"
 
     # Cargo: large transitive dependency surface (~250+ crates).
     # Weekly cadence + grouping keeps PR noise manageable while
@@ -16,9 +18,10 @@ updates:
     - package-ecosystem: "cargo"
       directory: "/"
       schedule:
-        interval: "weekly"
-        day: "monday"
+        interval: weekly
+        day: saturday
         time: "00:00"
+        timezone: "Europe/Ljubljana"
       open-pull-requests-limit: 5
       groups:
         cargo-dependencies:


### PR DESCRIPTION
Throttles Dependabot to one weekly run at the midnight between Friday and Saturday (00:00 Europe/Ljubljana) to conserve GitHub Actions minutes.

đź¤– Generated with [Claude Code](https://claude.com/claude-code)